### PR TITLE
[codex] 对齐 OpenCode Server API Bridge

### DIFF
--- a/src/bridge/queue.ts
+++ b/src/bridge/queue.ts
@@ -42,6 +42,14 @@ class ChatQueue {
     return this.active;
   }
 
+  peek(): BridgeTurn | null {
+    return this.active;
+  }
+
+  pendingCount(): number {
+    return this.pending.length;
+  }
+
   replaceActive(turn: BridgeTurn): void {
     this.active = turn;
   }

--- a/src/bridge/router.ts
+++ b/src/bridge/router.ts
@@ -1,20 +1,73 @@
 export type RoutedText =
-  | { kind: "command"; command: { kind: "new" | "status" | "abort" } }
+  | {
+    kind: "command";
+    command:
+      | { kind: "new" }
+      | { kind: "status" }
+      | { kind: "abort" }
+      | { kind: "models" }
+      | { kind: "sessions" }
+      | { kind: "sessions-select"; index: number }
+      | { kind: "allow"; policy: "once" | "always" }
+      | { kind: "deny" }
+      | { kind: "passthrough"; name: string; arguments: string[] };
+  }
   | { kind: "message"; text: string };
 
 export function routeIncomingText(text: string): RoutedText {
   const normalized = text.trim();
-  if (normalized === "/new") {
+  if (!normalized.startsWith("/")) {
+    return { kind: "message", text };
+  }
+
+  const parts = normalized.split(/\s+/);
+  const rawCommand = parts[0]?.slice(1) ?? "";
+  const args = parts.slice(1);
+
+  if (rawCommand === "new" && args.length === 0) {
     return { kind: "command", command: { kind: "new" } };
   }
 
-  if (normalized === "/status") {
+  if (rawCommand === "status" && args.length === 0) {
     return { kind: "command", command: { kind: "status" } };
   }
 
-  if (normalized === "/abort") {
+  if (rawCommand === "abort" && args.length === 0) {
     return { kind: "command", command: { kind: "abort" } };
   }
 
-  return { kind: "message", text };
+  if (rawCommand === "models" && args.length === 0) {
+    return { kind: "command", command: { kind: "models" } };
+  }
+
+  if (rawCommand === "sessions" && args.length === 0) {
+    return { kind: "command", command: { kind: "sessions" } };
+  }
+
+  if (rawCommand === "sessions" && args.length === 1 && /^\d+$/.test(args[0] ?? "")) {
+    return {
+      kind: "command",
+      command: { kind: "sessions-select", index: Number(args[0]) },
+    };
+  }
+
+  if (rawCommand === "allow" && (args[0] === "once" || args[0] === "always") && args.length === 1) {
+    return {
+      kind: "command",
+      command: { kind: "allow", policy: args[0] },
+    };
+  }
+
+  if (rawCommand === "deny" && args.length === 0) {
+    return { kind: "command", command: { kind: "deny" } };
+  }
+
+  return {
+    kind: "command",
+    command: {
+      kind: "passthrough",
+      name: rawCommand,
+      arguments: args,
+    },
+  };
 }

--- a/src/bridge/state-machine.ts
+++ b/src/bridge/state-machine.ts
@@ -1,11 +1,11 @@
 import type { BridgeTurn } from "./turn.js";
 
-export function transitionTurn(turn: BridgeTurn, nextState: "running" | "done" | "timeout" | "aborted"): BridgeTurn {
+export function transitionTurn(turn: BridgeTurn, nextState: "running" | "awaiting-sse" | "done" | "timeout" | "aborted"): BridgeTurn {
   const nextTurn: BridgeTurn = {
     ...turn,
     state: nextState,
   };
-  if (nextState === "running") {
+  if (nextState === "running" || nextState === "awaiting-sse") {
     nextTurn.startedAt = turn.startedAt ?? Date.now();
   } else if (turn.startedAt !== undefined) {
     nextTurn.startedAt = turn.startedAt;

--- a/src/bridge/state.ts
+++ b/src/bridge/state.ts
@@ -1,0 +1,26 @@
+export type PendingQuestionInteraction = {
+  kind: "question";
+  requestId: string;
+  sessionId: string;
+  questions: Array<{ header: string; question: string }>;
+};
+
+export type PendingPermissionInteraction = {
+  kind: "permission";
+  sessionId: string;
+  permissionId: string;
+  permissionName: string;
+  turnId: string;
+  expiresAt: number;
+};
+
+export type PendingSessionSelectionInteraction = {
+  kind: "session-select";
+  options: Array<{ index: number; sessionId: string; title: string }>;
+  expiresAt: number;
+};
+
+export type PendingInteraction =
+  | PendingQuestionInteraction
+  | PendingPermissionInteraction
+  | PendingSessionSelectionInteraction;

--- a/src/bridge/turn.ts
+++ b/src/bridge/turn.ts
@@ -7,7 +7,7 @@ export type BridgeTurn = {
   sessionId?: string;
   processMessageId?: string;
   finalMessageId?: string;
-  state?: "queued" | "running" | "done" | "timeout" | "aborted";
+  state?: "queued" | "running" | "awaiting-sse" | "done" | "timeout" | "aborted";
   startedAt?: number;
 };
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -23,7 +23,7 @@ export async function loadConfig(configPath?: string): Promise<AppConfig> {
     },
     opencode: {
       baseUrl: new URL(parsed.opencode.baseUrl),
-      directory: parsed.opencode.directory,
+      directory: resolveRelative(baseDir, parsed.opencode.directory),
     },
     storage: {
       dataDir,

--- a/src/opencode/client.ts
+++ b/src/opencode/client.ts
@@ -1,8 +1,94 @@
-type OpenCodeMessage = {
-  id?: string;
-  role?: string;
-  parts?: Array<Record<string, unknown>>;
+export type OpenCodeHealth = {
+  healthy: true;
+  version: string;
 };
+
+export type OpenCodeProject = {
+  id: string;
+  worktree: string;
+  vcs?: string;
+  sandboxes: string[];
+  time: {
+    created: number;
+    updated: number;
+    initialized?: number;
+  };
+};
+
+export type OpenCodeSession = {
+  id: string;
+  slug?: string;
+  version?: string;
+  projectID?: string;
+  directory?: string;
+  title?: string;
+  time?: {
+    created?: number;
+    updated?: number;
+  };
+};
+
+export type OpenCodeSessionStatus = {
+  type: string;
+  [key: string]: unknown;
+};
+
+export type OpenCodeMessageInfo = Record<string, unknown> & {
+  id?: string;
+  parentID?: string;
+  role?: string;
+  sessionID?: string;
+  finish?: string;
+  time?: Record<string, unknown>;
+};
+
+export type OpenCodePart = Record<string, unknown> & {
+  id?: string;
+  type?: string;
+  text?: string;
+  messageID?: string;
+  sessionID?: string;
+};
+
+export type OpenCodeMessage = {
+  info: OpenCodeMessageInfo;
+  parts: OpenCodePart[];
+};
+
+export type OpenCodePromptPart = {
+  type: string;
+  text?: string;
+  [key: string]: unknown;
+};
+
+export type OpenCodePromptRequest = {
+  messageID?: string;
+  model?: string | Record<string, unknown>;
+  agent?: string;
+  noReply?: boolean;
+  system?: string;
+  tools?: unknown;
+  parts: OpenCodePromptPart[];
+};
+
+export type OpenCodeCommandRequest = {
+  messageID?: string;
+  agent?: string;
+  model?: string | Record<string, unknown>;
+  command: string;
+  arguments: string[];
+};
+
+export type OpenCodeProvidersResponse = {
+  providers: Array<Record<string, unknown>>;
+  default: Record<string, string>;
+};
+
+export type OpenCodePromptAccepted = {
+  accepted: true;
+};
+
+export type PermissionPolicy = "once" | "always" | "reject";
 
 export type QuestionRequest = {
   id: string;
@@ -10,73 +96,124 @@ export type QuestionRequest = {
   questions: Array<{ header: string; question: string }>;
 };
 
-export class OpenCodeClient {
-  constructor(private readonly baseUrl: URL, private readonly directory: string) {}
+type RequestOptions = {
+  method: string;
+  body?: unknown;
+  query?: Record<string, string | number | undefined>;
+  expectedStatus?: number;
+};
 
-  async createSession(title: string): Promise<{ id: string }> {
+export class OpenCodeClient {
+  constructor(private readonly baseUrl: URL) {}
+
+  async health(): Promise<OpenCodeHealth> {
+    return this.request("/global/health", { method: "GET" });
+  }
+
+  async getCurrentProject(): Promise<OpenCodeProject> {
+    return this.request("/project/current", { method: "GET" });
+  }
+
+  async createSession(title: string): Promise<OpenCodeSession> {
     return this.request("/session", {
       method: "POST",
-      body: { title, directory: this.directory },
+      body: { title },
     });
   }
 
-  async postMessage(sessionId: string, text: string): Promise<void> {
-    await this.request(`/session/${sessionId}/message`, {
+  async listSessions(): Promise<OpenCodeSession[]> {
+    return this.request("/session", { method: "GET" });
+  }
+
+  async getSessionStatuses(): Promise<Record<string, OpenCodeSessionStatus>> {
+    return this.request("/session/status", { method: "GET" });
+  }
+
+  async getSessionMessages(sessionId: string, limit?: number): Promise<OpenCodeMessage[]> {
+    if (limit === undefined) {
+      return this.request(`/session/${encodeURIComponent(sessionId)}/message`, {
+        method: "GET",
+      });
+    }
+
+    return this.request(`/session/${encodeURIComponent(sessionId)}/message`, {
+      method: "GET",
+      query: { limit },
+    });
+  }
+
+  async postMessageSync(sessionId: string, request: OpenCodePromptRequest): Promise<OpenCodeMessage> {
+    return this.request(`/session/${encodeURIComponent(sessionId)}/message`, {
       method: "POST",
-      body: { parts: [{ type: "text", text }] },
+      body: request,
     });
   }
 
-  async abort(sessionId: string): Promise<void> {
-    await this.request(`/session/${sessionId}/abort`, { method: "POST" });
+  async promptAsync(sessionId: string, request: OpenCodePromptRequest): Promise<OpenCodePromptAccepted> {
+    await this.request(`/session/${encodeURIComponent(sessionId)}/prompt_async`, {
+      method: "POST",
+      body: request,
+      expectedStatus: 204,
+    });
+    return { accepted: true };
   }
 
-  async replyPermission(requestId: string, policy: "once" | "always"): Promise<void> {
-    await this.request(`/permission/${requestId}`, { method: "POST", body: { policy } });
+  async abort(sessionId: string): Promise<boolean> {
+    return this.request(`/session/${encodeURIComponent(sessionId)}/abort`, { method: "POST" });
+  }
+
+  async listProviders(): Promise<OpenCodeProvidersResponse> {
+    return this.request("/config/providers", { method: "GET" });
+  }
+
+  async runCommand(sessionId: string, request: OpenCodeCommandRequest): Promise<OpenCodeMessage> {
+    return this.request(`/session/${encodeURIComponent(sessionId)}/command`, {
+      method: "POST",
+      body: request,
+    });
+  }
+
+  async replyPermission(sessionId: string, permissionId: string, response: PermissionPolicy, remember: boolean): Promise<boolean> {
+    return this.request(`/session/${encodeURIComponent(sessionId)}/permissions/${encodeURIComponent(permissionId)}`, {
+      method: "POST",
+      body: { response, remember },
+    });
   }
 
   async replyQuestion(requestId: string, answers: string[]): Promise<void> {
-    await this.request(`/question/${requestId}`, { method: "POST", body: { answers } });
+    await this.request(`/question/${encodeURIComponent(requestId)}`, {
+      method: "POST",
+      body: { answers },
+    });
   }
 
-  async latestAssistantReply(sessionId: string): Promise<OpenCodeMessage | null> {
-    const messages = await this.request<OpenCodeMessage[]>(`/session/${sessionId}/messages`, { method: "GET" });
-    return [...messages].reverse().find((message) => message.role === "assistant") ?? null;
-  }
-
-  async latestAssistantTextSince(sessionId: string, baselineId: string | null): Promise<string> {
-    const messages = await this.request<OpenCodeMessage[]>(`/session/${sessionId}/messages`, { method: "GET" });
-    let seenBaseline = baselineId === null;
-    for (const message of messages) {
-      if (baselineId && message.id === baselineId) {
-        seenBaseline = true;
-        continue;
-      }
-      if (!seenBaseline || message.role !== "assistant") {
-        continue;
-      }
-
-      const text = message.parts?.map((part) => (typeof part.text === "string" ? part.text : "")).join("").trim();
-      if (text) {
-        return text;
-      }
+  private async request<T>(pathName: string, options: RequestOptions): Promise<T> {
+    const url = new URL(pathName.replace(/^\//, ""), this.baseUrl);
+    for (const [key, value] of Object.entries(options.query ?? {})) {
+      if (value === undefined) continue;
+      url.searchParams.set(key, String(value));
     }
 
-    return "";
-  }
-
-  private async request<T>(pathName: string, options: { method: string; body?: unknown }): Promise<T> {
-    const url = new URL(pathName.replace(/^\//, ""), this.baseUrl);
+    const headers = createOpenCodeHeaders(
+      options.body !== undefined ? { "Content-Type": "application/json" } : undefined,
+    );
     const init: RequestInit = {
       method: options.method,
-      headers: {
-        "Content-Type": "application/json",
-      },
+      headers,
     };
     if (options.body !== undefined) {
       init.body = JSON.stringify(options.body);
     }
+
     const response = await fetch(url, init);
+
+    const expectedStatus = options.expectedStatus;
+    if (expectedStatus !== undefined) {
+      if (response.status !== expectedStatus) {
+        throw new Error(`OpenCode request failed: ${response.status} ${response.statusText}`);
+      }
+      return undefined as T;
+    }
 
     if (!response.ok) {
       throw new Error(`OpenCode request failed: ${response.status} ${response.statusText}`);
@@ -88,4 +225,24 @@ export class OpenCodeClient {
 
     return (await response.json()) as T;
   }
+}
+
+export function createOpenCodeHeaders(initialHeaders?: Record<string, string>): Record<string, string> {
+  const headers = { ...(initialHeaders ?? {}) };
+  const authHeader = getOpenCodeAuthHeader();
+  if (authHeader) {
+    headers.Authorization = authHeader;
+  }
+  return headers;
+}
+
+export function getOpenCodeAuthHeader(): string | null {
+  const password = process.env.OPENCODE_SERVER_PASSWORD;
+  if (!password) {
+    return null;
+  }
+
+  const username = process.env.OPENCODE_SERVER_USERNAME || "opencode";
+  const token = Buffer.from(`${username}:${password}`, "utf8").toString("base64");
+  return `Basic ${token}`;
 }

--- a/src/opencode/events.ts
+++ b/src/opencode/events.ts
@@ -1,24 +1,79 @@
+import { createOpenCodeHeaders } from "./client.js";
+
 type EventListener = (event: OpenCodeEvent) => void | Promise<void>;
 
-export type OpenCodeEvent = {
+type LoggerLike = {
+  log: (scope: string, message: string, fields?: Record<string, unknown>, level?: "debug" | "info" | "warn" | "error") => void;
+};
+
+type StreamEndpoint = "/event" | "/global/event";
+
+type OpenCodeEventPayload = {
   type: string;
   properties: Record<string, unknown>;
 };
 
+export const KNOWN_EVENTS = [
+  "server.connected",
+  "server.heartbeat",
+  "session.created",
+  "session.updated",
+  "session.status",
+  "session.idle",
+  "session.diff",
+  "session.error",
+  "message.updated",
+  "message.part.updated",
+  "message.part.delta",
+  "permission.asked",
+  "question.asked",
+] as const;
+
+export type KnownOpenCodeEvent = (typeof KNOWN_EVENTS)[number];
+
+export type OpenCodeConnectionState = "connecting" | "connected" | "reconnecting" | "stopped";
+
+export type OpenCodeEvent = {
+  type: string;
+  properties: Record<string, unknown>;
+  sessionId: string | null;
+  receivedAt: number;
+  streamEndpoint: StreamEndpoint;
+  raw: unknown;
+};
+
+const RETRY_DELAYS_MS = [1_000, 2_000, 5_000, 10_000, 30_000] as const;
+
 export class OpenCodeEventStream {
   private readonly listeners = new Set<EventListener>();
+  private readonly seenUnknownEvents = new Set<string>();
   private controller: AbortController | null = null;
+  private loopPromise: Promise<void> | null = null;
+  private state: OpenCodeConnectionState = "stopped";
 
-  constructor(private readonly baseUrl: URL, private readonly directory: string, private readonly logger: { log: (...args: any[]) => void }) {}
+  constructor(private readonly baseUrl: URL, private readonly logger: LoggerLike) {}
 
   async start(): Promise<void> {
+    if (this.loopPromise) {
+      return;
+    }
+
     this.controller = new AbortController();
-    this.logger.log("opencode/events", "event stream connected", {});
+    this.state = "connecting";
+    this.loopPromise = this.run(this.controller.signal).catch((error) => {
+      if (!this.controller?.signal.aborted) {
+        const detail = error instanceof Error ? error.message : String(error);
+        this.logger.log("opencode/events", "event stream stopped unexpectedly", { detail }, "error");
+      }
+    });
   }
 
   async stop(): Promise<void> {
+    this.state = "stopped";
     this.controller?.abort();
     this.controller = null;
+    await this.loopPromise;
+    this.loopPromise = null;
   }
 
   subscribe(listener: EventListener): () => void {
@@ -28,14 +83,112 @@ export class OpenCodeEventStream {
     };
   }
 
+  getConnectionState(): OpenCodeConnectionState {
+    return this.state;
+  }
+
   async emit(event: OpenCodeEvent): Promise<void> {
     for (const listener of this.listeners) {
       await listener(event);
     }
   }
+
+  private async run(signal: AbortSignal): Promise<void> {
+    let attempt = 0;
+
+    while (!signal.aborted) {
+      this.state = attempt === 0 ? "connecting" : "reconnecting";
+
+      try {
+        const stream = await this.connect(signal);
+        attempt = 0;
+        this.state = "connected";
+        this.logger.log("opencode/events", "event stream connected", { endpoint: stream.endpoint });
+        await this.consumeStream(stream.response, stream.endpoint, signal);
+        if (signal.aborted) {
+          break;
+        }
+        this.logger.log("opencode/events", "event stream disconnected", { endpoint: stream.endpoint }, "warn");
+      } catch (error) {
+        if (signal.aborted) {
+          break;
+        }
+
+        const detail = error instanceof Error ? error.message : String(error);
+        this.logger.log("opencode/events", "event stream connection failed", { detail, attempt }, "warn");
+      }
+
+      const delayMs = RETRY_DELAYS_MS[Math.min(attempt, RETRY_DELAYS_MS.length - 1)] ?? 30_000;
+      attempt += 1;
+      await sleep(delayMs, signal);
+    }
+
+    this.state = "stopped";
+  }
+
+  private async connect(signal: AbortSignal): Promise<{ response: Response; endpoint: StreamEndpoint }> {
+    const endpoints: StreamEndpoint[] = ["/event", "/global/event"];
+    let lastError: Error | null = null;
+
+    for (const endpoint of endpoints) {
+      try {
+        const response = await fetch(new URL(endpoint.replace(/^\//, ""), this.baseUrl), {
+          method: "GET",
+          headers: createOpenCodeHeaders({ Accept: "text/event-stream" }),
+          signal,
+        });
+
+        if (!response.ok || !response.body) {
+          lastError = new Error(`OpenCode event stream failed: ${response.status} ${response.statusText}`);
+          continue;
+        }
+
+        return { response, endpoint };
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+      }
+    }
+
+    throw lastError ?? new Error("OpenCode event stream failed");
+  }
+
+  private async consumeStream(response: Response, endpoint: StreamEndpoint, signal: AbortSignal): Promise<void> {
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error("OpenCode event stream has no readable body");
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (!signal.aborted) {
+      const result = await reader.read();
+      if (result.done) {
+        break;
+      }
+
+      buffer += decoder.decode(result.value, { stream: true });
+      const chunks = splitSseBuffer(buffer);
+      buffer = chunks.rest;
+
+      for (const rawBlock of chunks.blocks) {
+        const parsed = parseSseBlock(rawBlock, endpoint);
+        if (!parsed) continue;
+        if (!isKnownEventType(parsed.type) && !this.seenUnknownEvents.has(parsed.type)) {
+          this.seenUnknownEvents.add(parsed.type);
+          this.logger.log("opencode/events", "unknown event type received", { type: parsed.type }, "warn");
+        }
+        await this.emit(parsed);
+      }
+    }
+  }
 }
 
-export function getEventSessionId(event: OpenCodeEvent): string | null {
+export function getEventSessionId(event: Pick<OpenCodeEvent, "properties" | "sessionId">): string | null {
+  if (typeof event.sessionId === "string") {
+    return event.sessionId;
+  }
+
   if (typeof event.properties.sessionID === "string") {
     return event.properties.sessionID;
   }
@@ -43,5 +196,101 @@ export function getEventSessionId(event: OpenCodeEvent): string | null {
     return event.properties.sessionId;
   }
 
+  const info = readRecord(event.properties.info);
+  if (info && typeof info.sessionID === "string") {
+    return info.sessionID;
+  }
+  if (info && typeof info.sessionId === "string") {
+    return info.sessionId;
+  }
+
+  const part = readRecord(event.properties.part);
+  if (part && typeof part.sessionID === "string") {
+    return part.sessionID;
+  }
+  if (part && typeof part.sessionId === "string") {
+    return part.sessionId;
+  }
+
   return null;
+}
+
+function isKnownEventType(type: string): type is KnownOpenCodeEvent {
+  return (KNOWN_EVENTS as readonly string[]).includes(type);
+}
+
+function splitSseBuffer(buffer: string): { blocks: string[]; rest: string } {
+  const normalized = buffer.replace(/\r\n/g, "\n");
+  const blocks: string[] = [];
+  let cursor = 0;
+  let separatorIndex = normalized.indexOf("\n\n", cursor);
+  while (separatorIndex !== -1) {
+    blocks.push(normalized.slice(cursor, separatorIndex));
+    cursor = separatorIndex + 2;
+    separatorIndex = normalized.indexOf("\n\n", cursor);
+  }
+
+  return { blocks, rest: normalized.slice(cursor) };
+}
+
+function parseSseBlock(block: string, endpoint: StreamEndpoint): OpenCodeEvent | null {
+  const dataLines: string[] = [];
+
+  for (const line of block.split("\n")) {
+    if (!line || line.startsWith(":")) continue;
+    if (line.startsWith("data:")) {
+      dataLines.push(line.slice(5).trimStart());
+    }
+  }
+
+  if (dataLines.length === 0) {
+    return null;
+  }
+
+  const raw = JSON.parse(dataLines.join("\n")) as unknown;
+  const payload = normalizeEventPayload(raw, endpoint);
+  return {
+    type: payload.type,
+    properties: payload.properties,
+    sessionId: getEventSessionId({ properties: payload.properties, sessionId: null }),
+    receivedAt: Date.now(),
+    streamEndpoint: endpoint,
+    raw,
+  };
+}
+
+function normalizeEventPayload(raw: unknown, endpoint: StreamEndpoint): OpenCodeEventPayload {
+  const root = readRecord(raw);
+  const maybePayload = endpoint === "/global/event" ? readRecord(root?.payload) ?? root : root;
+  if (!maybePayload || typeof maybePayload.type !== "string") {
+    throw new Error("OpenCode event payload missing type");
+  }
+
+  return {
+    type: maybePayload.type,
+    properties: readRecord(maybePayload.properties) ?? {},
+  };
+}
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null ? value as Record<string, unknown> : null;
+}
+
+async function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    const timeout = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    };
+    signal.addEventListener("abort", onAbort);
+  });
 }

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -1,7 +1,8 @@
 import crypto from "node:crypto";
 
 import { QueueRegistry } from "../bridge/queue.js";
-import { routeIncomingText } from "../bridge/router.js";
+import { type PendingInteraction, type PendingPermissionInteraction, type PendingQuestionInteraction, type PendingSessionSelectionInteraction } from "../bridge/state.js";
+import { routeIncomingText, type RoutedText } from "../bridge/router.js";
 import { transitionTurn } from "../bridge/state-machine.js";
 import { TurnWatchdog } from "../bridge/watchdog.js";
 import type { BridgeTurn } from "../bridge/turn.js";
@@ -15,8 +16,14 @@ import {
   type TurnStatusCardView,
 } from "../feishu/formatter.js";
 import { createTextPreview, type Logger, type TranscriptType } from "../logging/logger.js";
-import { OpenCodeClient, type QuestionRequest } from "../opencode/client.js";
-import { OpenCodeEventStream, getEventSessionId, type OpenCodeEvent } from "../opencode/events.js";
+import {
+  OpenCodeClient,
+  type OpenCodeMessage,
+  type OpenCodeProvidersResponse,
+  type OpenCodeSession,
+  type OpenCodeSessionStatus,
+} from "../opencode/client.js";
+import { getEventSessionId, OpenCodeEventStream, type OpenCodeEvent } from "../opencode/events.js";
 import { MappingStore, type MappingRecord } from "../store/mappings.js";
 import type { AppConfig } from "../config/schema.js";
 import { cleanAssistantReply } from "./sanitize.js";
@@ -43,7 +50,18 @@ type TurnCardState = {
   output: OutputView;
 };
 
+type StreamFlushState = {
+  flushedLength: number;
+  lastFlushedAt: number;
+  timer: NodeJS.Timeout | null;
+};
+
 const initialCardSummary = "已创建会话，等待 OpenCode 事件...";
+const FIRST_SSE_FALLBACK_MS = 5_000;
+const STREAM_FLUSH_MIN_CHARS = 120;
+const STREAM_FLUSH_INTERVAL_MS = 750;
+const PERMISSION_TTL_MS = 120_000;
+const SESSION_SELECTION_TTL_MS = 30_000;
 
 export class BridgeApp {
   private readonly queues: QueueRegistry;
@@ -52,26 +70,52 @@ export class BridgeApp {
   private readonly eventStream: OpenCodeEventStream;
   private sessionMap: MappingRecord = {};
   private readonly runningChats = new Map<string, Promise<void>>();
-  private readonly pendingQuestions = new Map<string, QuestionRequest>();
+  private readonly pendingInteractions = new Map<string, PendingInteraction>();
+  private readonly pendingInteractionTimers = new Map<string, NodeJS.Timeout>();
   private readonly turnCards = new Map<string, TurnCardState>();
+  private readonly streamFlushStates = new Map<string, StreamFlushState>();
+  private readonly sessionStatuses = new Map<string, OpenCodeSessionStatus>();
+  private globalEventUnsubscribe: (() => void) | null = null;
 
   constructor(private readonly config: AppConfig, private readonly outbound: OutboundPort, private readonly logger: Logger) {
     this.queues = new QueueRegistry(config.bridge.queueLimit, logger);
     this.mappings = new MappingStore(config.storage.dataDir, config.storage.mappingsFile);
-    this.opencode = new OpenCodeClient(config.opencode.baseUrl, config.opencode.directory);
-    this.eventStream = new OpenCodeEventStream(config.opencode.baseUrl, config.opencode.directory, logger);
+    this.opencode = new OpenCodeClient(config.opencode.baseUrl);
+    this.eventStream = new OpenCodeEventStream(config.opencode.baseUrl, logger);
   }
 
   async start(): Promise<void> {
     this.sessionMap = await this.mappings.load();
+    const health = await this.opencode.health();
+    const project = await this.opencode.getCurrentProject();
+    if (project.worktree !== this.config.opencode.directory) {
+      throw new Error(`opencode serve 当前在 ${project.worktree}，bridge 配置的是 ${this.config.opencode.directory}，请在正确目录重启 opencode serve`);
+    }
+
     await this.eventStream.start();
+    this.globalEventUnsubscribe = this.eventStream.subscribe(async (event) => {
+      await this.handleGlobalEvent(event);
+    });
+
     this.logger.log("bridge/app", "bridge started", {
       queueLimit: this.config.bridge.queueLimit,
       opencodeBaseUrl: this.config.opencode.baseUrl.toString(),
+      opencodeVersion: health.version,
+      project: project.worktree,
     });
   }
 
   async stop(): Promise<void> {
+    this.globalEventUnsubscribe?.();
+    this.globalEventUnsubscribe = null;
+    for (const timeout of this.pendingInteractionTimers.values()) {
+      clearTimeout(timeout);
+    }
+    for (const state of this.streamFlushStates.values()) {
+      if (state.timer) clearTimeout(state.timer);
+    }
+    this.pendingInteractionTimers.clear();
+    this.streamFlushStates.clear();
     await this.eventStream.stop();
   }
 
@@ -94,17 +138,22 @@ export class BridgeApp {
 
     const routed = routeIncomingText(message.text);
     if (routed.kind === "command") {
-      await this.handleCommand(message.chatId, routed.command.kind);
+      await this.handleCommand(message.chatId, routed);
       return;
     }
 
-    const pendingQuestion = this.pendingQuestions.get(message.chatId);
-    if (pendingQuestion) {
-      await this.handleQuestionReply(message.chatId, pendingQuestion, message.text);
+    const pending = this.pendingInteractions.get(message.chatId);
+    if (pending) {
+      const consumed = await this.handlePendingInteraction(message.chatId, pending, message.text);
+      if (consumed) return;
+    }
+
+    if (!await this.ensureServerAvailableForChat(message.chatId)) {
       return;
     }
 
     const queue = this.queues.get(message.chatId);
+    const existingSession = this.sessionMap[message.chatId];
     const turn: BridgeTurn = {
       turnId: crypto.randomUUID(),
       chatId: message.chatId,
@@ -112,10 +161,10 @@ export class BridgeApp {
       inboundMessageId: message.messageId,
       text: message.text,
     };
-    const existingSession = this.sessionMap[message.chatId];
-    if (existingSession) {
-      turn.sessionId = existingSession;
+    if (existingSession?.sessionId) {
+      turn.sessionId = existingSession.sessionId;
     }
+
     const result = queue.enqueue(turn);
     if (!result.accepted) {
       await this.sendPayload(message.chatId, buildQueueNoticePayload(result.notice ?? { message: "当前不可用。" }), {
@@ -156,8 +205,9 @@ export class BridgeApp {
 
   private async runTurn(chatId: string): Promise<void> {
     const queue = this.queues.get(chatId);
-    const active = queue.current();
+    const active = queue.peek();
     if (!active) return;
+
     let turn = transitionTurn(active, "running");
     queue.replaceActive(turn);
 
@@ -166,6 +216,7 @@ export class BridgeApp {
       turn = { ...turn, sessionId };
       queue.replaceActive(turn);
       this.logger.log("bridge/queue", "turn started", { turnId: turn.turnId, sessionId, chatId });
+
       const card = await this.createTurnCard(chatId, turn.turnId, sessionId);
       if (card) {
         queue.replaceActive({ ...turn, processMessageId: card.messageId });
@@ -174,8 +225,8 @@ export class BridgeApp {
       const reply = cleanAssistantReply(await this.executeTurn(chatId, turn as BridgeTurn & { sessionId: string }));
       this.logger.log("opencode/events", "reply completed", { turnId: turn.turnId, sessionId, len: reply.length });
       this.logger.logTranscript("opencode-reply", { sessionId, turnId: turn.turnId }, reply);
+      await this.flushStreamUpdate(turn.turnId, reply, true);
       await this.updateTurnCard(turn.turnId, { status: "已完成", update: `最终回复已生成（${reply.length} 字）`, target: "step" });
-      await this.updateTurnCard(turn.turnId, { update: reply, sanitize: false, target: "final" });
       queue.replaceActive(transitionTurn({ ...turn, sessionId }, "done"));
       this.logger.log("bridge/queue", "turn completed", { turnId: turn.turnId, duration: Date.now() - (turn.startedAt ?? Date.now()) });
     } catch (error) {
@@ -185,50 +236,70 @@ export class BridgeApp {
       queue.replaceActive(transitionTurn(turn, detail.includes("超时") ? "timeout" : "aborted"));
     } finally {
       this.turnCards.delete(turn.turnId);
+      this.clearPendingInteraction(chatId, false);
+      this.clearStreamFlushState(turn.turnId);
     }
   }
 
-  private async ensureSession(chatId: string): Promise<string> {
-    const existing = this.sessionMap[chatId];
-    if (existing) return existing;
-    const session = await this.opencode.createSession(`Feishu ${chatId}`);
-    this.sessionMap[chatId] = session.id;
-    await this.mappings.save(this.sessionMap);
-    return session.id;
-  }
-
   private async executeTurn(chatId: string, turn: BridgeTurn & { sessionId: string }): Promise<string> {
+    const baselineAssistant = await this.getLatestAssistantMessage(turn.sessionId);
+    const baselineAssistantId = baselineAssistant?.info.id ?? null;
+    const queue = this.queues.get(chatId);
+
     return new Promise<string>((resolve, reject) => {
       let assistantMessageId: string | null = null;
       let finalText = "";
       let settled = false;
-      let baselineAssistantId: string | null = null;
+      let fallbackTimer: NodeJS.Timeout | null = null;
+      let seenSessionEvent = false;
       const ignoredTextPartIds = new Set<string>();
+
+      const settleWithError = (error: Error): void => {
+        if (settled) return;
+        settled = true;
+        if (fallbackTimer) clearTimeout(fallbackTimer);
+        unsubscribe();
+        watchdog.clear();
+        reject(error);
+      };
+
+      const settleWithText = async (): Promise<void> => {
+        if (settled) return;
+        settled = true;
+        if (fallbackTimer) clearTimeout(fallbackTimer);
+        unsubscribe();
+        watchdog.clear();
+        try {
+          const text = await this.finalizeAssistantReply(turn.sessionId, finalText, baselineAssistantId);
+          resolve(text);
+        } catch (error) {
+          reject(error instanceof Error ? error : new Error(String(error)));
+        }
+      };
+
       const unsubscribe = this.eventStream.subscribe(async (event) => {
         if (getEventSessionId(event) !== turn.sessionId) return;
+        seenSessionEvent = true;
+        if (fallbackTimer) {
+          clearTimeout(fallbackTimer);
+          fallbackTimer = null;
+        }
+
         try {
           await this.handleEvent(chatId, turn, event, {
             getAssistantMessageId: () => assistantMessageId,
             setAssistantMessageId: (value) => { assistantMessageId = value; },
             ignoredTextPartIds,
-            appendFinalText: (delta) => { finalText += delta; },
-            setFinalText: (value) => { finalText = value; },
-            baselineAssistantId,
-            setBaselineAssistantId: (value) => { baselineAssistantId = value; },
-            finish: (text) => {
-              if (settled) return;
-              settled = true;
-              unsubscribe();
-              watchdog.clear();
-              resolve(text);
+            appendFinalText: async (delta) => {
+              finalText += delta;
+              await this.scheduleStreamUpdate(turn.turnId, finalText);
             },
-            fail: (error) => {
-              if (settled) return;
-              settled = true;
-              unsubscribe();
-              watchdog.clear();
-              reject(error);
+            setFinalText: async (value) => {
+              finalText = value;
+              await this.scheduleStreamUpdate(turn.turnId, finalText);
             },
+            finish: settleWithText,
+            fail: settleWithError,
             getFinalText: () => finalText,
           });
           watchdog.markEvent();
@@ -245,18 +316,31 @@ export class BridgeApp {
           totalTimeoutMs: this.config.bridge.totalTimeoutMs,
         },
         {
-          onFirstEventTimeout: () => reject(new Error("处理超时，请重试或 /new 开新会话")),
-          onEventGapTimeout: () => reject(new Error("处理超时，请重试或 /new 开新会话")),
-          onTotalTimeout: () => reject(new Error("处理超时，请重试或 /new 开新会话")),
+          onFirstEventTimeout: () => settleWithError(new Error("处理超时，请重试或 /new 开新会话")),
+          onEventGapTimeout: () => settleWithError(new Error("处理超时，请重试或 /new 开新会话")),
+          onTotalTimeout: () => settleWithError(new Error("处理超时，请重试或 /new 开新会话")),
         },
       );
+
       watchdog.start();
-      void this.opencode.latestAssistantReply(turn.sessionId)
-        .then((reply) => {
-          baselineAssistantId = reply?.id ?? null;
-          return this.opencode.postMessage(turn.sessionId, turn.text);
+      void this.opencode.promptAsync(turn.sessionId, buildPromptRequest(turn.text))
+        .then(() => {
+          queue.replaceActive(transitionTurn(turn, "awaiting-sse"));
+          void this.updateTurnCard(turn.turnId, { status: "处理中", update: "请求已发送，等待事件流...", target: "step" });
+          fallbackTimer = setTimeout(() => {
+            if (!seenSessionEvent) {
+              void this.runFirstSseFallback(turn.sessionId, baselineAssistantId, {
+                updateText: async (text) => {
+                  finalText = text;
+                  await this.scheduleStreamUpdate(turn.turnId, finalText);
+                },
+                finish: settleWithText,
+                fail: settleWithError,
+              });
+            }
+          }, FIRST_SSE_FALLBACK_MS);
         })
-        .catch(reject);
+        .catch((error) => settleWithError(error instanceof Error ? error : new Error(String(error))));
     });
   }
 
@@ -268,11 +352,9 @@ export class BridgeApp {
       getAssistantMessageId: () => string | null;
       setAssistantMessageId: (value: string | null) => void;
       ignoredTextPartIds: Set<string>;
-      appendFinalText: (delta: string) => void;
-      setFinalText: (value: string) => void;
-      baselineAssistantId: string | null;
-      setBaselineAssistantId: (value: string | null) => void;
-      finish: (text: string) => void;
+      appendFinalText: (delta: string) => Promise<void>;
+      setFinalText: (value: string) => Promise<void>;
+      finish: () => Promise<void>;
       fail: (error: Error) => void;
       getFinalText: () => string;
     },
@@ -291,7 +373,7 @@ export class BridgeApp {
       if (context.getAssistantMessageId() && messageId && messageId !== context.getAssistantMessageId()) return;
       if (partId && context.ignoredTextPartIds.has(partId)) return;
       if (readOptionalString(event.properties, "field") === "text") {
-        context.appendFinalText(readOptionalString(event.properties, "delta") ?? "");
+        await context.appendFinalText(readOptionalString(event.properties, "delta") ?? "");
       }
       return;
     }
@@ -303,15 +385,19 @@ export class BridgeApp {
       if (context.getAssistantMessageId() && messageId && messageId !== context.getAssistantMessageId()) return;
       const partType = readOptionalString(part, "type");
       const partId = readOptionalString(part, "id");
+
       if (partType === "text") {
         if (readOptionalBoolean(part, "synthetic") || readOptionalBoolean(part, "ignored")) {
           if (partId) context.ignoredTextPartIds.add(partId);
           return;
         }
         const text = readOptionalString(part, "text");
-        if (text) context.setFinalText(text);
+        if (text !== undefined) {
+          await context.setFinalText(text);
+        }
         return;
       }
+
       if (partType === "reasoning") {
         const text = readOptionalString(part, "text") ?? "";
         if (partId) {
@@ -324,6 +410,7 @@ export class BridgeApp {
         }
         return;
       }
+
       if (partType === "tool") {
         const state = readOptionalRecord(part, "state");
         const status = state ? readOptionalString(state, "status") : undefined;
@@ -340,88 +427,365 @@ export class BridgeApp {
     }
 
     if (event.type === "permission.asked") {
-      const requestId = readOptionalString(event.properties, "id");
+      const permissionId = readOptionalString(event.properties, "id");
       const permissionName = readOptionalString(event.properties, "permission") ?? "unknown";
-      await this.updateTurnCard(turn.turnId, { status: "处理中", update: `请求权限：${permissionName}`, target: "step" });
-      if (requestId) {
-        await this.opencode.replyPermission(requestId, "once");
-      }
+      if (!permissionId) return;
+      this.setPendingInteraction(chatId, {
+        kind: "permission",
+        sessionId: turn.sessionId,
+        permissionId,
+        permissionName,
+        turnId: turn.turnId,
+        expiresAt: Date.now() + PERMISSION_TTL_MS,
+      });
+      await this.updateTurnCard(turn.turnId, {
+        status: "等待确认",
+        update: `请求权限：${permissionName}，请回复 /allow once、/allow always 或 /deny`,
+        target: "step",
+      });
+      await this.sendPayload(chatId, buildPostMarkdownPayload(`OpenCode 请求权限 \`${escapeMarkdownText(permissionName)}\`，请回复 \`/allow once\`、\`/allow always\` 或 \`/deny\`。`), {
+        event: "final message sent",
+        transcriptType: "outbound-final",
+        textPreview: `权限请求：${permissionName}`,
+        len: permissionName.length + 16,
+      });
       return;
     }
 
     if (event.type === "question.asked") {
       const request = toQuestionRequest(event.properties, turn.sessionId);
       if (!request) return;
-      this.pendingQuestions.set(chatId, request);
-      await this.updateTurnCard(turn.turnId, { status: "等待回答", update: formatQuestionPrompt(request), target: "step" });
+      this.setPendingInteraction(chatId, {
+        kind: "question",
+        requestId: request.id,
+        sessionId: request.sessionId,
+        questions: request.questions,
+      });
+      await this.updateTurnCard(turn.turnId, { status: "等待回答", update: formatQuestionPrompt(request.questions), target: "step" });
+      return;
+    }
+
+    if (event.type === "session.status") {
+      const status = readOptionalRecord(event.properties, "status");
+      if (status && readOptionalString(status, "type") === "idle") {
+        await context.finish();
+      }
       return;
     }
 
     if (event.type === "session.idle") {
-      const text = context.getFinalText().trim() || await this.opencode.latestAssistantTextSince(turn.sessionId, context.baselineAssistantId);
-      if (!text) {
-        context.fail(new Error("OpenCode 未返回文本回复。"));
+      await context.finish();
+    }
+  }
+
+  private async handleCommand(chatId: string, routed: Extract<RoutedText, { kind: "command" }>): Promise<void> {
+    const { command } = routed;
+    if (command.kind === "new") {
+      const session = await this.opencode.createSession(`Feishu ${chatId}`);
+      await this.bindSession(chatId, session.id);
+      await this.sendMarkdown(chatId, "已创建并绑定新会话，下一条消息将继续在这个 session 中处理。");
+      return;
+    }
+
+    if (command.kind === "status") {
+      try {
+        const statuses = await this.opencode.getSessionStatuses();
+        for (const [sessionId, status] of Object.entries(statuses)) {
+          this.sessionStatuses.set(sessionId, status);
+        }
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        this.logger.log("bridge/status", "refresh status failed", { detail }, "warn");
+      }
+
+      const queue = this.queues.get(chatId);
+      const active = queue.peek();
+      const binding = this.sessionMap[chatId];
+      const status = binding ? this.sessionStatuses.get(binding.sessionId)?.type ?? "unknown" : "unbound";
+      const message = [
+        `事件流状态：${this.eventStream.getConnectionState()}`,
+        `当前会话：${binding ? `\`${binding.sessionId}\`` : "未绑定"}`,
+        `Session 状态：${status}`,
+        `队列状态：${active ? `处理中 ${createTextPreview(active.text)}` : "空闲"}`,
+        `排队数量：${queue.pendingCount()}`,
+      ].join("\n");
+      await this.sendMarkdown(chatId, message);
+      return;
+    }
+
+    if (command.kind === "abort") {
+      const binding = this.sessionMap[chatId];
+      if (binding) {
+        await this.opencode.abort(binding.sessionId);
+      }
+      await this.sendMarkdown(chatId, "已请求中止当前任务。");
+      return;
+    }
+
+    if (command.kind === "models") {
+      const providers = await this.opencode.listProviders();
+      await this.sendMarkdown(chatId, formatProviders(providers));
+      return;
+    }
+
+    if (command.kind === "sessions") {
+      const sessions = [...await this.opencode.listSessions()]
+        .sort((a, b) => getSessionUpdatedAt(b) - getSessionUpdatedAt(a))
+        .slice(0, 10);
+      if (sessions.length === 0) {
+        await this.sendMarkdown(chatId, "当前没有可切换的会话。");
         return;
       }
-      context.finish(text);
-    }
-  }
 
-  private async handleCommand(chatId: string, kind: "new" | "status" | "abort"): Promise<void> {
-    if (kind === "new") {
-      delete this.sessionMap[chatId];
-      await this.mappings.save(this.sessionMap);
-      await this.sendPayload(chatId, buildPostMarkdownPayload("已清空当前会话，下一条消息会创建新会话。"), {
-        event: "final message sent",
-        transcriptType: "outbound-final",
-        textPreview: "已清空当前会话，下一条消息会创建新会话。",
-        len: 19,
+      const options = sessions.map((session, index) => ({
+        index: index + 1,
+        sessionId: session.id,
+        title: session.title?.trim() || session.slug || session.id,
+      }));
+      this.setPendingInteraction(chatId, {
+        kind: "session-select",
+        options,
+        expiresAt: Date.now() + SESSION_SELECTION_TTL_MS,
       });
+      await this.sendMarkdown(chatId, formatSessionList(options));
       return;
     }
 
-    if (kind === "status") {
-      const queue = this.queues.get(chatId);
-      const active = queue.current();
-      const message = active ? `当前处理中：${createTextPreview(active.text)}` : "当前没有进行中的任务。";
-      await this.sendPayload(chatId, buildPostMarkdownPayload(message), {
-        event: "final message sent",
-        transcriptType: "outbound-final",
-        textPreview: message,
-        len: message.length,
-      });
+    if (command.kind === "sessions-select") {
+      const pending = this.pendingInteractions.get(chatId);
+      if (!pending || pending.kind !== "session-select" || pending.expiresAt <= Date.now()) {
+        this.clearPendingInteraction(chatId, false);
+        await this.sendMarkdown(chatId, "会话列表已过期，请先重新执行 `/sessions`。");
+        return;
+      }
+
+      const match = pending.options.find((option) => option.index === command.index);
+      if (!match) {
+        await this.sendMarkdown(chatId, "无效的会话编号，请重新执行 `/sessions` 查看列表。");
+        return;
+      }
+
+      await this.bindSession(chatId, match.sessionId);
+      this.clearPendingInteraction(chatId, false);
+      await this.sendMarkdown(chatId, `已切换到会话 \`${match.sessionId}\`。`);
       return;
     }
 
-    const sessionId = this.sessionMap[chatId];
-    if (sessionId) {
-      await this.opencode.abort(sessionId);
+    if (command.kind === "allow" || command.kind === "deny") {
+      const pending = this.pendingInteractions.get(chatId);
+      if (!pending || pending.kind !== "permission") {
+        await this.sendMarkdown(chatId, "当前没有待确认的权限请求。");
+        return;
+      }
+
+      const response = command.kind === "deny" ? "reject" : command.policy;
+      const remember = command.kind === "allow" && command.policy === "always";
+      await this.opencode.replyPermission(pending.sessionId, pending.permissionId, response, remember);
+      this.clearPendingInteraction(chatId, false);
+      await this.updateTurnCard(pending.turnId, { status: "处理中", update: `已处理权限请求：${pending.permissionName}`, target: "step" });
+      await this.sendMarkdown(chatId, command.kind === "deny" ? "已拒绝权限请求。" : "已确认权限请求。");
+      return;
     }
-    await this.sendPayload(chatId, buildPostMarkdownPayload("已请求中止当前任务。"), {
-      event: "final message sent",
-      transcriptType: "outbound-final",
-      textPreview: "已请求中止当前任务。",
-      len: 10,
+
+    const sessionId = await this.ensureSession(chatId);
+    const result = await this.opencode.runCommand(sessionId, {
+      command: command.name,
+      arguments: command.arguments,
     });
+    const text = extractAssistantText(result) || "命令已执行。";
+    await this.sendMarkdown(chatId, text);
   }
 
-  private async handleQuestionReply(chatId: string, request: QuestionRequest, text: string): Promise<void> {
+  private async handlePendingInteraction(chatId: string, pending: PendingInteraction, text: string): Promise<boolean> {
+    if (pending.kind === "question") {
+      try {
+        await this.opencode.replyQuestion(pending.requestId, [text]);
+        this.clearPendingInteraction(chatId, false);
+        const currentTurnId = this.queues.get(chatId).peek()?.turnId;
+        if (currentTurnId) {
+          await this.updateTurnCard(currentTurnId, { status: "处理中", update: "已收到你的回答，继续处理中...", target: "step" });
+        }
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        await this.sendMarkdown(chatId, `回答问题失败：${escapeMarkdownText(detail)}`);
+      }
+      return true;
+    }
+
+    if (pending.kind === "permission") {
+      await this.sendMarkdown(chatId, "当前有待确认的权限请求，请先回复 `/allow once`、`/allow always` 或 `/deny`。");
+      return true;
+    }
+
+    return false;
+  }
+
+  private async ensureSession(chatId: string): Promise<string> {
+    const existing = this.sessionMap[chatId];
+    if (existing) {
+      await this.touchSession(chatId, existing.sessionId);
+      return existing.sessionId;
+    }
+
+    const session = await this.opencode.createSession(`Feishu ${chatId}`);
+    await this.bindSession(chatId, session.id);
+    return session.id;
+  }
+
+  private async bindSession(chatId: string, sessionId: string): Promise<void> {
+    this.sessionMap[chatId] = {
+      sessionId,
+      lastUsedAt: Date.now(),
+    };
+    await this.mappings.save(this.sessionMap);
+  }
+
+  private async touchSession(chatId: string, sessionId: string): Promise<void> {
+    this.sessionMap[chatId] = {
+      sessionId,
+      lastUsedAt: Date.now(),
+    };
+    await this.mappings.save(this.sessionMap);
+  }
+
+  private async ensureServerAvailableForChat(chatId: string): Promise<boolean> {
+    if (this.eventStream.getConnectionState() === "connected") {
+      return true;
+    }
+
     try {
-      await this.opencode.replyQuestion(request.id, [text]);
-      this.pendingQuestions.delete(chatId);
-      const currentTurnId = this.queues.get(chatId).current()?.turnId;
-      if (currentTurnId) {
-        await this.updateTurnCard(currentTurnId, { status: "处理中", update: "已收到你的回答，继续处理中...", target: "step" });
+      await this.opencode.health();
+      return true;
+    } catch {
+      await this.sendMarkdown(chatId, "OpenCode 服务不可用，请先确认 `opencode serve` 正在运行。");
+      return false;
+    }
+  }
+
+  private async handleGlobalEvent(event: OpenCodeEvent): Promise<void> {
+    if (event.type === "session.status") {
+      const sessionId = getEventSessionId(event);
+      const status = readOptionalRecord(event.properties, "status");
+      if (sessionId && status) {
+        this.sessionStatuses.set(sessionId, status as OpenCodeSessionStatus);
+      }
+      return;
+    }
+
+    if (event.type === "session.idle") {
+      const sessionId = getEventSessionId(event);
+      if (sessionId) {
+        this.sessionStatuses.set(sessionId, { type: "idle" });
+      }
+    }
+  }
+
+  private async runFirstSseFallback(
+    sessionId: string,
+    baselineAssistantId: string | null,
+    handlers: {
+      updateText: (text: string) => Promise<void>;
+      finish: () => Promise<void>;
+      fail: (error: Error) => void;
+    },
+  ): Promise<void> {
+    try {
+      const latestAssistant = await this.getLatestAssistantMessage(sessionId, baselineAssistantId);
+      if (!latestAssistant) {
+        return;
+      }
+
+      const text = extractAssistantText(latestAssistant);
+      if (!text) {
+        return;
+      }
+
+      await handlers.updateText(text);
+      if (isCompletedMessage(latestAssistant)) {
+        await handlers.finish();
       }
     } catch (error) {
-      const detail = error instanceof Error ? error.message : String(error);
-      await this.sendPayload(chatId, buildPostMarkdownPayload(`回答问题失败：${escapeMarkdownText(detail)}`), {
-        event: "final message sent",
-        transcriptType: "outbound-final",
-        textPreview: detail,
-        len: detail.length,
-      });
+      handlers.fail(error instanceof Error ? error : new Error(String(error)));
     }
+  }
+
+  private async finalizeAssistantReply(sessionId: string, currentText: string, baselineAssistantId: string | null): Promise<string> {
+    const normalizedCurrent = cleanAssistantReply(currentText);
+    if (normalizedCurrent) {
+      return normalizedCurrent;
+    }
+
+    const latestAssistant = await this.getLatestAssistantMessage(sessionId, baselineAssistantId);
+    const text = cleanAssistantReply(extractAssistantText(latestAssistant));
+    if (!text) {
+      throw new Error("OpenCode 未返回文本回复。");
+    }
+    return text;
+  }
+
+  private async getLatestAssistantMessage(sessionId: string, baselineAssistantId?: string | null): Promise<OpenCodeMessage | null> {
+    const messages = await this.opencode.getSessionMessages(sessionId, 50);
+    const baselineIndex = baselineAssistantId
+      ? messages.findIndex((message) => message.info.id === baselineAssistantId)
+      : -1;
+    const tail = baselineIndex >= 0 ? messages.slice(baselineIndex + 1) : messages;
+    return [...tail].reverse().find((message) => message.info.role === "assistant") ?? null;
+  }
+
+  private setPendingInteraction(chatId: string, interaction: PendingInteraction): void {
+    this.clearPendingInteraction(chatId, false);
+    this.pendingInteractions.set(chatId, interaction);
+
+    if (interaction.kind === "permission") {
+      const timer = setTimeout(() => {
+        void this.handlePermissionTimeout(chatId, interaction);
+      }, Math.max(0, interaction.expiresAt - Date.now()));
+      this.pendingInteractionTimers.set(chatId, timer);
+      return;
+    }
+
+    if (interaction.kind === "session-select") {
+      const timer = setTimeout(() => {
+        this.clearPendingInteraction(chatId, false);
+      }, Math.max(0, interaction.expiresAt - Date.now()));
+      this.pendingInteractionTimers.set(chatId, timer);
+    }
+  }
+
+  private clearPendingInteraction(chatId: string, keepNonExpiring: boolean): void {
+    const timeout = this.pendingInteractionTimers.get(chatId);
+    if (timeout) {
+      clearTimeout(timeout);
+      this.pendingInteractionTimers.delete(chatId);
+    }
+
+    if (keepNonExpiring) {
+      const current = this.pendingInteractions.get(chatId);
+      if (current?.kind === "question") {
+        return;
+      }
+    }
+
+    this.pendingInteractions.delete(chatId);
+  }
+
+  private async handlePermissionTimeout(chatId: string, pending: PendingPermissionInteraction): Promise<void> {
+    const current = this.pendingInteractions.get(chatId);
+    if (!current || current.kind !== "permission" || current.permissionId !== pending.permissionId) {
+      return;
+    }
+
+    try {
+      await this.opencode.replyPermission(current.sessionId, current.permissionId, "reject", false);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      this.logger.log("bridge/permission", "auto deny failed", { chatId, permissionId: current.permissionId, detail }, "warn");
+    } finally {
+      this.clearPendingInteraction(chatId, false);
+    }
+
+    await this.updateTurnCard(current.turnId, { status: "处理中", update: "权限请求已超时，已默认拒绝", target: "step" });
+    await this.sendMarkdown(chatId, "权限请求已超时，已默认拒绝。");
   }
 
   private async createTurnCard(chatId: string, turnId: string, sessionId: string): Promise<TurnCardState | null> {
@@ -450,6 +814,65 @@ export class BridgeApp {
       this.logger.log("feishu/reply", "process card send failed", { chatId, turnId, detail }, "warn");
       return null;
     }
+  }
+
+  private async scheduleStreamUpdate(turnId: string, text: string): Promise<void> {
+    const card = this.turnCards.get(turnId);
+    if (!card) return;
+
+    const state = this.streamFlushStates.get(turnId) ?? {
+      flushedLength: 0,
+      lastFlushedAt: 0,
+      timer: null,
+    };
+    this.streamFlushStates.set(turnId, state);
+
+    const deltaLength = Math.max(0, text.length - state.flushedLength);
+    const elapsed = Date.now() - state.lastFlushedAt;
+    if (deltaLength >= STREAM_FLUSH_MIN_CHARS || elapsed >= STREAM_FLUSH_INTERVAL_MS) {
+      await this.flushStreamUpdate(turnId, text, false);
+      return;
+    }
+
+    if (state.timer) {
+      return;
+    }
+
+    const delay = Math.max(0, STREAM_FLUSH_INTERVAL_MS - elapsed);
+    state.timer = setTimeout(() => {
+      state.timer = null;
+      void this.flushStreamUpdate(turnId, text, false);
+    }, delay);
+  }
+
+  private async flushStreamUpdate(turnId: string, text: string, force: boolean): Promise<void> {
+    const state = this.streamFlushStates.get(turnId);
+    if (state?.timer) {
+      clearTimeout(state.timer);
+      state.timer = null;
+    }
+
+    await this.updateTurnCard(turnId, { update: text, sanitize: false, target: "final" });
+    const nextState = state ?? {
+      flushedLength: 0,
+      lastFlushedAt: 0,
+      timer: null,
+    };
+    nextState.flushedLength = text.length;
+    nextState.lastFlushedAt = Date.now();
+    this.streamFlushStates.set(turnId, nextState);
+
+    if (force) {
+      this.clearStreamFlushState(turnId);
+    }
+  }
+
+  private clearStreamFlushState(turnId: string): void {
+    const state = this.streamFlushStates.get(turnId);
+    if (state?.timer) {
+      clearTimeout(state.timer);
+    }
+    this.streamFlushStates.delete(turnId);
   }
 
   private async updateTurnCard(turnId: string, update: { status?: string; update?: string; sanitize?: boolean; target?: "step" | "tool" | "final"; toolKey?: string }): Promise<void> {
@@ -495,6 +918,15 @@ export class BridgeApp {
     };
   }
 
+  private async sendMarkdown(chatId: string, markdown: string): Promise<void> {
+    await this.sendPayload(chatId, buildPostMarkdownPayload(markdown), {
+      event: "final message sent",
+      transcriptType: "outbound-final",
+      textPreview: createTextPreview(markdown),
+      len: markdown.length,
+    });
+  }
+
   private async sendPayload(chatId: string, payload: FeishuPostPayload, options: { event: string; transcriptType: TranscriptType; textPreview: string; len: number }): Promise<{ messageId: string }> {
     const result = await this.outbound.sendMessage(chatId, payload);
     this.logger.log("feishu/reply", options.event, { chatId, messageId: result.messageId, textPreview: options.textPreview, len: options.len });
@@ -503,7 +935,13 @@ export class BridgeApp {
   }
 }
 
-function toQuestionRequest(properties: Record<string, unknown>, sessionId: string): QuestionRequest | null {
+function buildPromptRequest(text: string): { parts: Array<{ type: "text"; text: string }> } {
+  return {
+    parts: [{ type: "text", text }],
+  };
+}
+
+function toQuestionRequest(properties: Record<string, unknown>, sessionId: string): { id: string; sessionId: string; questions: Array<{ header: string; question: string }> } | null {
   const requestId = readOptionalString(properties, "id");
   const rawQuestions = properties.questions;
   if (!requestId || !Array.isArray(rawQuestions)) return null;
@@ -519,8 +957,50 @@ function toQuestionRequest(properties: Record<string, unknown>, sessionId: strin
   return { id: requestId, sessionId, questions };
 }
 
-function formatQuestionPrompt(request: QuestionRequest): string {
-  return ["❓ OpenCode 需要你回答：", ...request.questions.map((question, index) => `${index + 1}. ${escapeMarkdownText(question.header)}\n${escapeMarkdownText(question.question)}`)].join("\n\n");
+function formatQuestionPrompt(questions: PendingQuestionInteraction["questions"]): string {
+  return ["OpenCode 需要你回答：", ...questions.map((question, index) => `${index + 1}. ${escapeMarkdownText(question.header)}\n${escapeMarkdownText(question.question)}`)].join("\n\n");
+}
+
+function formatProviders(providers: OpenCodeProvidersResponse): string {
+  const lines = ["可用模型提供方："];
+  const defaults = providers.default;
+  for (const provider of providers.providers) {
+    const id = typeof provider.id === "string" ? provider.id : typeof provider.providerID === "string" ? provider.providerID : "unknown";
+    const name = typeof provider.name === "string" ? provider.name : id;
+    const model = defaults[id];
+    lines.push(`- ${name}${model ? `：默认 \`${model}\`` : ""}`);
+  }
+  if (lines.length === 1) {
+    lines.push("- 当前没有 provider 信息");
+  }
+  return lines.join("\n");
+}
+
+function formatSessionList(options: PendingSessionSelectionInteraction["options"]): string {
+  return [
+    "最近会话：",
+    ...options.map((option) => `${option.index}. ${escapeMarkdownText(option.title)}\n   \`${option.sessionId}\``),
+    "",
+    "30 秒内可用 `/sessions <编号>` 切换。",
+  ].join("\n");
+}
+
+function getSessionUpdatedAt(session: OpenCodeSession): number {
+  return session.time?.updated ?? session.time?.created ?? 0;
+}
+
+function extractAssistantText(message: OpenCodeMessage | null): string {
+  if (!message) return "";
+  return message.parts
+    .filter((part) => part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text ?? "")
+    .join("")
+    .trim();
+}
+
+function isCompletedMessage(message: OpenCodeMessage): boolean {
+  const time = isRecord(message.info.time) ? message.info.time : null;
+  return typeof message.info.finish === "string" || typeof time?.completed === "number";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/store/mappings.ts
+++ b/src/store/mappings.ts
@@ -1,9 +1,61 @@
 import { JsonStore } from "./json-store.js";
 
-export type MappingRecord = Record<string, string>;
+export type SessionBindingRecord = {
+  sessionId: string;
+  lastUsedAt: number;
+};
+
+export type MappingRecord = Record<string, SessionBindingRecord>;
 
 export class MappingStore extends JsonStore<MappingRecord> {
-  constructor(dataDir: string, fileName: string) {
+  constructor(dataDir: string, fileName: string, private readonly maxEntries = 200) {
     super(dataDir, fileName, {});
   }
+
+  override async load(): Promise<MappingRecord> {
+    const loaded = await super.load();
+    return normalizeMappings(loaded);
+  }
+
+  override async save(value: MappingRecord): Promise<void> {
+    await super.save(trimMappings(normalizeMappings(value), this.maxEntries));
+  }
+}
+
+function normalizeMappings(value: unknown): MappingRecord {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  const now = Date.now();
+  const normalizedEntries = Object.entries(value)
+    .map(([chatId, raw]) => {
+      if (typeof raw === "string") {
+        return [chatId, { sessionId: raw, lastUsedAt: now }] as const;
+      }
+
+      if (!isRecord(raw) || typeof raw.sessionId !== "string") {
+        return null;
+      }
+
+      return [
+        chatId,
+        {
+          sessionId: raw.sessionId,
+          lastUsedAt: typeof raw.lastUsedAt === "number" ? raw.lastUsedAt : now,
+        },
+      ] as const;
+    })
+    .filter((entry): entry is readonly [string, SessionBindingRecord] => entry !== null);
+
+  return Object.fromEntries(normalizedEntries);
+}
+
+function trimMappings(value: MappingRecord, maxEntries: number): MappingRecord {
+  const sorted = Object.entries(value).sort((a, b) => b[1].lastUsedAt - a[1].lastUsedAt);
+  return Object.fromEntries(sorted.slice(0, maxEntries));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }

--- a/start-bridge-dev.sh
+++ b/start-bridge-dev.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+cd "$SCRIPT_DIR"
+npm run dev

--- a/start-local-stack.sh
+++ b/start-local-stack.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+OPEN_CODE_DIR="$SCRIPT_DIR/.."
+OPEN_CODE_CLI="$OPEN_CODE_DIR/opencode-cli"
+
+if [ ! -f "$OPEN_CODE_CLI" ]; then
+  echo "Could not find $OPEN_CODE_CLI"
+  exit 1
+fi
+
+echo "Starting OpenCode Serve..."
+"$OPEN_CODE_CLI" serve &
+CLI_PID=$!
+
+echo "Starting Feishu Bridge..."
+cd "$SCRIPT_DIR"
+npm run dev
+
+# Ensure the background process is terminated when the script exits
+trap "kill $CLI_PID" EXIT

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OpenCodeClient } from "../src/opencode/client.js";
+
+describe("OpenCodeClient", () => {
+  const originalPassword = process.env.OPENCODE_SERVER_PASSWORD;
+  const originalUsername = process.env.OPENCODE_SERVER_USERNAME;
+
+  beforeEach(() => {
+    process.env.OPENCODE_SERVER_PASSWORD = "secret";
+    process.env.OPENCODE_SERVER_USERNAME = "tester";
+  });
+
+  afterEach(() => {
+    process.env.OPENCODE_SERVER_PASSWORD = originalPassword;
+    process.env.OPENCODE_SERVER_USERNAME = originalUsername;
+    vi.unstubAllGlobals();
+  });
+
+  it("sends basic auth and prompt_async body", async () => {
+    const fetch = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetch);
+    const client = new OpenCodeClient(new URL("http://127.0.0.1:4096/"));
+
+    const result = await client.promptAsync("ses_123", {
+      parts: [{ type: "text", text: "hello" }],
+    });
+
+    expect(result.accepted).toBe(true);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = fetch.mock.calls[0] as [URL, RequestInit];
+    expect(String(url)).toBe("http://127.0.0.1:4096/session/ses_123/prompt_async");
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>).Authorization).toBe(`Basic ${Buffer.from("tester:secret").toString("base64")}`);
+    expect(init.body).toBe(JSON.stringify({ parts: [{ type: "text", text: "hello" }] }));
+  });
+
+  it("adds query params when listing messages", async () => {
+    const fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify([]), { status: 200 }));
+    vi.stubGlobal("fetch", fetch);
+    const client = new OpenCodeClient(new URL("http://127.0.0.1:4096/"));
+
+    await client.getSessionMessages("ses_1", 20);
+
+    const [url] = fetch.mock.calls[0] as [URL];
+    expect(String(url)).toBe("http://127.0.0.1:4096/session/ses_1/message?limit=20");
+  });
+
+  it("uses the documented permission path and payload", async () => {
+    const fetch = vi.fn().mockResolvedValue(new Response("true", { status: 200 }));
+    vi.stubGlobal("fetch", fetch);
+    const client = new OpenCodeClient(new URL("http://127.0.0.1:4096/"));
+
+    await client.replyPermission("ses_9", "per_7", "always", true);
+
+    const [url, init] = fetch.mock.calls[0] as [URL, RequestInit];
+    expect(String(url)).toBe("http://127.0.0.1:4096/session/ses_9/permissions/per_7");
+    expect(init.body).toBe(JSON.stringify({ response: "always", remember: true }));
+  });
+});

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,21 +1,78 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { getEventSessionId, OpenCodeEventStream } from "../src/opencode/events.js";
 
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 describe("events", () => {
   it("reads session id from event", () => {
-    expect(getEventSessionId({ type: "x", properties: { sessionID: "ses_1" } })).toBe("ses_1");
+    expect(getEventSessionId({ sessionId: null, properties: { sessionID: "ses_1" } })).toBe("ses_1");
   });
 
   it("supports lowercase sessionId", () => {
-    expect(getEventSessionId({ type: "x", properties: { sessionId: "ses_2" } })).toBe("ses_2");
+    expect(getEventSessionId({ sessionId: null, properties: { sessionId: "ses_2" } })).toBe("ses_2");
   });
 
   it("emits subscribed events", async () => {
-    const stream = new OpenCodeEventStream(new URL("http://127.0.0.1:4096/"), ".", { log() {} });
+    const stream = new OpenCodeEventStream(new URL("http://127.0.0.1:4096/"), { log() {} });
     let called = false;
     stream.subscribe(async () => { called = true; });
-    await stream.emit({ type: "x", properties: {} });
+    await stream.emit({ type: "x", properties: {}, sessionId: null, receivedAt: Date.now(), streamEndpoint: "/event", raw: {} });
     expect(called).toBe(true);
   });
+
+  it("normalizes /event payloads", async () => {
+    const fetch = vi.fn().mockResolvedValue(new Response(createSseBody([
+      'data: {"type":"server.connected","properties":{}}',
+      'data: {"type":"message.part.delta","properties":{"sessionID":"ses_1","field":"text","delta":"Hi"}}',
+    ]), { status: 200 }));
+    vi.stubGlobal("fetch", fetch);
+
+    const events: string[] = [];
+    const stream = new OpenCodeEventStream(new URL("http://127.0.0.1:4096/"), { log() {} });
+    stream.subscribe(async (event) => {
+      events.push(`${event.streamEndpoint}:${event.type}:${event.sessionId ?? "-"}`);
+    });
+
+    await stream.start();
+    await vi.waitFor(() => expect(events).toContain("/event:message.part.delta:ses_1"));
+    await stream.stop();
+  });
+
+  it("falls back to /global/event and unwraps payload", async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(new Response("nope", { status: 404, statusText: "Not Found" }))
+      .mockResolvedValueOnce(new Response(createSseBody([
+        'data: {"payload":{"type":"server.connected","properties":{}}}',
+        'data: {"payload":{"type":"session.idle","properties":{"sessionID":"ses_2"}}}',
+      ]), { status: 200 }));
+    vi.stubGlobal("fetch", fetch);
+
+    const seen: string[] = [];
+    const logger = { log: vi.fn() };
+    const stream = new OpenCodeEventStream(new URL("http://127.0.0.1:4096/"), logger);
+    stream.subscribe(async (event) => {
+      seen.push(`${event.streamEndpoint}:${event.type}:${event.sessionId ?? "-"}`);
+    });
+
+    await stream.start();
+    await vi.waitFor(() => expect(seen).toContain("/global/event:session.idle:ses_2"));
+    await stream.stop();
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
 });
+
+function createSseBody(events: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(encoder.encode(`${event}\n\n`));
+      }
+      controller.close();
+    },
+    cancel() {},
+  });
+}

--- a/test/mappings.test.ts
+++ b/test/mappings.test.ts
@@ -1,0 +1,34 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { MappingStore } from "../src/store/mappings.js";
+
+describe("MappingStore", () => {
+  it("normalizes legacy string mappings on load", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-mappings-"));
+    await writeFile(path.join(dir, "mappings.json"), JSON.stringify({ chat: "ses_1" }), "utf8");
+    const store = new MappingStore(dir, "mappings.json", 2);
+
+    const mappings = await store.load();
+
+    expect(mappings.chat?.sessionId).toBe("ses_1");
+    expect(typeof mappings.chat?.lastUsedAt).toBe("number");
+  });
+
+  it("trims to the configured LRU size on save", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-mappings-"));
+    const store = new MappingStore(dir, "mappings.json", 2);
+
+    await store.save({
+      a: { sessionId: "ses_a", lastUsedAt: 1 },
+      b: { sessionId: "ses_b", lastUsedAt: 3 },
+      c: { sessionId: "ses_c", lastUsedAt: 2 },
+    });
+
+    const raw = JSON.parse(await readFile(path.join(dir, "mappings.json"), "utf8")) as Record<string, { sessionId: string; lastUsedAt: number }>;
+    expect(Object.keys(raw)).toEqual(["b", "c"]);
+  });
+});

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { routeIncomingText } from "../src/bridge/router.js";
+
+describe("routeIncomingText", () => {
+  it("routes /sessions <index> without accepting bare numbers", () => {
+    expect(routeIncomingText("/sessions 3")).toEqual({
+      kind: "command",
+      command: { kind: "sessions-select", index: 3 },
+    });
+    expect(routeIncomingText("3 个文件要处理")).toEqual({
+      kind: "message",
+      text: "3 个文件要处理",
+    });
+  });
+
+  it("routes permission commands", () => {
+    expect(routeIncomingText("/allow once")).toEqual({
+      kind: "command",
+      command: { kind: "allow", policy: "once" },
+    });
+    expect(routeIncomingText("/deny")).toEqual({
+      kind: "command",
+      command: { kind: "deny" },
+    });
+  });
+
+  it("passes unknown slash commands through", () => {
+    expect(routeIncomingText("/compact fast now")).toEqual({
+      kind: "command",
+      command: { kind: "passthrough", name: "compact", arguments: ["fast", "now"] },
+    });
+  });
+});

--- a/test/state-machine.test.ts
+++ b/test/state-machine.test.ts
@@ -13,4 +13,10 @@ describe("transitionTurn", () => {
     const turn = transitionTurn({ turnId: "1", chatId: "c", senderOpenId: "u", inboundMessageId: "m", text: "hi", startedAt: 1 }, "running");
     expect(turn.startedAt).toBe(1);
   });
+
+  it("keeps startedAt when transitioning to awaiting-sse", () => {
+    const turn = transitionTurn({ turnId: "1", chatId: "c", senderOpenId: "u", inboundMessageId: "m", text: "hi", startedAt: 1 }, "awaiting-sse");
+    expect(turn.state).toBe("awaiting-sse");
+    expect(turn.startedAt).toBe(1);
+  });
 });


### PR DESCRIPTION
## 变更内容
- 重写 OpenCode HTTP Client 与 SSE 事件流层，使 bridge 对齐真实的 OpenCode Server API
- 将运行时消息处理切换为 `prompt_async` + SSE 驱动完成，并补充启动健康检查、项目目录校验、首个事件兜底轮询与飞书卡片流式更新
- 增加命令路由、统一的 pending interaction 状态、权限超时自动拒绝，以及带 LRU 裁剪的聊天到 session 映射持久化
- 补充 client、router、mappings、events 与 state machine 的测试覆盖
- 新增 Linux/macOS 用的启动脚本 `start-bridge-dev.sh` 与 `start-local-stack.sh`

## 变更原因
原来的 bridge 依赖本地占位事件模型和不完整的 OpenCode 接口，无法稳定对接 `opencode serve`。

## 影响
飞书桥接现在可以直接对接真实的 OpenCode 服务契约，支持更完整的 session / 权限工作流，并在服务不可用或项目目录不匹配时给出更明确的错误反馈。

## 验证
- `npm run typecheck`
- `npm run lint`
- `npm test`