### PR TITLE
[codex] 新增窗口级会话模式与切换能力

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## 变更内容
+- 
+
+## 变更原因
+
+## 影响
+
+## 验证
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,6 @@
 - Do not simulate session creation, switching, closing, or renaming inside the agent response.
 - Use `lark-cli` only when the user explicitly asks to operate on Feishu or Lark resources.
 - Treat bridge-injected system state as authoritative for the current window, active session, and visible sessions.
+- For GitHub pull requests, use Chinese titles and descriptions by default.
+- Preferred PR title format: `[codex] <动词><变更主题>`.
+- Preferred PR body sections: `变更内容`, `变更原因`, `影响`, `验证`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Bridge Runtime Rules
+
+- The bridge owns session control for `/new`, `/sessions`, `/switch`, and `/status`.
+- The bridge owns runtime process cards, final replies, and other operational status messages sent back to Feishu.
+- Do not simulate session creation, switching, closing, or renaming inside the agent response.
+- Use `lark-cli` only when the user explicitly asks to operate on Feishu or Lark resources.
+- Treat bridge-injected system state as authoritative for the current window, active session, and visible sessions.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It listens to Feishu message events over WebSocket, maps each conversation to an
 ## Features
 
 - Supports Feishu `p2p`, `group`, and `topic_group` chats
-- Uses one OpenCode session per conversation
+- Uses per-window session registries with configurable `single` or `multi` mode
 - Uses thread-aware isolation for group chats
 - Supports OpenCode `prompt_async`, command routing, abort, status, models, permissions, and session switching
 - Streams progress into a Feishu interactive card and updates the same message in place
@@ -92,6 +92,14 @@ Copy the example config and fill in your real values:
   },
   "bridge": {
     "queueLimit": 3,
+    "sessions": {
+      "p2pMode": "multi",
+      "groupMode": "single",
+      "topicGroupMode": "single",
+      "maxSessionsPerWindow": 20,
+      "listLimit": 10,
+      "injectSystemState": true
+    },
     "timeouts": {
       "firstEvent": 30000,
       "eventInterval": 120000,
@@ -127,6 +135,13 @@ Copy the example config and fill in your real values:
 When `requireBotMentionInGroup=true`, group messages are handled only when they match your configured bot identity rules.
 
 When `strictBotMention=true`, the bridge only accepts messages that explicitly mention one of the configured bot identities.
+
+### Session modes
+
+- `p2pMode`, `groupMode`, and `topicGroupMode` control whether a window behaves as `single` or `multi` session mode.
+- `single` keeps exactly one active session in the window. `/new` replaces it. `/switch` and `/sessions <index>` are rejected.
+- `multi` keeps multiple sessions per window, shows them through `/sessions`, and allows switching with `/switch <index>` or `/sessions <index>`.
+- `injectSystemState=true` adds bridge-owned window and session state into the OpenCode `system` field without polluting the user message text.
 
 ## OpenCode auth
 
@@ -169,6 +184,7 @@ Supported slash commands:
 - `/abort`
 - `/models`
 - `/sessions`
+- `/switch <index>`
 - `/sessions <index>`
 - `/allow once`
 - `/allow always`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,7 +7,7 @@ Feishu OpenCode Bridge 是一个独立运行的 TypeScript 服务，用来把飞
 ## 功能特性
 
 - 支持飞书 `p2p`、`group`、`topic_group` 三类会话
-- 一个飞书对话绑定一个 OpenCode session
+- 按窗口维护 OpenCode session registry，并支持 `single` / `multi` 两种会话模式
 - 群聊按线程隔离上下文
 - 支持 OpenCode `prompt_async`、命令转发、中止、状态、模型、权限请求、session 切换
 - 使用飞书交互卡片承载过程消息，并持续更新同一条回复
@@ -92,6 +92,14 @@ npm install
   },
   "bridge": {
     "queueLimit": 3,
+    "sessions": {
+      "p2pMode": "multi",
+      "groupMode": "single",
+      "topicGroupMode": "single",
+      "maxSessionsPerWindow": 20,
+      "listLimit": 10,
+      "injectSystemState": true
+    },
     "timeouts": {
       "firstEvent": 30000,
       "eventInterval": 120000,
@@ -127,6 +135,13 @@ npm install
 当 `requireBotMentionInGroup=true` 时，群聊消息只有命中机器人匹配规则才会处理。
 
 当 `strictBotMention=true` 时，只接受明确命中已配置机器人身份的消息。
+
+### 会话模式
+
+- `p2pMode`、`groupMode`、`topicGroupMode` 用来控制窗口采用 `single` 还是 `multi` 模式。
+- `single` 模式下，窗口内始终只有 1 个 active session。`/new` 会替换它，`/switch` 和 `/sessions <编号>` 会被拒绝。
+- `multi` 模式下，窗口内可保留多个 session，可通过 `/sessions` 查看，并用 `/switch <编号>` 或 `/sessions <编号>` 切换。
+- `injectSystemState=true` 会把 bridge 的窗口和会话状态写进 OpenCode 的 `system` 字段，不污染用户正文。
 
 ## OpenCode 鉴权
 
@@ -167,6 +182,7 @@ npm run dev:once
 - `/abort`
 - `/models`
 - `/sessions`
+- `/switch <编号>`
 - `/sessions <编号>`
 - `/allow once`
 - `/allow always`

--- a/config.example.json
+++ b/config.example.json
@@ -28,6 +28,14 @@
   },
   "bridge": {
     "queueLimit": 3,
+    "sessions": {
+      "p2pMode": "multi",
+      "groupMode": "single",
+      "topicGroupMode": "single",
+      "maxSessionsPerWindow": 20,
+      "listLimit": 10,
+      "injectSystemState": true
+    },
     "timeouts": {
       "firstEvent": 30000,
       "eventInterval": 120000,

--- a/src/bridge/router.ts
+++ b/src/bridge/router.ts
@@ -51,6 +51,13 @@ export function routeIncomingText(text: string): RoutedText {
     };
   }
 
+  if (rawCommand === "switch" && args.length === 1 && /^\d+$/.test(args[0] ?? "")) {
+    return {
+      kind: "command",
+      command: { kind: "sessions-select", index: Number(args[0]) },
+    };
+  }
+
   if (rawCommand === "allow" && (args[0] === "once" || args[0] === "always") && args.length === 1) {
     return {
       kind: "command",

--- a/src/bridge/state.ts
+++ b/src/bridge/state.ts
@@ -18,7 +18,7 @@ export type PendingPermissionInteraction = {
 
 export type PendingSessionSelectionInteraction = {
   kind: "session-select";
-  options: Array<{ index: number; sessionId: string; title: string }>;
+  options: Array<{ index: number; sessionId: string; title: string; current?: boolean }>;
   expiresAt: number;
 };
 

--- a/src/bridge/turn.ts
+++ b/src/bridge/turn.ts
@@ -6,6 +6,7 @@ export type BridgeTurn = {
   chatType?: string;
   senderOpenId: string;
   inboundMessageId: string;
+  plainText: string;
   text: string;
   sessionId?: string;
   processMessageId?: string;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -44,6 +44,14 @@ export async function loadConfig(configPath?: string): Promise<AppConfig> {
     },
     bridge: {
       queueLimit: parsed.bridge.queueLimit,
+      sessionModes: {
+        p2p: parsed.bridge.sessions.p2pMode,
+        group: parsed.bridge.sessions.groupMode,
+        topicGroup: parsed.bridge.sessions.topicGroupMode,
+      },
+      maxSessionsPerWindow: parsed.bridge.sessions.maxSessionsPerWindow,
+      sessionListLimit: parsed.bridge.sessions.listLimit,
+      injectSystemState: parsed.bridge.sessions.injectSystemState,
       firstEventTimeoutMs: parsed.bridge.timeouts.firstEvent,
       eventGapTimeoutMs: parsed.bridge.timeouts.eventInterval,
       totalTimeoutMs: parsed.bridge.timeouts.totalTurn,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+const SessionModeSchema = z.enum(["single", "multi"]);
+
 export const ConfigSchema = z.object({
   feishu: z.object({
     appId: z.string().min(1),
@@ -30,6 +32,14 @@ export const ConfigSchema = z.object({
   }),
   bridge: z.object({
     queueLimit: z.number().int().positive().default(3),
+    sessions: z.object({
+      p2pMode: SessionModeSchema.default("multi"),
+      groupMode: SessionModeSchema.default("single"),
+      topicGroupMode: SessionModeSchema.default("single"),
+      maxSessionsPerWindow: z.number().int().positive().default(20),
+      listLimit: z.number().int().positive().default(10),
+      injectSystemState: z.boolean().default(true),
+    }).default({}),
     timeouts: z.object({
       firstEvent: z.number().int().positive().default(30_000),
       eventInterval: z.number().int().positive().default(120_000),
@@ -76,6 +86,14 @@ export type AppConfig = {
   };
   bridge: {
     queueLimit: number;
+    sessionModes: {
+      p2p: "single" | "multi";
+      group: "single" | "multi";
+      topicGroup: "single" | "multi";
+    };
+    maxSessionsPerWindow: number;
+    sessionListLimit: number;
+    injectSystemState: boolean;
     firstEventTimeoutMs: number;
     eventGapTimeoutMs: number;
     totalTimeoutMs: number;

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -24,9 +24,20 @@ import {
   type OpenCodeSessionStatus,
 } from "../opencode/client.js";
 import { getEventSessionId, OpenCodeEventStream, type OpenCodeEvent } from "../opencode/events.js";
-import { MappingStore, type MappingRecord } from "../store/mappings.js";
+import { MappingStore, type MappingRecord, type SessionBindingRecord, type SessionMode, type SessionWindowRecord } from "../store/mappings.js";
 import type { AppConfig } from "../config/schema.js";
 import { cleanAssistantReply } from "./sanitize.js";
+import {
+  addSession,
+  createSessionEntry,
+  getActiveSession,
+  getVisibleSessions,
+  normalizeSessionWindowRecord,
+  removeSession,
+  resolveSessionMode,
+  setActiveSession,
+  updateSessionLabel,
+} from "./session-windows.js";
 
 export type IncomingChatMessage = {
   chatId: string;
@@ -99,6 +110,7 @@ export class BridgeApp {
     if (project.worktree !== this.config.opencode.directory) {
       throw new Error(`opencode serve 当前在 ${project.worktree}，bridge 配置的是 ${this.config.opencode.directory}，请在正确目录重启 opencode serve`);
     }
+    await this.syncStoredSessionLabels();
 
     await this.eventStream.start();
     this.globalEventUnsubscribe = this.eventStream.subscribe(async (event) => {
@@ -165,7 +177,6 @@ export class BridgeApp {
     }
 
     const queue = this.queues.get(message.conversationKey);
-    const existingSession = this.sessionMap[message.conversationKey];
     const turn: BridgeTurn = {
       turnId: crypto.randomUUID(),
       chatId: message.chatId,
@@ -174,11 +185,9 @@ export class BridgeApp {
       chatType: message.chatType,
       senderOpenId: message.senderOpenId,
       inboundMessageId: message.messageId,
+      plainText: message.plainText,
       text: toOpencodePromptText(message),
     };
-    if (existingSession?.sessionId) {
-      turn.sessionId = existingSession.sessionId;
-    }
 
     const result = queue.enqueue(turn);
     if (!result.accepted) {
@@ -240,6 +249,7 @@ export class BridgeApp {
       const reply = cleanAssistantReply(await this.executeTurn(conversationKey, turn as BridgeTurn & { sessionId: string }));
       this.logger.log("opencode/events", "reply completed", { turnId: turn.turnId, sessionId, len: reply.length });
       this.logger.logTranscript("opencode-reply", { sessionId, turnId: turn.turnId }, reply);
+      await this.maybeUpdateSessionLabel(turn as BridgeTurn & { sessionId: string });
       await this.flushStreamUpdate(turn.turnId, reply, true);
       await this.updateTurnCard(turn.turnId, { status: "已完成", update: `最终回复已生成（${reply.length} 字）`, target: "step" });
       queue.replaceActive(transitionTurn({ ...turn, sessionId }, "done"));
@@ -343,7 +353,10 @@ export class BridgeApp {
       );
 
       watchdog.start();
-      void this.opencode.promptAsync(turn.sessionId, buildPromptRequest(turn.text))
+      const systemPrompt = this.config.bridge.injectSystemState
+        ? buildBridgeSystemPrompt(turn, this.getSessionWindow(turn.conversationKey, turn.chatType))
+        : undefined;
+      void this.opencode.promptAsync(turn.sessionId, buildPromptRequest(turn.text, systemPrompt))
         .then(() => {
           queue.replaceActive(transitionTurn(turn, "awaiting-sse"));
           void this.updateTurnCard(turn.turnId, { status: "处理中", update: "请求已发送，等待事件流...", target: "step" });
@@ -509,9 +522,8 @@ export class BridgeApp {
   ): Promise<void> {
     const { command } = routed;
     if (command.kind === "new") {
-      const session = await this.opencode.createSession(buildSessionTitle(message.chatId, message.chatType, message.threadKey));
-      await this.bindSession(message.conversationKey, session.id);
-      await this.sendMarkdown(message.chatId, "已创建并绑定新会话，下一条消息将继续在这个 session 中处理。", message.messageId);
+      const entry = await this.createAndBindSession(message);
+      await this.sendMarkdown(message.chatId, `已创建并切换到新会话 \`${entry.sessionId}\`。`, message.messageId);
       return;
     }
 
@@ -528,23 +540,27 @@ export class BridgeApp {
 
       const queue = this.queues.get(message.conversationKey);
       const active = queue.peek();
-      const binding = this.sessionMap[message.conversationKey];
-      const status = binding ? this.sessionStatuses.get(binding.sessionId)?.type ?? "unknown" : "unbound";
+      const window = this.getSessionWindow(message.conversationKey, message.chatType);
+      const currentSession = getActiveSession(window);
+      const status = currentSession ? this.sessionStatuses.get(currentSession.sessionId)?.type ?? "unknown" : "unbound";
       const statusText = [
         `事件流状态：${this.eventStream.getConnectionState()}`,
-        `当前会话：${binding ? `\`${binding.sessionId}\`` : "未绑定"}`,
+        `会话模式：${window.mode}`,
+        `当前会话：${currentSession ? `${escapeMarkdownText(currentSession.label)} \`${currentSession.sessionId}\`` : "未绑定"}`,
         `Session 状态：${status}`,
         `队列状态：${active ? `处理中 ${createTextPreview(active.text)}` : "空闲"}`,
         `排队数量：${queue.pendingCount()}`,
+        `窗口会话数：${window.sessions.length}`,
       ].join("\n");
       await this.sendMarkdown(message.chatId, statusText, message.messageId);
       return;
     }
 
     if (command.kind === "abort") {
-      const binding = this.sessionMap[message.conversationKey];
-      if (binding) {
-        await this.opencode.abort(binding.sessionId);
+      const window = this.getSessionWindow(message.conversationKey, message.chatType);
+      const currentSession = getActiveSession(window);
+      if (currentSession) {
+        await this.opencode.abort(currentSession.sessionId);
       }
       await this.sendMarkdown(message.chatId, "已请求中止当前任务。", message.messageId);
       return;
@@ -557,18 +573,27 @@ export class BridgeApp {
     }
 
     if (command.kind === "sessions") {
-      const sessions = [...await this.opencode.listSessions()]
-        .sort((a, b) => getSessionUpdatedAt(b) - getSessionUpdatedAt(a))
-        .slice(0, 10);
-      if (sessions.length === 0) {
-        await this.sendMarkdown(message.chatId, "当前没有可切换的会话。", message.messageId);
+      const window = this.getSessionWindow(message.conversationKey, message.chatType);
+      const currentSession = getActiveSession(window);
+      if (window.mode === "single") {
+        const text = currentSession
+          ? formatSingleSessionStatus(window.mode, currentSession)
+          : "当前窗口为单会话模式，暂未绑定会话。";
+        await this.sendMarkdown(message.chatId, text, message.messageId);
         return;
       }
 
-      const options = sessions.map((session, index) => ({
+      const visibleSessions = getVisibleSessions(window).slice(0, this.config.bridge.sessionListLimit);
+      if (visibleSessions.length === 0) {
+        await this.sendMarkdown(message.chatId, "当前窗口暂无可切换的会话。", message.messageId);
+        return;
+      }
+
+      const options = visibleSessions.map((session, index) => ({
         index: index + 1,
-        sessionId: session.id,
-        title: session.title?.trim() || session.slug || session.id,
+        sessionId: session.sessionId,
+        title: session.label,
+        current: session.sessionId === currentSession?.sessionId,
       }));
       this.setPendingInteraction(message.conversationKey, {
         kind: "session-select",
@@ -580,6 +605,12 @@ export class BridgeApp {
     }
 
     if (command.kind === "sessions-select") {
+      const window = this.getSessionWindow(message.conversationKey, message.chatType);
+      if (window.mode === "single") {
+        await this.sendMarkdown(message.chatId, "当前窗口为单会话模式，不支持切换。", message.messageId);
+        return;
+      }
+
       const pending = this.pendingInteractions.get(message.conversationKey);
       if (!pending || pending.kind !== "session-select" || pending.expiresAt <= Date.now()) {
         this.clearPendingInteraction(message.conversationKey, false);
@@ -593,9 +624,22 @@ export class BridgeApp {
         return;
       }
 
-      await this.bindSession(message.conversationKey, match.sessionId);
+      const openCodeSessions = await this.listOpenCodeSessionsById();
+      if (!openCodeSessions.has(match.sessionId)) {
+        const nextWindow = removeSession(window, match.sessionId, this.config.bridge.maxSessionsPerWindow);
+        await this.saveSessionWindow(message.conversationKey, nextWindow);
+        this.clearPendingInteraction(message.conversationKey, false);
+        await this.sendMarkdown(message.chatId, "目标会话已失效，已从当前窗口列表移除，请重新执行 `/sessions`。", message.messageId);
+        return;
+      }
+
+      let nextWindow = setActiveSession(window, match.sessionId, Date.now(), this.config.bridge.maxSessionsPerWindow);
+      const sessionMeta = openCodeSessions.get(match.sessionId);
+      const fallbackLabel = resolveDisplayLabel(sessionMeta, match.title, match.sessionId);
+      nextWindow = updateSessionLabel(nextWindow, match.sessionId, fallbackLabel, this.config.bridge.maxSessionsPerWindow);
+      await this.saveSessionWindow(message.conversationKey, nextWindow);
       this.clearPendingInteraction(message.conversationKey, false);
-      await this.sendMarkdown(message.chatId, `已切换到会话 \`${match.sessionId}\`。`, message.messageId);
+      await this.sendMarkdown(message.chatId, `已切换到会话 ${escapeMarkdownText(fallbackLabel)} \`${match.sessionId}\`。`, message.messageId);
       return;
     }
 
@@ -649,31 +693,27 @@ export class BridgeApp {
   }
 
   private async ensureSession(source: Pick<BridgeTurn, "chatId" | "chatType" | "conversationKey" | "threadKey">): Promise<string> {
-    const existing = this.sessionMap[source.conversationKey];
-    if (existing) {
-      await this.touchSession(source.conversationKey, existing.sessionId);
-      return existing.sessionId;
+    const openCodeSessions = await this.listOpenCodeSessionsById();
+    let window = this.getSessionWindow(source.conversationKey, source.chatType);
+    let currentSession = getActiveSession(window);
+
+    while (currentSession) {
+      if (openCodeSessions.has(currentSession.sessionId)) {
+        let nextWindow = setActiveSession(window, currentSession.sessionId, Date.now(), this.config.bridge.maxSessionsPerWindow);
+        const sessionMeta = openCodeSessions.get(currentSession.sessionId);
+        const fallbackLabel = resolveDisplayLabel(sessionMeta, currentSession.label, currentSession.sessionId);
+        nextWindow = updateSessionLabel(nextWindow, currentSession.sessionId, fallbackLabel, this.config.bridge.maxSessionsPerWindow);
+        await this.saveSessionWindow(source.conversationKey, nextWindow);
+        return currentSession.sessionId;
+      }
+
+      window = removeSession(window, currentSession.sessionId, this.config.bridge.maxSessionsPerWindow);
+      await this.saveSessionWindow(source.conversationKey, window);
+      currentSession = getActiveSession(window);
     }
 
-    const session = await this.opencode.createSession(buildSessionTitle(source.chatId, source.chatType, source.threadKey));
-    await this.bindSession(source.conversationKey, session.id);
-    return session.id;
-  }
-
-  private async bindSession(conversationKey: string, sessionId: string): Promise<void> {
-    this.sessionMap[conversationKey] = {
-      sessionId,
-      lastUsedAt: Date.now(),
-    };
-    await this.mappings.save(this.sessionMap);
-  }
-
-  private async touchSession(conversationKey: string, sessionId: string): Promise<void> {
-    this.sessionMap[conversationKey] = {
-      sessionId,
-      lastUsedAt: Date.now(),
-    };
-    await this.mappings.save(this.sessionMap);
+    const entry = await this.createAndBindSession(source);
+    return entry.sessionId;
   }
 
   private async ensureServerAvailableForMessage(message: Pick<IncomingChatMessage, "chatId" | "messageId">): Promise<boolean> {
@@ -805,6 +845,77 @@ export class BridgeApp {
   private async getAssistantMessageById(sessionId: string, messageId: string): Promise<OpenCodeMessage | null> {
     const messages = await this.opencode.getSessionMessages(sessionId, 200);
     return messages.find((message) => message.info.id === messageId && message.info.role === "assistant") ?? null;
+  }
+
+  private getSessionWindow(conversationKey: string, chatType?: string): SessionWindowRecord {
+    const mode = resolveSessionMode(chatType, this.config.bridge.sessionModes);
+    return normalizeSessionWindowRecord(this.sessionMap[conversationKey], mode, this.config.bridge.maxSessionsPerWindow);
+  }
+
+  private async saveSessionWindow(conversationKey: string, window: SessionWindowRecord): Promise<void> {
+    if (window.sessions.length === 0) {
+      delete this.sessionMap[conversationKey];
+    } else {
+      this.sessionMap[conversationKey] = window;
+    }
+    await this.mappings.save(this.sessionMap);
+  }
+
+  private async createAndBindSession(
+    source: Pick<BridgeTurn, "chatId" | "chatType" | "conversationKey" | "threadKey">,
+  ): Promise<SessionBindingRecord> {
+    const session = await this.opencode.createSession(buildSessionTitle(source.chatId, source.chatType, source.threadKey));
+    const entry = createSessionEntry(session.id, Date.now(), "新会话");
+    const window = this.getSessionWindow(source.conversationKey, source.chatType);
+    const nextWindow = addSession(window, entry, this.config.bridge.maxSessionsPerWindow);
+    await this.saveSessionWindow(source.conversationKey, nextWindow);
+    return entry;
+  }
+
+  private async maybeUpdateSessionLabel(turn: BridgeTurn & { sessionId: string }): Promise<void> {
+    const window = this.getSessionWindow(turn.conversationKey, turn.chatType);
+    const currentSession = window.sessions.find((session) => session.sessionId === turn.sessionId);
+    if (!currentSession || currentSession.label !== "新会话") {
+      return;
+    }
+
+    const nextLabel = summarizeSessionLabel(turn.plainText) || currentSession.label;
+    if (nextLabel === currentSession.label) {
+      return;
+    }
+
+    const nextWindow = updateSessionLabel(window, turn.sessionId, nextLabel, this.config.bridge.maxSessionsPerWindow);
+    await this.saveSessionWindow(turn.conversationKey, nextWindow);
+  }
+
+  private async listOpenCodeSessionsById(): Promise<Map<string, OpenCodeSession>> {
+    const sessions = await this.opencode.listSessions();
+    return new Map(sessions.map((session) => [session.id, session]));
+  }
+
+  private async syncStoredSessionLabels(): Promise<void> {
+    const sessionsById = await this.listOpenCodeSessionsById();
+    let changed = false;
+
+    for (const [conversationKey, window] of Object.entries(this.sessionMap)) {
+      let nextWindow = normalizeSessionWindowRecord(window, window.mode, this.config.bridge.maxSessionsPerWindow);
+      for (const session of nextWindow.sessions) {
+        if (!shouldHydrateLabelFromSessionMeta(session.label, session.sessionId)) {
+          continue;
+        }
+        const nextLabel = resolveDisplayLabel(sessionsById.get(session.sessionId), session.label, session.sessionId);
+        if (nextLabel === session.label) {
+          continue;
+        }
+        nextWindow = updateSessionLabel(nextWindow, session.sessionId, nextLabel, this.config.bridge.maxSessionsPerWindow);
+        changed = true;
+      }
+      this.sessionMap[conversationKey] = nextWindow;
+    }
+
+    if (changed) {
+      await this.mappings.save(this.sessionMap);
+    }
   }
 
   private setPendingInteraction(conversationKey: string, interaction: PendingInteraction): void {
@@ -1018,10 +1129,15 @@ export class BridgeApp {
   }
 }
 
-function buildPromptRequest(text: string): { parts: Array<{ type: "text"; text: string }> } {
-  return {
-    parts: [{ type: "text", text }],
-  };
+export function buildPromptRequest(text: string, system?: string): { system?: string; parts: Array<{ type: "text"; text: string }> } {
+  return system
+    ? {
+      system,
+      parts: [{ type: "text", text }],
+    }
+    : {
+      parts: [{ type: "text", text }],
+    };
 }
 
 export function toOpencodePromptText(message: Pick<IncomingChatMessage, "chatType" | "senderOpenId" | "plainText">): string {
@@ -1077,15 +1193,63 @@ function formatProviders(providers: OpenCodeProvidersResponse): string {
 
 function formatSessionList(options: PendingSessionSelectionInteraction["options"]): string {
   return [
-    "最近会话：",
-    ...options.map((option) => `${option.index}. ${escapeMarkdownText(option.title)}\n   \`${option.sessionId}\``),
+    "当前窗口会话：",
+    ...options.map((option) => `${option.index}. ${escapeMarkdownText(option.title)}${option.current ? " ← 当前" : ""}\n   \`${option.sessionId}\``),
     "",
-    "30 秒内可用 `/sessions <编号>` 切换。",
+    "30 秒内可用 `/switch <编号>` 或 `/sessions <编号>` 切换。",
   ].join("\n");
 }
 
-function getSessionUpdatedAt(session: OpenCodeSession): number {
-  return session.time?.updated ?? session.time?.created ?? 0;
+function formatSingleSessionStatus(mode: SessionMode, session: SessionBindingRecord): string {
+  return [
+    `当前窗口为${mode}会话模式。`,
+    `当前会话：${escapeMarkdownText(session.label)}`,
+    `Session ID：\`${session.sessionId}\``,
+  ].join("\n");
+}
+
+export function buildBridgeSystemPrompt(
+  turn: Pick<BridgeTurn, "chatType" | "conversationKey" | "senderOpenId" | "sessionId">,
+  window: SessionWindowRecord,
+): string {
+  const visibleSessions = getVisibleSessions(window);
+  const lines = [
+    "[Bridge State]",
+    `windowType: ${turn.chatType ?? "p2p"}`,
+    `conversationKey: ${turn.conversationKey}`,
+    `sessionMode: ${window.mode}`,
+    `activeSessionId: ${window.activeSessionId ?? "none"}`,
+    "visibleSessions:",
+    ...(visibleSessions.length > 0
+      ? visibleSessions.map((session) => `- ${session.sessionId === turn.sessionId ? "*" : " "} ${session.label} (${session.sessionId})`)
+      : ["- none"]),
+    `senderOpenId: ${turn.senderOpenId}`,
+    "rules:",
+    "- Bridge owns /new /sessions /switch /status and all runtime progress or reply messages.",
+    "- Do not pretend to switch, create, close, or rename bridge sessions yourself.",
+    "- Use lark-cli only when the user explicitly asks to operate on Feishu or Lark resources.",
+  ];
+  return lines.join("\n");
+}
+
+export function resolveDisplayLabel(session: OpenCodeSession | undefined, currentLabel: string, sessionId: string): string {
+  if (!shouldHydrateLabelFromSessionMeta(currentLabel, sessionId)) {
+    return currentLabel;
+  }
+
+  return session?.title?.trim() || session?.slug?.trim() || currentLabel || sessionId;
+}
+
+function shouldHydrateLabelFromSessionMeta(currentLabel: string, sessionId: string): boolean {
+  return currentLabel === sessionId;
+}
+
+function summarizeSessionLabel(plainText: string): string {
+  const normalized = plainText.trim().replace(/\s+/g, " ");
+  if (!normalized) {
+    return "";
+  }
+  return normalized.slice(0, 20);
 }
 
 function extractAssistantText(message: OpenCodeMessage | null): string {

--- a/src/runtime/session-windows.ts
+++ b/src/runtime/session-windows.ts
@@ -1,0 +1,154 @@
+import type { SessionBindingRecord, SessionMode, SessionWindowRecord } from "../store/mappings.js";
+
+export type SessionModeConfig = {
+  p2p: SessionMode;
+  group: SessionMode;
+  topicGroup: SessionMode;
+};
+
+export function resolveSessionMode(chatType: string | undefined, config: SessionModeConfig): SessionMode {
+  if (chatType === "group") {
+    return config.group;
+  }
+  if (chatType === "topic_group") {
+    return config.topicGroup;
+  }
+  return config.p2p;
+}
+
+export function normalizeSessionWindowRecord(
+  record: SessionWindowRecord | undefined,
+  mode: SessionMode,
+  maxSessions: number,
+): SessionWindowRecord {
+  const sessions = sortSessionsByLastUsed(record?.sessions ?? []);
+  if (mode === "single") {
+    const active = findSessionById(sessions, record?.activeSessionId) ?? sessions[0] ?? null;
+    return {
+      mode,
+      activeSessionId: active?.sessionId ?? null,
+      sessions: active ? [active] : [],
+    };
+  }
+
+  const uniqueSessions = dedupeSessions(sessions).slice(0, Math.max(1, maxSessions));
+  const active = findSessionById(uniqueSessions, record?.activeSessionId) ?? uniqueSessions[0] ?? null;
+  return {
+    mode,
+    activeSessionId: active?.sessionId ?? null,
+    sessions: uniqueSessions,
+  };
+}
+
+export function createSessionEntry(sessionId: string, now: number, label = "新会话"): SessionBindingRecord {
+  return {
+    sessionId,
+    label,
+    createdAt: now,
+    lastUsedAt: now,
+  };
+}
+
+export function getActiveSession(window: SessionWindowRecord): SessionBindingRecord | null {
+  return findSessionById(window.sessions, window.activeSessionId) ?? null;
+}
+
+export function setActiveSession(
+  window: SessionWindowRecord,
+  sessionId: string,
+  now: number,
+  maxSessions: number,
+): SessionWindowRecord {
+  const updatedSessions = window.sessions.map((session) => {
+    if (session.sessionId !== sessionId) {
+      return session;
+    }
+    return { ...session, lastUsedAt: now };
+  });
+
+  return normalizeSessionWindowRecord({
+    mode: window.mode,
+    activeSessionId: sessionId,
+    sessions: updatedSessions,
+  }, window.mode, maxSessions);
+}
+
+export function addSession(
+  window: SessionWindowRecord,
+  session: SessionBindingRecord,
+  maxSessions: number,
+): SessionWindowRecord {
+  return normalizeSessionWindowRecord({
+    mode: window.mode,
+    activeSessionId: session.sessionId,
+    sessions: [session, ...window.sessions.filter((item) => item.sessionId !== session.sessionId)],
+  }, window.mode, maxSessions);
+}
+
+export function removeSession(
+  window: SessionWindowRecord,
+  sessionId: string,
+  maxSessions: number,
+): SessionWindowRecord {
+  const remaining = window.sessions.filter((session) => session.sessionId !== sessionId);
+  const nextActive = window.activeSessionId === sessionId
+    ? remaining[0]?.sessionId ?? null
+    : window.activeSessionId;
+  return normalizeSessionWindowRecord({
+    mode: window.mode,
+    activeSessionId: nextActive,
+    sessions: remaining,
+  }, window.mode, maxSessions);
+}
+
+export function updateSessionLabel(
+  window: SessionWindowRecord,
+  sessionId: string,
+  label: string,
+  maxSessions: number,
+): SessionWindowRecord {
+  const normalizedLabel = label.trim();
+  if (!normalizedLabel) {
+    return window;
+  }
+
+  return normalizeSessionWindowRecord({
+    mode: window.mode,
+    activeSessionId: window.activeSessionId,
+    sessions: window.sessions.map((session) => (
+      session.sessionId === sessionId
+        ? { ...session, label: normalizedLabel }
+        : session
+    )),
+  }, window.mode, maxSessions);
+}
+
+export function getVisibleSessions(window: SessionWindowRecord): SessionBindingRecord[] {
+  return sortSessionsByLastUsed(window.sessions);
+}
+
+export function hasSession(window: SessionWindowRecord, sessionId: string): boolean {
+  return window.sessions.some((session) => session.sessionId === sessionId);
+}
+
+function dedupeSessions(sessions: SessionBindingRecord[]): SessionBindingRecord[] {
+  const seenSessionIds = new Set<string>();
+  return sessions.filter((session) => {
+    if (seenSessionIds.has(session.sessionId)) {
+      return false;
+    }
+    seenSessionIds.add(session.sessionId);
+    return true;
+  });
+}
+
+function sortSessionsByLastUsed(sessions: SessionBindingRecord[]): SessionBindingRecord[] {
+  return [...sessions].sort((a, b) => b.lastUsedAt - a.lastUsedAt);
+}
+
+function findSessionById(sessions: SessionBindingRecord[], sessionId: string | null | undefined): SessionBindingRecord | null {
+  if (!sessionId) {
+    return null;
+  }
+  return sessions.find((session) => session.sessionId === sessionId) ?? null;
+}

--- a/src/store/mappings.ts
+++ b/src/store/mappings.ts
@@ -1,22 +1,32 @@
 import { JsonStore } from "./json-store.js";
 
+export type SessionMode = "single" | "multi";
+
 export type SessionBindingRecord = {
   sessionId: string;
+  label: string;
+  createdAt: number;
   lastUsedAt: number;
 };
 
-export type MappingRecord = Record<string, SessionBindingRecord>;
+export type SessionWindowRecord = {
+  mode: SessionMode;
+  activeSessionId: string | null;
+  sessions: SessionBindingRecord[];
+};
+
+export type MappingRecord = Record<string, SessionWindowRecord>;
 
 type LoggerLike = {
   log: (scope: string, message: string, fields?: Record<string, unknown>, level?: "debug" | "info" | "warn" | "error") => void;
 };
 
 type MappingFile = {
-  version: 2;
+  version: 3;
   mappings: MappingRecord;
 };
 
-const MAPPING_STORE_VERSION = 2 as const;
+const MAPPING_STORE_VERSION = 3 as const;
 
 export class MappingStore extends JsonStore<unknown> {
   constructor(
@@ -34,9 +44,18 @@ export class MappingStore extends JsonStore<unknown> {
       return trimMappings(normalizeMappings(loaded.mappings), this.maxEntries);
     }
 
+    if (isVersion2MappingFile(loaded)) {
+      const migrated = trimMappings(migrateVersion2Mappings(loaded.mappings), this.maxEntries);
+      this.logger?.log("store/mappings", "mapping store 格式升级，已迁移", { fromVersion: 2 }, "warn");
+      await super.save({ version: MAPPING_STORE_VERSION, mappings: migrated } satisfies MappingFile);
+      return migrated;
+    }
+
     if (isLegacyMappingFile(loaded)) {
-      this.logger?.log("store/mappings", "mapping store 格式升级，已重置", {}, "warn");
-      await super.save({ version: MAPPING_STORE_VERSION, mappings: {} } satisfies MappingFile);
+      const migrated = trimMappings(migrateLegacyMappings(loaded), this.maxEntries);
+      this.logger?.log("store/mappings", "mapping store 格式升级，已迁移", { fromVersion: "legacy" }, "warn");
+      await super.save({ version: MAPPING_STORE_VERSION, mappings: migrated } satisfies MappingFile);
+      return migrated;
     }
 
     return {};
@@ -54,7 +73,11 @@ function isMappingFile(value: unknown): value is MappingFile {
   return isRecord(value) && value.version === MAPPING_STORE_VERSION && isRecord(value.mappings);
 }
 
-function isLegacyMappingFile(value: unknown): boolean {
+function isVersion2MappingFile(value: unknown): value is { version: 2; mappings: Record<string, unknown> } {
+  return isRecord(value) && value.version === 2 && isRecord(value.mappings);
+}
+
+function isLegacyMappingFile(value: unknown): value is Record<string, unknown> {
   if (!isRecord(value)) {
     return false;
   }
@@ -71,33 +94,153 @@ function normalizeMappings(value: unknown): MappingRecord {
     return {};
   }
 
-  const now = Date.now();
   const normalizedEntries = Object.entries(value)
     .map(([conversationKey, raw]) => {
+      const normalized = normalizeWindowRecord(raw);
+      if (!normalized) {
+        return null;
+      }
+      return [conversationKey, normalized] as const;
+    })
+    .filter((entry): entry is readonly [string, SessionWindowRecord] => entry !== null);
+
+  return Object.fromEntries(normalizedEntries);
+}
+
+function trimMappings(value: MappingRecord, maxEntries: number): MappingRecord {
+  const sorted = Object.entries(value).sort((a, b) => getWindowLastUsedAt(b[1]) - getWindowLastUsedAt(a[1]));
+  return Object.fromEntries(sorted.slice(0, maxEntries));
+}
+
+function migrateVersion2Mappings(value: Record<string, unknown>): MappingRecord {
+  const now = Date.now();
+  const migratedEntries = Object.entries(value)
+    .map(([conversationKey, raw]) => {
       if (typeof raw === "string") {
-        return [conversationKey, { sessionId: raw, lastUsedAt: now }] as const;
+        return [conversationKey, createSingleWindow(raw, now, raw)] as const;
       }
 
       if (!isRecord(raw) || typeof raw.sessionId !== "string") {
         return null;
       }
 
-      return [
-        conversationKey,
-        {
-          sessionId: raw.sessionId,
-          lastUsedAt: typeof raw.lastUsedAt === "number" ? raw.lastUsedAt : now,
-        },
-      ] as const;
+      const lastUsedAt = typeof raw.lastUsedAt === "number" ? raw.lastUsedAt : now;
+      return [conversationKey, createSingleWindow(raw.sessionId, lastUsedAt, raw.sessionId)] as const;
     })
-    .filter((entry): entry is readonly [string, SessionBindingRecord] => entry !== null);
+    .filter((entry): entry is readonly [string, SessionWindowRecord] => entry !== null);
 
-  return Object.fromEntries(normalizedEntries);
+  return Object.fromEntries(migratedEntries);
 }
 
-function trimMappings(value: MappingRecord, maxEntries: number): MappingRecord {
-  const sorted = Object.entries(value).sort((a, b) => b[1].lastUsedAt - a[1].lastUsedAt);
-  return Object.fromEntries(sorted.slice(0, maxEntries));
+function migrateLegacyMappings(value: Record<string, unknown>): MappingRecord {
+  const now = Date.now();
+  const migratedEntries = Object.entries(value)
+    .map(([conversationKey, raw]) => {
+      if (typeof raw === "string") {
+        return [conversationKey, createSingleWindow(raw, now, raw)] as const;
+      }
+      if (!isRecord(raw) || typeof raw.sessionId !== "string") {
+        return null;
+      }
+      const lastUsedAt = typeof raw.lastUsedAt === "number" ? raw.lastUsedAt : now;
+      return [conversationKey, createSingleWindow(raw.sessionId, lastUsedAt, raw.sessionId)] as const;
+    })
+    .filter((entry): entry is readonly [string, SessionWindowRecord] => entry !== null);
+
+  return Object.fromEntries(migratedEntries);
+}
+
+function normalizeWindowRecord(value: unknown): SessionWindowRecord | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const mode = value.mode === "multi" ? "multi" : value.mode === "single" ? "single" : null;
+  const rawSessions = Array.isArray(value.sessions) ? value.sessions : null;
+  if (!mode || !rawSessions) {
+    return null;
+  }
+
+  const now = Date.now();
+  const seenSessionIds = new Set<string>();
+  const sessions = rawSessions
+    .map((raw) => normalizeSessionBindingRecord(raw, now))
+    .filter((entry): entry is SessionBindingRecord => entry !== null)
+    .filter((entry) => {
+      if (seenSessionIds.has(entry.sessionId)) {
+        return false;
+      }
+      seenSessionIds.add(entry.sessionId);
+      return true;
+    });
+
+  if (sessions.length === 0) {
+    return {
+      mode,
+      activeSessionId: null,
+      sessions: [],
+    };
+  }
+
+  const activeSessionId = typeof value.activeSessionId === "string" && sessions.some((entry) => entry.sessionId === value.activeSessionId)
+    ? value.activeSessionId
+    : pickMostRecentSession(sessions)?.sessionId ?? null;
+
+  return mode === "single"
+    ? {
+      mode,
+      activeSessionId,
+      sessions: [findSessionById(sessions, activeSessionId) ?? pickMostRecentSession(sessions)!],
+    }
+    : {
+      mode,
+      activeSessionId,
+      sessions: sessions.sort((a, b) => b.lastUsedAt - a.lastUsedAt),
+    };
+}
+
+function normalizeSessionBindingRecord(value: unknown, now: number): SessionBindingRecord | null {
+  if (!isRecord(value) || typeof value.sessionId !== "string") {
+    return null;
+  }
+
+  const lastUsedAt = typeof value.lastUsedAt === "number" ? value.lastUsedAt : now;
+  const createdAt = typeof value.createdAt === "number" ? value.createdAt : lastUsedAt;
+  const label = typeof value.label === "string" && value.label.trim().length > 0 ? value.label.trim() : value.sessionId;
+  return {
+    sessionId: value.sessionId,
+    label,
+    createdAt,
+    lastUsedAt,
+  };
+}
+
+function createSingleWindow(sessionId: string, now: number, label: string): SessionWindowRecord {
+  return {
+    mode: "single",
+    activeSessionId: sessionId,
+    sessions: [{
+      sessionId,
+      label,
+      createdAt: now,
+      lastUsedAt: now,
+    }],
+  };
+}
+
+function getWindowLastUsedAt(window: SessionWindowRecord): number {
+  return window.sessions.reduce((max, session) => Math.max(max, session.lastUsedAt), 0);
+}
+
+function pickMostRecentSession(sessions: SessionBindingRecord[]): SessionBindingRecord | null {
+  return [...sessions].sort((a, b) => b.lastUsedAt - a.lastUsedAt)[0] ?? null;
+}
+
+function findSessionById(sessions: SessionBindingRecord[], sessionId: string | null): SessionBindingRecord | null {
+  if (!sessionId) {
+    return null;
+  }
+  return sessions.find((session) => session.sessionId === sessionId) ?? null;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/test/app-helpers.test.ts
+++ b/test/app-helpers.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { buildBridgeSystemPrompt, buildPromptRequest, resolveDisplayLabel } from "../src/runtime/app.js";
+
+describe("runtime prompt helpers", () => {
+  it("adds system state when provided", () => {
+    expect(buildPromptRequest("hello", "state")).toEqual({
+      system: "state",
+      parts: [{ type: "text", text: "hello" }],
+    });
+  });
+
+  it("builds bridge system state from the current window", () => {
+    const prompt = buildBridgeSystemPrompt({
+      chatType: "group",
+      conversationKey: "oc_group_1:om_1",
+      senderOpenId: "ou_123",
+      sessionId: "ses_2",
+    }, {
+      mode: "multi",
+      activeSessionId: "ses_2",
+      sessions: [
+        { sessionId: "ses_2", label: "当前会话", createdAt: 2, lastUsedAt: 2 },
+        { sessionId: "ses_1", label: "旧会话", createdAt: 1, lastUsedAt: 1 },
+      ],
+    });
+
+    expect(prompt).toContain("windowType: group");
+    expect(prompt).toContain("sessionMode: multi");
+    expect(prompt).toContain("activeSessionId: ses_2");
+    expect(prompt).toContain("* 当前会话 (ses_2)");
+    expect(prompt).toContain("Bridge owns /new /sessions /switch /status");
+  });
+
+  it("keeps local labels until they are still raw session ids", () => {
+    expect(resolveDisplayLabel({
+      id: "ses_1",
+      title: "Feishu chat title",
+    }, "新会话", "ses_1")).toBe("新会话");
+
+    expect(resolveDisplayLabel({
+      id: "ses_1",
+      title: "Feishu chat title",
+    }, "自定义标签", "ses_1")).toBe("自定义标签");
+
+    expect(resolveDisplayLabel({
+      id: "ses_1",
+      title: "Feishu chat title",
+    }, "ses_1", "ses_1")).toBe("Feishu chat title");
+  });
+});

--- a/test/mappings.test.ts
+++ b/test/mappings.test.ts
@@ -7,18 +7,29 @@ import { describe, expect, it, vi } from "vitest";
 import { MappingStore } from "../src/store/mappings.js";
 
 describe("MappingStore", () => {
-  it("resets legacy mapping files and logs the upgrade", async () => {
+  it("migrates legacy mapping files and logs the upgrade", async () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-mappings-"));
     await writeFile(path.join(dir, "mappings.json"), JSON.stringify({ chat: "ses_1" }), "utf8");
     const logger = { log: vi.fn() };
     const store = new MappingStore(dir, "mappings.json", 2, logger);
 
     const mappings = await store.load();
-    const raw = JSON.parse(await readFile(path.join(dir, "mappings.json"), "utf8")) as { version: number; mappings: Record<string, unknown> };
+    const raw = JSON.parse(await readFile(path.join(dir, "mappings.json"), "utf8")) as {
+      version: number;
+      mappings: Record<string, {
+        mode: string;
+        activeSessionId: string | null;
+        sessions: Array<{ sessionId: string; label: string }>;
+      }>;
+    };
 
-    expect(mappings).toEqual({});
-    expect(raw).toEqual({ version: 2, mappings: {} });
-    expect(logger.log).toHaveBeenCalledWith("store/mappings", "mapping store 格式升级，已重置", {}, "warn");
+    expect(mappings.chat?.mode).toBe("single");
+    expect(mappings.chat?.activeSessionId).toBe("ses_1");
+    expect(mappings.chat?.sessions).toHaveLength(1);
+    expect(mappings.chat?.sessions[0]?.label).toBe("ses_1");
+    expect(raw.version).toBe(3);
+    expect(raw.mappings.chat?.sessions[0]?.sessionId).toBe("ses_1");
+    expect(logger.log).toHaveBeenCalledWith("store/mappings", "mapping store 格式升级，已迁移", { fromVersion: "legacy" }, "warn");
   });
 
   it("trims to the configured LRU size on save", async () => {
@@ -26,16 +37,20 @@ describe("MappingStore", () => {
     const store = new MappingStore(dir, "mappings.json", 2);
 
     await store.save({
-      a: { sessionId: "ses_a", lastUsedAt: 1 },
-      b: { sessionId: "ses_b", lastUsedAt: 3 },
-      c: { sessionId: "ses_c", lastUsedAt: 2 },
+      a: { mode: "single", activeSessionId: "ses_a", sessions: [{ sessionId: "ses_a", label: "A", createdAt: 1, lastUsedAt: 1 }] },
+      b: { mode: "single", activeSessionId: "ses_b", sessions: [{ sessionId: "ses_b", label: "B", createdAt: 3, lastUsedAt: 3 }] },
+      c: { mode: "single", activeSessionId: "ses_c", sessions: [{ sessionId: "ses_c", label: "C", createdAt: 2, lastUsedAt: 2 }] },
     });
 
     const raw = JSON.parse(await readFile(path.join(dir, "mappings.json"), "utf8")) as {
       version: number;
-      mappings: Record<string, { sessionId: string; lastUsedAt: number }>;
+      mappings: Record<string, {
+        mode: string;
+        activeSessionId: string | null;
+        sessions: Array<{ sessionId: string; lastUsedAt: number }>;
+      }>;
     };
-    expect(raw.version).toBe(2);
+    expect(raw.version).toBe(3);
     expect(Object.keys(raw.mappings)).toEqual(["b", "c"]);
   });
 });

--- a/test/queue.test.ts
+++ b/test/queue.test.ts
@@ -13,6 +13,7 @@ function makeTurn(overrides: Partial<BridgeTurn> = {}): BridgeTurn {
     threadKey: "thread",
     senderOpenId: "u",
     inboundMessageId: "m",
+    plainText: "hi",
     text: "hi",
     ...overrides,
   };

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -14,6 +14,13 @@ describe("routeIncomingText", () => {
     });
   });
 
+  it("routes /switch <index> to session selection", () => {
+    expect(routeIncomingText("/switch 2")).toEqual({
+      kind: "command",
+      command: { kind: "sessions-select", index: 2 },
+    });
+  });
+
   it("routes permission commands", () => {
     expect(routeIncomingText("/allow once")).toEqual({
       kind: "command",

--- a/test/session-windows.test.ts
+++ b/test/session-windows.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import type { SessionWindowRecord } from "../src/store/mappings.js";
+import {
+  addSession,
+  createSessionEntry,
+  getActiveSession,
+  normalizeSessionWindowRecord,
+  removeSession,
+  resolveSessionMode,
+  setActiveSession,
+} from "../src/runtime/session-windows.js";
+
+describe("session windows", () => {
+  it("resolves chat types into configured modes", () => {
+    expect(resolveSessionMode("p2p", { p2p: "multi", group: "single", topicGroup: "single" })).toBe("multi");
+    expect(resolveSessionMode("group", { p2p: "multi", group: "single", topicGroup: "multi" })).toBe("single");
+    expect(resolveSessionMode("topic_group", { p2p: "single", group: "single", topicGroup: "multi" })).toBe("multi");
+  });
+
+  it("keeps only one active session in single mode", () => {
+    const record: SessionWindowRecord = {
+      mode: "single",
+      activeSessionId: "ses_old",
+      sessions: [
+        { sessionId: "ses_old", label: "old", createdAt: 1, lastUsedAt: 1 },
+        { sessionId: "ses_new", label: "new", createdAt: 2, lastUsedAt: 2 },
+      ],
+    };
+
+    const normalized = normalizeSessionWindowRecord(record, "single", 20);
+    expect(normalized.sessions).toHaveLength(1);
+    expect(normalized.activeSessionId).toBe("ses_old");
+  });
+
+  it("adds and switches sessions in multi mode", () => {
+    const now = 100;
+    let record = normalizeSessionWindowRecord(undefined, "multi", 3);
+    record = addSession(record, createSessionEntry("ses_1", now, "one"), 3);
+    record = addSession(record, createSessionEntry("ses_2", now + 1, "two"), 3);
+    record = setActiveSession(record, "ses_1", now + 2, 3);
+
+    expect(getActiveSession(record)?.sessionId).toBe("ses_1");
+    expect(record.sessions).toHaveLength(2);
+  });
+
+  it("trims multi-session windows by LRU", () => {
+    let record = normalizeSessionWindowRecord(undefined, "multi", 2);
+    record = addSession(record, createSessionEntry("ses_1", 1, "one"), 2);
+    record = addSession(record, createSessionEntry("ses_2", 2, "two"), 2);
+    record = addSession(record, createSessionEntry("ses_3", 3, "three"), 2);
+
+    expect(record.sessions.map((session) => session.sessionId)).toEqual(["ses_3", "ses_2"]);
+  });
+
+  it("removes stale sessions and promotes the next active item", () => {
+    const record = removeSession({
+      mode: "multi",
+      activeSessionId: "ses_2",
+      sessions: [
+        { sessionId: "ses_2", label: "two", createdAt: 2, lastUsedAt: 2 },
+        { sessionId: "ses_1", label: "one", createdAt: 1, lastUsedAt: 1 },
+      ],
+    }, "ses_2", 5);
+
+    expect(record.activeSessionId).toBe("ses_1");
+    expect(record.sessions).toHaveLength(1);
+  });
+});

--- a/test/state-machine.test.ts
+++ b/test/state-machine.test.ts
@@ -11,6 +11,7 @@ function makeTurn(overrides: Partial<BridgeTurn> = {}): BridgeTurn {
     threadKey: "thread",
     senderOpenId: "u",
     inboundMessageId: "m",
+    plainText: "hi",
     text: "hi",
     ...overrides,
   };


### PR DESCRIPTION
## 变更内容
- 新增按窗口维护的 session registry，并支持为 `p2p`、`group`、`topic_group` 分别配置 `single` / `multi` 会话模式
- 在运行时接入窗口级 active session 管理，补充 `/switch <编号>`、增强 `/sessions` 与 `/status` 的会话信息展示
- 为 OpenCode 请求注入 bridge 维护的窗口与会话状态，并在会话切换、失效清理、标签同步时保持映射一致
- 升级 mapping store 持久化结构，兼容迁移旧版本单 session 映射，并补充相关测试覆盖
- 更新中英文文档、示例配置与运行规则说明，补充新的 session 模式配置项

## 变更原因
原来的 bridge 主要按单对话绑定单个 OpenCode session，无法很好支持同一窗口下的多会话切换，也缺少对不同聊天类型采用不同 session 策略的配置能力。

## 影响
bridge 现在可以按聊天窗口维护更灵活的 session 生命周期，在私聊中保留多会话切换能力，同时让群聊继续保持更稳妥的单会话模式；相关配置、状态展示和持久化行为也更完整一致。

## 验证
- `npm test`
- `npm run typecheck`
- `npm run lint`
