### PR TITLE
[codex] 新增长期用户记忆召回能力

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - Do not simulate session creation, switching, closing, or renaming inside the agent response.
 - Use `lark-cli` only when the user explicitly asks to operate on Feishu or Lark resources.
 - Treat bridge-injected system state as authoritative for the current window, active session, and visible sessions.
-- Long-term user facts may be injected through a `[Memory Recall]` block in `system`; treat it as user memory, not current window state.
+- Long-term user facts may be injected into `system` as a `[Memory Recall]` block; treat them as stable background context, not current window state.
 - For GitHub pull requests, use Chinese titles and descriptions by default.
 - Preferred PR title format: `[codex] <动词><变更主题>`.
 - Preferred PR body sections: `变更内容`, `变更原因`, `影响`, `验证`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,5 @@
 - For GitHub pull requests, use Chinese titles and descriptions by default.
 - Preferred PR title format: `[codex] <动词><变更主题>`.
 - Preferred PR body sections: `变更内容`, `变更原因`, `影响`, `验证`.
+- Keep updating the same branch and PR while the related feature line is still open and unmerged.
+- Once a PR has been merged into `main`, do not reopen or reuse it for follow-up work; create a new branch and a new PR instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - Do not simulate session creation, switching, closing, or renaming inside the agent response.
 - Use `lark-cli` only when the user explicitly asks to operate on Feishu or Lark resources.
 - Treat bridge-injected system state as authoritative for the current window, active session, and visible sessions.
+- Long-term user facts may be injected through a `[Memory Recall]` block in `system`; treat it as user memory, not current window state.
 - For GitHub pull requests, use Chinese titles and descriptions by default.
 - Preferred PR title format: `[codex] <动词><变更主题>`.
 - Preferred PR body sections: `变更内容`, `变更原因`, `影响`, `验证`.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It listens to Feishu message events over WebSocket, maps each conversation to an
 - Uses per-window session registries with configurable `single` or `multi` mode
 - Uses thread-aware isolation for group chats
 - Supports OpenCode `prompt_async`, command routing, abort, status, models, permissions, and session switching
-- Supports optional long-term user memory recall keyed by `senderOpenId`
+- Supports optional long-term memory recall, embedding-based retrieval, and Obsidian profile sync
 - Streams progress into a Feishu interactive card and updates the same message in place
 - Supports strict or relaxed group mention matching through config
 - Supports multiple bot identities and separate self-bot identities
@@ -114,7 +114,20 @@ Copy the example config and fill in your real values:
     "searchLimit": 5,
     "extractQueueLimit": 100,
     "sourcePreviewLength": 50,
-    "shutdownDrainTimeoutMs": 5000
+    "shutdownDrainTimeoutMs": 5000,
+    "retriever": "recent",
+    "embeddingSimilarityThreshold": 0.75,
+    "embeddingProvider": {
+      "baseUrl": "https://api.openai.com/v1/",
+      "apiKey": "sk-xxx",
+      "model": "text-embedding-3-small"
+    },
+    "obsidian": {
+      "enabled": false,
+      "vaultPath": "/absolute/path/to/vault",
+      "syncCron": "0 2 * * *",
+      "enableWikiLinks": false
+    }
   },
   "logging": {
     "dir": "./logs",
@@ -155,10 +168,10 @@ When `strictBotMention=true`, the bridge only accepts messages that explicitly m
 
 ### Memory
 
-- `memory.enabled=true` turns on long-term fact memory keyed by `senderOpenId`.
-- Recall is injected into OpenCode through a separate `[Memory Recall]` system block.
-- Learn runs asynchronously after a successful turn and does not block or fail the main reply path.
-- The SQLite database path is controlled by `memory.dbPath`.
+- `memory.enabled=true` turns on long-term user memory keyed by `senderOpenId`.
+- `retriever="recent"` always recalls the user's most recently accessed facts.
+- `retriever="embedding"` uses the configured OpenAI-compatible embeddings API and falls back to recent recall when no vector match is found.
+- `obsidian.enabled=true` writes `${vaultPath}/memory/<userId>/profile.md` on the configured cron schedule and also runs a startup catch-up sync when needed.
 
 ## OpenCode auth
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It listens to Feishu message events over WebSocket, maps each conversation to an
 - Uses per-window session registries with configurable `single` or `multi` mode
 - Uses thread-aware isolation for group chats
 - Supports OpenCode `prompt_async`, command routing, abort, status, models, permissions, and session switching
+- Supports optional long-term user memory recall keyed by `senderOpenId`
 - Streams progress into a Feishu interactive card and updates the same message in place
 - Supports strict or relaxed group mention matching through config
 - Supports multiple bot identities and separate self-bot identities
@@ -106,6 +107,15 @@ Copy the example config and fill in your real values:
       "totalTurn": 300000
     }
   },
+  "memory": {
+    "enabled": false,
+    "dbPath": "./data/memory.db",
+    "maxMemoriesPerUser": 500,
+    "searchLimit": 5,
+    "extractQueueLimit": 100,
+    "sourcePreviewLength": 50,
+    "shutdownDrainTimeoutMs": 5000
+  },
   "logging": {
     "dir": "./logs",
     "level": "info",
@@ -142,6 +152,13 @@ When `strictBotMention=true`, the bridge only accepts messages that explicitly m
 - `single` keeps exactly one active session in the window. `/new` replaces it. `/switch` and `/sessions <index>` are rejected.
 - `multi` keeps multiple sessions per window, shows them through `/sessions`, and allows switching with `/switch <index>` or `/sessions <index>`.
 - `injectSystemState=true` adds bridge-owned window and session state into the OpenCode `system` field without polluting the user message text.
+
+### Memory
+
+- `memory.enabled=true` turns on long-term fact memory keyed by `senderOpenId`.
+- Recall is injected into OpenCode through a separate `[Memory Recall]` system block.
+- Learn runs asynchronously after a successful turn and does not block or fail the main reply path.
+- The SQLite database path is controlled by `memory.dbPath`.
 
 ## OpenCode auth
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,6 +10,7 @@ Feishu OpenCode Bridge 是一个独立运行的 TypeScript 服务，用来把飞
 - 按窗口维护 OpenCode session registry，并支持 `single` / `multi` 两种会话模式
 - 群聊按线程隔离上下文
 - 支持 OpenCode `prompt_async`、命令转发、中止、状态、模型、权限请求、session 切换
+- 支持可选的长期用户记忆召回，按 `senderOpenId` 归档
 - 使用飞书交互卡片承载过程消息，并持续更新同一条回复
 - 群聊 `@` 规则支持通过配置控制严格或宽松模式
 - 支持多个机器人身份，以及“触发身份”和“自身身份”分离
@@ -106,6 +107,15 @@ npm install
       "totalTurn": 300000
     }
   },
+  "memory": {
+    "enabled": false,
+    "dbPath": "./data/memory.db",
+    "maxMemoriesPerUser": 500,
+    "searchLimit": 5,
+    "extractQueueLimit": 100,
+    "sourcePreviewLength": 50,
+    "shutdownDrainTimeoutMs": 5000
+  },
   "logging": {
     "dir": "./logs",
     "level": "info",
@@ -142,6 +152,13 @@ npm install
 - `single` 模式下，窗口内始终只有 1 个 active session。`/new` 会替换它，`/switch` 和 `/sessions <编号>` 会被拒绝。
 - `multi` 模式下，窗口内可保留多个 session，可通过 `/sessions` 查看，并用 `/switch <编号>` 或 `/sessions <编号>` 切换。
 - `injectSystemState=true` 会把 bridge 的窗口和会话状态写进 OpenCode 的 `system` 字段，不污染用户正文。
+
+### 记忆模块
+
+- `memory.enabled=true` 后，会按 `senderOpenId` 维护长期事实记忆。
+- recall 会以独立的 `[Memory Recall]` system 块注入到 OpenCode。
+- learn 在 turn 成功完成后异步执行，不阻塞也不影响主回复链路。
+- SQLite 存储路径由 `memory.dbPath` 控制。
 
 ## OpenCode 鉴权
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@ Feishu OpenCode Bridge 是一个独立运行的 TypeScript 服务，用来把飞
 - 按窗口维护 OpenCode session registry，并支持 `single` / `multi` 两种会话模式
 - 群聊按线程隔离上下文
 - 支持 OpenCode `prompt_async`、命令转发、中止、状态、模型、权限请求、session 切换
-- 支持可选的长期用户记忆召回，按 `senderOpenId` 归档
+- 支持可选的长期记忆召回、embedding 检索，以及 Obsidian 用户画像同步
 - 使用飞书交互卡片承载过程消息，并持续更新同一条回复
 - 群聊 `@` 规则支持通过配置控制严格或宽松模式
 - 支持多个机器人身份，以及“触发身份”和“自身身份”分离
@@ -114,7 +114,20 @@ npm install
     "searchLimit": 5,
     "extractQueueLimit": 100,
     "sourcePreviewLength": 50,
-    "shutdownDrainTimeoutMs": 5000
+    "shutdownDrainTimeoutMs": 5000,
+    "retriever": "recent",
+    "embeddingSimilarityThreshold": 0.75,
+    "embeddingProvider": {
+      "baseUrl": "https://api.openai.com/v1/",
+      "apiKey": "sk-xxx",
+      "model": "text-embedding-3-small"
+    },
+    "obsidian": {
+      "enabled": false,
+      "vaultPath": "/absolute/path/to/vault",
+      "syncCron": "0 2 * * *",
+      "enableWikiLinks": false
+    }
   },
   "logging": {
     "dir": "./logs",
@@ -155,10 +168,10 @@ npm install
 
 ### 记忆模块
 
-- `memory.enabled=true` 后，会按 `senderOpenId` 维护长期事实记忆。
-- recall 会以独立的 `[Memory Recall]` system 块注入到 OpenCode。
-- learn 在 turn 成功完成后异步执行，不阻塞也不影响主回复链路。
-- SQLite 存储路径由 `memory.dbPath` 控制。
+- `memory.enabled=true` 后，会按 `senderOpenId` 维度记录长期用户事实。
+- `retriever="recent"` 会优先召回最近访问的记忆，作为 recall 兜底。
+- `retriever="embedding"` 会调用 OpenAI-compatible embedding API 做相似度检索，命中为空时自动回退到 recent。
+- `obsidian.enabled=true` 时，会按 `syncCron` 定时写 `${vaultPath}/memory/<userId>/profile.md`，启动时也会做一次补偿同步。
 
 ## OpenCode 鉴权
 

--- a/config.example.json
+++ b/config.example.json
@@ -49,7 +49,20 @@
     "searchLimit": 5,
     "extractQueueLimit": 100,
     "sourcePreviewLength": 50,
-    "shutdownDrainTimeoutMs": 5000
+    "shutdownDrainTimeoutMs": 5000,
+    "retriever": "recent",
+    "embeddingSimilarityThreshold": 0.75,
+    "embeddingProvider": {
+      "baseUrl": "https://api.openai.com/v1/",
+      "apiKey": "sk-xxx",
+      "model": "text-embedding-3-small"
+    },
+    "obsidian": {
+      "enabled": false,
+      "vaultPath": "/absolute/path/to/vault",
+      "syncCron": "0 2 * * *",
+      "enableWikiLinks": false
+    }
   },
   "logging": {
     "dir": "./logs",

--- a/config.example.json
+++ b/config.example.json
@@ -42,6 +42,15 @@
       "totalTurn": 300000
     }
   },
+  "memory": {
+    "enabled": false,
+    "dbPath": "./data/memory.db",
+    "maxMemoriesPerUser": 500,
+    "searchLimit": 5,
+    "extractQueueLimit": 100,
+    "sourcePreviewLength": 50,
+    "shutdownDrainTimeoutMs": 5000
+  },
   "logging": {
     "dir": "./logs",
     "level": "info",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.1.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.42.0",
+        "better-sqlite3": "^12.8.0",
         "ws": "^8.18.0",
         "zod": "^3.24.1"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^22.13.10",
         "@types/ws": "^8.5.14",
         "@typescript-eslint/eslint-plugin": "^8.26.0",
@@ -1112,6 +1114,16 @@
         "win32"
       ]
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1621,6 +1633,60 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -1632,6 +1698,30 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/cac": {
@@ -1727,6 +1817,12 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1799,6 +1895,21 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -1807,6 +1918,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -1823,6 +1943,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/doctrine": {
@@ -1850,6 +1979,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -2161,6 +2299,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2232,6 +2379,12 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -2307,6 +2460,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -2388,6 +2547,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -2539,6 +2704,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -2592,7 +2777,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/is-extglob": {
@@ -2787,6 +2977,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -2802,6 +3004,21 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2829,12 +3046,30 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -2852,7 +3087,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -3017,6 +3251,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3056,6 +3317,16 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -3102,6 +3373,44 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3220,11 +3529,30 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3335,6 +3663,51 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3358,6 +3731,15 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
@@ -3409,6 +3791,34 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/text-table": {
@@ -3512,6 +3922,18 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3567,6 +3989,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.1",
@@ -3786,7 +4214,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.42.0",
         "better-sqlite3": "^12.8.0",
+        "node-cron": "^4.2.1",
         "ws": "^8.18.0",
         "zod": "^3.24.1"
       },
@@ -3069,6 +3070,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@larksuiteoapi/node-sdk": "^1.42.0",
     "better-sqlite3": "^12.8.0",
+    "node-cron": "^4.2.1",
     "ws": "^8.18.0",
     "zod": "^3.24.1"
   },

--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
   },
   "dependencies": {
     "@larksuiteoapi/node-sdk": "^1.42.0",
+    "better-sqlite3": "^12.8.0",
     "ws": "^8.18.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.13.10",
     "@types/ws": "^8.5.14",
     "@typescript-eslint/eslint-plugin": "^8.26.0",

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -11,7 +11,6 @@ export async function loadConfig(configPath?: string): Promise<AppConfig> {
   const baseDir = path.dirname(resolvedConfigPath);
   const dataDir = resolveRelative(baseDir, parsed.storage.dataDir);
   const loggingDir = resolveRelative(baseDir, parsed.logging.dir);
-  const memoryDbPath = resolveRelative(baseDir, parsed.memory.dbPath);
   await mkdir(dataDir, { recursive: true });
   await mkdir(loggingDir, { recursive: true });
 
@@ -57,15 +56,6 @@ export async function loadConfig(configPath?: string): Promise<AppConfig> {
       eventGapTimeoutMs: parsed.bridge.timeouts.eventInterval,
       totalTimeoutMs: parsed.bridge.timeouts.totalTurn,
     },
-    memory: {
-      enabled: parsed.memory.enabled,
-      dbPath: memoryDbPath,
-      maxMemoriesPerUser: parsed.memory.maxMemoriesPerUser,
-      searchLimit: parsed.memory.searchLimit,
-      extractQueueLimit: parsed.memory.extractQueueLimit,
-      sourcePreviewLength: parsed.memory.sourcePreviewLength,
-      shutdownDrainTimeoutMs: parsed.memory.shutdownDrainTimeoutMs,
-    },
     logging: {
       dir: loggingDir,
       level: parsed.logging.level,
@@ -73,6 +63,32 @@ export async function loadConfig(configPath?: string): Promise<AppConfig> {
       enableConsole: parsed.logging.enableConsole,
       enableColor: parsed.logging.enableColor,
       rotateDaily: parsed.logging.rotateDaily,
+    },
+    memory: {
+      enabled: parsed.memory.enabled,
+      dbPath: resolveRelative(baseDir, parsed.memory.dbPath ?? path.join(dataDir, "memory.db")),
+      maxMemoriesPerUser: parsed.memory.maxMemoriesPerUser,
+      searchLimit: parsed.memory.searchLimit,
+      extractQueueLimit: parsed.memory.extractQueueLimit,
+      sourcePreviewLength: parsed.memory.sourcePreviewLength,
+      shutdownDrainTimeoutMs: parsed.memory.shutdownDrainTimeoutMs,
+      retriever: parsed.memory.retriever,
+      embeddingProvider: parsed.memory.embeddingProvider
+        ? {
+          baseUrl: new URL(parsed.memory.embeddingProvider.baseUrl),
+          apiKey: parsed.memory.embeddingProvider.apiKey,
+          model: parsed.memory.embeddingProvider.model,
+        }
+        : undefined,
+      embeddingSimilarityThreshold: parsed.memory.embeddingSimilarityThreshold,
+      obsidian: {
+        enabled: parsed.memory.obsidian.enabled,
+        vaultPath: parsed.memory.obsidian.vaultPath
+          ? resolveRelative(baseDir, parsed.memory.obsidian.vaultPath)
+          : undefined,
+        syncCron: parsed.memory.obsidian.syncCron,
+        enableWikiLinks: parsed.memory.obsidian.enableWikiLinks,
+      },
     },
   };
 }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -11,6 +11,7 @@ export async function loadConfig(configPath?: string): Promise<AppConfig> {
   const baseDir = path.dirname(resolvedConfigPath);
   const dataDir = resolveRelative(baseDir, parsed.storage.dataDir);
   const loggingDir = resolveRelative(baseDir, parsed.logging.dir);
+  const memoryDbPath = resolveRelative(baseDir, parsed.memory.dbPath);
   await mkdir(dataDir, { recursive: true });
   await mkdir(loggingDir, { recursive: true });
 
@@ -55,6 +56,15 @@ export async function loadConfig(configPath?: string): Promise<AppConfig> {
       firstEventTimeoutMs: parsed.bridge.timeouts.firstEvent,
       eventGapTimeoutMs: parsed.bridge.timeouts.eventInterval,
       totalTimeoutMs: parsed.bridge.timeouts.totalTurn,
+    },
+    memory: {
+      enabled: parsed.memory.enabled,
+      dbPath: memoryDbPath,
+      maxMemoriesPerUser: parsed.memory.maxMemoriesPerUser,
+      searchLimit: parsed.memory.searchLimit,
+      extractQueueLimit: parsed.memory.extractQueueLimit,
+      sourcePreviewLength: parsed.memory.sourcePreviewLength,
+      shutdownDrainTimeoutMs: parsed.memory.shutdownDrainTimeoutMs,
     },
     logging: {
       dir: loggingDir,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -46,6 +46,15 @@ export const ConfigSchema = z.object({
       totalTurn: z.number().int().positive().default(300_000),
     }).default({}),
   }),
+  memory: z.object({
+    enabled: z.boolean().default(false),
+    dbPath: z.string().min(1).default("./data/memory.db"),
+    maxMemoriesPerUser: z.number().int().positive().default(500),
+    searchLimit: z.number().int().positive().default(5),
+    extractQueueLimit: z.number().int().positive().default(100),
+    sourcePreviewLength: z.number().int().positive().default(50),
+    shutdownDrainTimeoutMs: z.number().int().positive().default(5_000),
+  }).default({}),
   logging: z.object({
     dir: z.string().min(1).default("./logs"),
     level: z.enum(["debug", "info", "warn", "error"]).default("info"),
@@ -97,6 +106,15 @@ export type AppConfig = {
     firstEventTimeoutMs: number;
     eventGapTimeoutMs: number;
     totalTimeoutMs: number;
+  };
+  memory: {
+    enabled: boolean;
+    dbPath: string;
+    maxMemoriesPerUser: number;
+    searchLimit: number;
+    extractQueueLimit: number;
+    sourcePreviewLength: number;
+    shutdownDrainTimeoutMs: number;
   };
   logging: {
     dir: string;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,6 +1,47 @@
 import { z } from "zod";
 
 const SessionModeSchema = z.enum(["single", "multi"]);
+const MemoryRetrieverSchema = z.enum(["recent", "embedding"]);
+const EmbeddingProviderSchema = z.object({
+  baseUrl: z.string().url(),
+  apiKey: z.string().min(1),
+  model: z.string().min(1),
+});
+const ObsidianConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  vaultPath: z.string().min(1).optional(),
+  syncCron: z.string().min(1).default("0 2 * * *"),
+  enableWikiLinks: z.boolean().default(false),
+}).default({});
+const MemoryConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  dbPath: z.string().min(1).optional(),
+  maxMemoriesPerUser: z.number().int().positive().default(500),
+  searchLimit: z.number().int().positive().default(5),
+  extractQueueLimit: z.number().int().positive().default(100),
+  sourcePreviewLength: z.number().int().positive().default(50),
+  shutdownDrainTimeoutMs: z.number().int().positive().default(5_000),
+  retriever: MemoryRetrieverSchema.default("recent"),
+  embeddingProvider: EmbeddingProviderSchema.optional(),
+  embeddingSimilarityThreshold: z.number().positive().max(1).default(0.75),
+  obsidian: ObsidianConfigSchema,
+}).superRefine((value, context) => {
+  if (value.retriever === "embedding" && !value.embeddingProvider) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["embeddingProvider"],
+      message: "retriever=embedding 时必须提供 embeddingProvider",
+    });
+  }
+
+  if (value.obsidian.enabled && !value.obsidian.vaultPath) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["obsidian", "vaultPath"],
+      message: "obsidian.enabled=true 时必须提供 vaultPath",
+    });
+  }
+});
 
 export const ConfigSchema = z.object({
   feishu: z.object({
@@ -46,15 +87,6 @@ export const ConfigSchema = z.object({
       totalTurn: z.number().int().positive().default(300_000),
     }).default({}),
   }),
-  memory: z.object({
-    enabled: z.boolean().default(false),
-    dbPath: z.string().min(1).default("./data/memory.db"),
-    maxMemoriesPerUser: z.number().int().positive().default(500),
-    searchLimit: z.number().int().positive().default(5),
-    extractQueueLimit: z.number().int().positive().default(100),
-    sourcePreviewLength: z.number().int().positive().default(50),
-    shutdownDrainTimeoutMs: z.number().int().positive().default(5_000),
-  }).default({}),
   logging: z.object({
     dir: z.string().min(1).default("./logs"),
     level: z.enum(["debug", "info", "warn", "error"]).default("info"),
@@ -63,6 +95,7 @@ export const ConfigSchema = z.object({
     enableColor: z.boolean().default(true),
     rotateDaily: z.boolean().default(true),
   }).default({}),
+  memory: MemoryConfigSchema.default({}),
 });
 
 export type AppConfig = {
@@ -107,6 +140,14 @@ export type AppConfig = {
     eventGapTimeoutMs: number;
     totalTimeoutMs: number;
   };
+  logging: {
+    dir: string;
+    level: "debug" | "info" | "warn" | "error";
+    enableTranscript: boolean;
+    enableConsole: boolean;
+    enableColor: boolean;
+    rotateDaily: boolean;
+  };
   memory: {
     enabled: boolean;
     dbPath: string;
@@ -115,13 +156,18 @@ export type AppConfig = {
     extractQueueLimit: number;
     sourcePreviewLength: number;
     shutdownDrainTimeoutMs: number;
-  };
-  logging: {
-    dir: string;
-    level: "debug" | "info" | "warn" | "error";
-    enableTranscript: boolean;
-    enableConsole: boolean;
-    enableColor: boolean;
-    rotateDaily: boolean;
+    retriever: "recent" | "embedding";
+    embeddingProvider?: {
+      baseUrl: URL;
+      apiKey: string;
+      model: string;
+    } | undefined;
+    embeddingSimilarityThreshold: number;
+    obsidian: {
+      enabled: boolean;
+      vaultPath?: string | undefined;
+      syncCron: string;
+      enableWikiLinks: boolean;
+    };
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,12 @@ import { BridgeApp } from "./runtime/app.js";
 import { FeishuApiClient } from "./feishu/api.js";
 import { createFeishuIngressOptions, FeishuWsClient } from "./feishu/ws.js";
 
-async function main(): Promise<void> {
+type Runtime = {
+  app: BridgeApp;
+  ws: FeishuWsClient;
+};
+
+async function main(): Promise<Runtime> {
   const config = await loadConfig();
   const logger = await createLogger(config.logging.dir);
   const outbound = new FeishuApiClient(config.feishu.appId, config.feishu.appSecret);
@@ -18,9 +23,60 @@ async function main(): Promise<void> {
     logger,
   );
   await ws.start();
+  return { app, ws };
 }
 
-void main().catch((error) => {
-  console.error(error);
-  process.exitCode = 1;
+let runtime: Runtime | null = null;
+let shuttingDown: Promise<void> | null = null;
+
+async function shutdown(reason: string): Promise<void> {
+  if (shuttingDown) {
+    return shuttingDown;
+  }
+
+  shuttingDown = (async () => {
+    if (!runtime) {
+      return;
+    }
+
+    try {
+      await runtime.ws.stop();
+    } catch (error) {
+      console.error(`[shutdown:${reason}] failed to stop Feishu WS`, error);
+    }
+
+    try {
+      await runtime.app.stop();
+    } catch (error) {
+      console.error(`[shutdown:${reason}] failed to stop bridge app`, error);
+    }
+  })();
+
+  return shuttingDown;
+}
+
+process.once("SIGINT", () => {
+  void shutdown("SIGINT").finally(() => {
+    process.exit(0);
+  });
 });
+
+process.once("SIGTERM", () => {
+  void shutdown("SIGTERM").finally(() => {
+    process.exit(0);
+  });
+});
+
+process.once("beforeExit", () => {
+  void shutdown("beforeExit");
+});
+
+void main()
+  .then((started) => {
+    runtime = started;
+  })
+  .catch(async (error) => {
+    console.error(error);
+    await shutdown("startup-error");
+    process.exitCode = 1;
+  });

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -1,0 +1,182 @@
+import Database from "better-sqlite3";
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+
+export type MemoryRow = {
+  id: number;
+  userId: string;
+  fact: string;
+  sourceMessage: string;
+  createdAt: number;
+  accessedAt: number;
+};
+
+export class MemoryDb {
+  private readonly db: Database.Database;
+
+  constructor(
+    dbPath: string,
+    private readonly maxMemoriesPerUser: number,
+    private readonly sourcePreviewLength: number,
+  ) {
+    mkdirSync(path.dirname(dbPath), { recursive: true });
+    this.db = new Database(dbPath);
+    this.init();
+  }
+
+  add(userId: string, facts: string[], sourceMessage: string): { saved: number } {
+    const normalizedFacts = dedupeFacts(facts);
+    if (normalizedFacts.length === 0) {
+      return { saved: 0 };
+    }
+
+    const now = Date.now();
+    const sourcePreview = truncateSourcePreview(sourceMessage, this.sourcePreviewLength);
+    const insert = this.db.prepare(`
+      INSERT OR IGNORE INTO memories (user_id, fact, source_message, created_at, accessed_at)
+      VALUES (@userId, @fact, @sourceMessage, @now, @now)
+    `);
+    const touch = this.db.prepare(`
+      UPDATE memories
+      SET accessed_at = @now
+      WHERE user_id = @userId AND fact = @fact
+    `);
+    const transaction = this.db.transaction((rows: string[]) => {
+      let saved = 0;
+      for (const fact of rows) {
+        const result = insert.run({ userId, fact, sourceMessage: sourcePreview, now });
+        if (result.changes > 0) {
+          saved += 1;
+          continue;
+        }
+        touch.run({ userId, fact, now });
+      }
+      this.evict(userId);
+      return { saved };
+    });
+
+    return transaction(normalizedFacts);
+  }
+
+  search(userId: string, query: string, limit: number): string[] {
+    const sanitizedQuery = sanitizeSearchQuery(query);
+    if (!sanitizedQuery) {
+      return [];
+    }
+
+    const rows = this.db.prepare(`
+      SELECT m.id, m.fact
+      FROM memories_fts f
+      JOIN memories m ON m.id = f.rowid
+      WHERE memories_fts MATCH @query
+        AND m.user_id = @userId
+      ORDER BY bm25(memories_fts), m.accessed_at DESC
+      LIMIT @limit
+    `).all({ query: sanitizedQuery, userId, limit }) as Array<{ id: number; fact: string }>;
+
+    if (rows.length > 0) {
+      const now = Date.now();
+      const ids = rows.map((row) => row.id);
+      this.db.prepare(`
+        UPDATE memories
+        SET accessed_at = ${now}
+        WHERE id IN (${ids.map(() => "?").join(",")})
+      `).run(...ids);
+    }
+
+    return rows.map((row) => row.fact);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  private init(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS memories (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id TEXT NOT NULL,
+        fact TEXT NOT NULL,
+        source_message TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        accessed_at INTEGER NOT NULL
+      );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_user_fact
+        ON memories(user_id, fact);
+
+      CREATE INDEX IF NOT EXISTS idx_memories_user_accessed
+        ON memories(user_id, accessed_at DESC);
+
+      CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
+        fact,
+        content='memories',
+        content_rowid='id'
+      );
+
+      CREATE TRIGGER IF NOT EXISTS memories_ai AFTER INSERT ON memories BEGIN
+        INSERT INTO memories_fts(rowid, fact) VALUES (new.id, new.fact);
+      END;
+
+      CREATE TRIGGER IF NOT EXISTS memories_au AFTER UPDATE OF fact ON memories BEGIN
+        INSERT INTO memories_fts(memories_fts, rowid, fact) VALUES ('delete', old.id, old.fact);
+        INSERT INTO memories_fts(rowid, fact) VALUES (new.id, new.fact);
+      END;
+
+      CREATE TRIGGER IF NOT EXISTS memories_ad AFTER DELETE ON memories BEGIN
+        INSERT INTO memories_fts(memories_fts, rowid, fact) VALUES ('delete', old.id, old.fact);
+      END;
+    `);
+  }
+
+  private evict(userId: string): void {
+    const row = this.db.prepare(`
+      SELECT COUNT(*) AS count
+      FROM memories
+      WHERE user_id = ?
+    `).get(userId) as { count: number };
+
+    if (row.count <= this.maxMemoriesPerUser) {
+      return;
+    }
+
+    const toDelete = Math.max(1, Math.ceil(this.maxMemoriesPerUser * 0.2));
+    this.db.prepare(`
+      DELETE FROM memories
+      WHERE id IN (
+        SELECT id
+        FROM memories
+        WHERE user_id = ?
+        ORDER BY accessed_at ASC
+        LIMIT ?
+      )
+    `).run(userId, toDelete);
+  }
+}
+
+function sanitizeSearchQuery(query: string): string {
+  return query
+    .replace(/["'*:()-]/g, " ")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .join(" ");
+}
+
+function truncateSourcePreview(text: string, maxLength: number): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  return normalized.length > maxLength ? normalized.slice(0, maxLength) : normalized;
+}
+
+function dedupeFacts(facts: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const fact of facts.map((fact) => fact.trim()).filter(Boolean)) {
+    if (seen.has(fact)) {
+      continue;
+    }
+    seen.add(fact);
+    result.push(fact);
+  }
+  return result;
+}

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -11,6 +11,19 @@ export type MemoryRow = {
   accessedAt: number;
 };
 
+export type MemoryFactRecord = {
+  id: number;
+  fact: string;
+  createdAt: number;
+  accessedAt: number;
+};
+
+type MemoryEmbeddingCandidate = {
+  id: number;
+  fact: string;
+  embedding: number[];
+};
+
 export class MemoryDb {
   private readonly db: Database.Database;
 
@@ -25,37 +38,176 @@ export class MemoryDb {
   }
 
   add(userId: string, facts: string[], sourceMessage: string): { saved: number } {
-    const normalizedFacts = dedupeFacts(facts);
+    const ids = this.saveFacts(
+      userId,
+      facts.map((fact) => ({ fact, sourceMessage })),
+    );
+    return { saved: ids.length };
+  }
+
+  saveFacts(userId: string, facts: Array<{ fact: string; sourceMessage: string }>): number[] {
+    const normalizedFacts = dedupeFactEntries(facts, this.sourcePreviewLength);
     if (normalizedFacts.length === 0) {
-      return { saved: 0 };
+      return [];
     }
 
     const now = Date.now();
-    const sourcePreview = truncateSourcePreview(sourceMessage, this.sourcePreviewLength);
+    const ids: number[] = [];
     const insert = this.db.prepare(`
-      INSERT OR IGNORE INTO memories (user_id, fact, source_message, created_at, accessed_at)
-      VALUES (@userId, @fact, @sourceMessage, @now, @now)
+      INSERT OR IGNORE INTO memories (
+        user_id,
+        fact,
+        source_message,
+        created_at,
+        accessed_at,
+        embedding_model,
+        embedding_json
+      )
+      VALUES (
+        @userId,
+        @fact,
+        @sourceMessage,
+        @now,
+        @now,
+        NULL,
+        NULL
+      )
     `);
-    const touch = this.db.prepare(`
+    const selectId = this.db.prepare(`
+      SELECT id
+      FROM memories
+      WHERE user_id = @userId AND fact = @fact
+    `);
+    const touchExisting = this.db.prepare(`
       UPDATE memories
       SET accessed_at = @now
       WHERE user_id = @userId AND fact = @fact
     `);
-    const transaction = this.db.transaction((rows: string[]) => {
-      let saved = 0;
-      for (const fact of rows) {
-        const result = insert.run({ userId, fact, sourceMessage: sourcePreview, now });
-        if (result.changes > 0) {
-          saved += 1;
-          continue;
+    const transaction = this.db.transaction((rows: Array<{ fact: string; sourceMessage: string }>) => {
+      for (const row of rows) {
+        const insertResult = insert.run({
+          userId,
+          fact: row.fact,
+          sourceMessage: row.sourceMessage,
+          now,
+        });
+        if (insertResult.changes === 0) {
+          touchExisting.run({ userId, fact: row.fact, now });
         }
-        touch.run({ userId, fact, now });
+        const record = selectId.get({ userId, fact: row.fact }) as { id: number } | undefined;
+        if (record) {
+          ids.push(record.id);
+        }
       }
       this.evict(userId);
-      return { saved };
     });
 
-    return transaction(normalizedFacts);
+    transaction(normalizedFacts);
+    return ids;
+  }
+
+  updateEmbedding(id: number, embedding: number[], model: string): void {
+    this.db.prepare(`
+      UPDATE memories
+      SET embedding_model = @model,
+          embedding_json = @embedding
+      WHERE id = @id
+    `).run({
+      id,
+      model,
+      embedding: JSON.stringify(embedding),
+    });
+  }
+
+  listEmbeddingCandidates(userId: string, model: string): MemoryEmbeddingCandidate[] {
+    const rows = this.db.prepare(`
+      SELECT id, fact, embedding_json
+      FROM memories
+      WHERE user_id = @userId
+        AND embedding_model = @model
+        AND embedding_json IS NOT NULL
+      ORDER BY accessed_at DESC, id DESC
+    `).all({ userId, model }) as Array<{
+      id: number;
+      fact: string;
+      embedding_json: string | null;
+    }>;
+
+    return rows.flatMap((row) => {
+      if (!row.embedding_json) {
+        return [];
+      }
+      try {
+        const embedding = JSON.parse(row.embedding_json) as unknown;
+        if (!Array.isArray(embedding) || embedding.some((value) => typeof value !== "number")) {
+          return [];
+        }
+        return [{ id: row.id, fact: row.fact, embedding: embedding as number[] }];
+      } catch {
+        return [];
+      }
+    });
+  }
+
+  listRecent(userId: string, limit: number): MemoryFactRecord[] {
+    return this.db.prepare(`
+      SELECT id, fact, created_at, accessed_at
+      FROM memories
+      WHERE user_id = @userId
+      ORDER BY accessed_at DESC, id DESC
+      LIMIT @limit
+    `).all({ userId, limit }) as MemoryFactRecord[];
+  }
+
+  touch(ids: number[]): void {
+    if (ids.length === 0) {
+      return;
+    }
+    const now = Date.now();
+    this.db.prepare(`
+      UPDATE memories
+      SET accessed_at = ${now}
+      WHERE id IN (${ids.map(() => "?").join(",")})
+    `).run(...ids);
+  }
+
+  listUsers(): string[] {
+    const rows = this.db.prepare(`
+      SELECT DISTINCT user_id
+      FROM memories
+      ORDER BY user_id ASC
+    `).all() as Array<{ user_id: string }>;
+    return rows.map((row) => row.user_id);
+  }
+
+  listFactsForUser(userId: string): MemoryFactRecord[] {
+    return this.db.prepare(`
+      SELECT id, fact, created_at, accessed_at
+      FROM memories
+      WHERE user_id = @userId
+      ORDER BY accessed_at DESC, id DESC
+    `).all({ userId }) as MemoryFactRecord[];
+  }
+
+  getObsidianLastSyncedAt(): number | null {
+    const row = this.db.prepare(`
+      SELECT value
+      FROM metadata
+      WHERE key = 'obsidian_last_synced_at'
+    `).get() as { value: string } | undefined;
+    if (!row) {
+      return null;
+    }
+    const value = Number(row.value);
+    return Number.isFinite(value) ? value : null;
+  }
+
+  setObsidianLastSyncedAt(timestamp: number): void {
+    this.db.prepare(`
+      INSERT INTO metadata (key, value)
+      VALUES ('obsidian_last_synced_at', @value)
+      ON CONFLICT(key) DO UPDATE SET value = excluded.value
+    `).run({ value: String(timestamp) });
   }
 
   search(userId: string, query: string, limit: number): string[] {
@@ -74,16 +226,7 @@ export class MemoryDb {
       LIMIT @limit
     `).all({ query: sanitizedQuery, userId, limit }) as Array<{ id: number; fact: string }>;
 
-    if (rows.length > 0) {
-      const now = Date.now();
-      const ids = rows.map((row) => row.id);
-      this.db.prepare(`
-        UPDATE memories
-        SET accessed_at = ${now}
-        WHERE id IN (${ids.map(() => "?").join(",")})
-      `).run(...ids);
-    }
-
+    this.touch(rows.map((row) => row.id));
     return rows.map((row) => row.fact);
   }
 
@@ -100,6 +243,11 @@ export class MemoryDb {
         source_message TEXT NOT NULL,
         created_at INTEGER NOT NULL,
         accessed_at INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS metadata (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
       );
 
       CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_user_fact
@@ -127,6 +275,15 @@ export class MemoryDb {
         INSERT INTO memories_fts(memories_fts, rowid, fact) VALUES ('delete', old.id, old.fact);
       END;
     `);
+
+    const columns = this.db.prepare("PRAGMA table_info(memories)").all() as Array<{ name: string }>;
+    const columnNames = new Set(columns.map((column) => column.name));
+    if (!columnNames.has("embedding_model")) {
+      this.db.exec("ALTER TABLE memories ADD COLUMN embedding_model TEXT");
+    }
+    if (!columnNames.has("embedding_json")) {
+      this.db.exec("ALTER TABLE memories ADD COLUMN embedding_json TEXT");
+    }
   }
 
   private evict(userId: string): void {
@@ -168,15 +325,22 @@ function truncateSourcePreview(text: string, maxLength: number): string {
   return normalized.length > maxLength ? normalized.slice(0, maxLength) : normalized;
 }
 
-function dedupeFacts(facts: string[]): string[] {
+function dedupeFactEntries(
+  facts: Array<{ fact: string; sourceMessage: string }>,
+  sourcePreviewLength: number,
+): Array<{ fact: string; sourceMessage: string }> {
   const seen = new Set<string>();
-  const result: string[] = [];
-  for (const fact of facts.map((fact) => fact.trim()).filter(Boolean)) {
-    if (seen.has(fact)) {
+  const result: Array<{ fact: string; sourceMessage: string }> = [];
+  for (const item of facts) {
+    const fact = item.fact.trim();
+    if (!fact || seen.has(fact)) {
       continue;
     }
     seen.add(fact);
-    result.push(fact);
+    result.push({
+      fact,
+      sourceMessage: truncateSourcePreview(item.sourceMessage, sourcePreviewLength),
+    });
   }
   return result;
 }

--- a/src/memory/embedding-retriever.ts
+++ b/src/memory/embedding-retriever.ts
@@ -1,0 +1,123 @@
+import type { Logger } from "../logging/logger.js";
+import type { MemoryDb } from "./db.js";
+import type { MemoryRetriever } from "./retriever.js";
+
+export interface EmbeddingProviderClient {
+  readonly model: string;
+  embed(text: string): Promise<number[]>;
+}
+
+type OpenAIEmbeddingResponse = {
+  data?: Array<{
+    embedding?: unknown;
+  }>;
+};
+
+export class OpenAICompatibleEmbeddingClient implements EmbeddingProviderClient {
+  readonly model: string;
+
+  constructor(
+    private readonly baseUrl: URL,
+    private readonly apiKey: string,
+    model: string,
+  ) {
+    this.model = model;
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const url = new URL("embeddings", ensureTrailingSlash(this.baseUrl));
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: this.model,
+        input: text,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`embedding request failed: ${response.status} ${response.statusText}`);
+    }
+
+    const payload = await response.json() as OpenAIEmbeddingResponse;
+    const embedding = payload.data?.[0]?.embedding;
+    if (!Array.isArray(embedding) || embedding.some((value) => typeof value !== "number")) {
+      throw new Error("embedding response missing numeric vector");
+    }
+    return embedding as number[];
+  }
+}
+
+export class EmbeddingRetriever implements MemoryRetriever {
+  constructor(
+    private readonly db: MemoryDb,
+    private readonly embeddingClient: EmbeddingProviderClient,
+    private readonly fallback: MemoryRetriever,
+    private readonly similarityThreshold: number,
+    private readonly logger: Logger,
+  ) {}
+
+  async recall(userId: string, query: string, limit: number): Promise<string[]> {
+    let queryEmbedding: number[];
+    try {
+      queryEmbedding = await this.embeddingClient.embed(query);
+    } catch (error) {
+      this.logger.log("memory/recall", "embedding query failed, fallback to recent", {
+        userId,
+        detail: error instanceof Error ? error.message : String(error),
+      }, "warn");
+      return this.fallback.recall(userId, query, limit);
+    }
+
+    const candidates = this.db.listEmbeddingCandidates(userId, this.embeddingClient.model);
+    if (candidates.length === 0) {
+      return this.fallback.recall(userId, query, limit);
+    }
+
+    const matches = candidates
+      .map((candidate) => ({
+        id: candidate.id,
+        fact: candidate.fact,
+        score: cosineSimilarity(queryEmbedding, candidate.embedding),
+      }))
+      .filter((candidate) => Number.isFinite(candidate.score) && candidate.score >= this.similarityThreshold)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, limit);
+
+    if (matches.length === 0) {
+      return this.fallback.recall(userId, query, limit);
+    }
+
+    this.db.touch(matches.map((match) => match.id));
+    return matches.map((match) => match.fact);
+  }
+}
+
+export function cosineSimilarity(left: number[], right: number[]): number {
+  if (left.length === 0 || right.length === 0 || left.length !== right.length) {
+    return Number.NaN;
+  }
+
+  let dot = 0;
+  let leftNorm = 0;
+  let rightNorm = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    const leftValue = left[index]!;
+    const rightValue = right[index]!;
+    dot += leftValue * rightValue;
+    leftNorm += leftValue * leftValue;
+    rightNorm += rightValue * rightValue;
+  }
+
+  if (leftNorm === 0 || rightNorm === 0) {
+    return Number.NaN;
+  }
+  return dot / (Math.sqrt(leftNorm) * Math.sqrt(rightNorm));
+}
+
+function ensureTrailingSlash(url: URL): URL {
+  return new URL(url.toString().endsWith("/") ? url.toString() : `${url.toString()}/`);
+}

--- a/src/memory/extractor.ts
+++ b/src/memory/extractor.ts
@@ -1,0 +1,126 @@
+import type { Logger } from "../logging/logger.js";
+import type { OpenCodeClient, OpenCodeMessage, OpenCodePromptRequest } from "../opencode/client.js";
+
+const EXTRACTION_SYSTEM_PROMPT = [
+  "你是用户长期事实提取器。",
+  "请从给定对话中提取值得长期记住的用户事实。",
+  "每行一条，以“用户”开头。",
+  "不要输出编号、解释、前后缀或空话。",
+  "如果没有可记忆的事实，输出空字符串。",
+].join("\n");
+
+const EXTRACTION_TIMEOUT_MS = 15_000;
+const POLL_INTERVAL_MS = 500;
+const MESSAGE_SLICE_LIMIT = 500;
+
+export type MemoryExtractor = {
+  extract(userMessage: string, assistantMessage: string): Promise<string[]>;
+};
+
+export class OpenCodeMemoryExtractor implements MemoryExtractor {
+  constructor(
+    private readonly client: OpenCodeClient,
+    private readonly logger: Logger,
+  ) {}
+
+  async extract(userMessage: string, assistantMessage: string): Promise<string[]> {
+    const prompt = buildExtractionPrompt(userMessage, assistantMessage);
+    const syncSession = await this.client.createSession("Memory Extraction");
+    try {
+      const syncMessage = await this.client.postMessageSync(syncSession.id, buildExtractionRequest(prompt));
+      const syncFacts = parseFacts(extractAssistantText(syncMessage));
+      if (syncFacts.length > 0) {
+        return syncFacts;
+      }
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      this.logger.log("memory/extractor", "sync extraction failed", { detail }, "warn");
+    }
+
+    this.logger.log("memory/extractor", "fallback", { mode: "async-poll" }, "warn");
+    const asyncSession = await this.client.createSession("Memory Extraction Fallback");
+    try {
+      await this.client.promptAsync(asyncSession.id, buildExtractionRequest(prompt));
+      const asyncText = await pollForAssistantText(this.client, asyncSession.id, EXTRACTION_TIMEOUT_MS);
+      return parseFacts(asyncText);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      this.logger.log("memory/extractor", "fallback extraction failed", { detail }, "warn");
+      return [];
+    }
+  }
+}
+
+function buildExtractionPrompt(userMessage: string, assistantMessage: string): string {
+  return [
+    "以下是一段对话，请提取值得长期记住的用户事实：",
+    `用户: ${sliceForPrompt(userMessage)}`,
+    `助手: ${sliceForPrompt(assistantMessage)}`,
+  ].join("\n");
+}
+
+function buildExtractionRequest(prompt: string): OpenCodePromptRequest {
+  return {
+    system: EXTRACTION_SYSTEM_PROMPT,
+    parts: [{ type: "text", text: prompt }],
+  };
+}
+
+async function pollForAssistantText(client: OpenCodeClient, sessionId: string, timeoutMs: number): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  let lastSeenText = "";
+
+  while (Date.now() < deadline) {
+    const messages = await client.getSessionMessages(sessionId, 50);
+    const latestAssistant = [...messages].reverse().find((message) => message.info.role === "assistant") ?? null;
+    if (latestAssistant) {
+      const text = extractAssistantText(latestAssistant);
+      if (text) {
+        lastSeenText = text;
+      }
+      if (text && isCompletedMessage(latestAssistant)) {
+        return text;
+      }
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  return lastSeenText;
+}
+
+function extractAssistantText(message: OpenCodeMessage | null): string {
+  if (!message) {
+    return "";
+  }
+
+  return message.parts
+    .filter((part) => part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text ?? "")
+    .join("")
+    .trim();
+}
+
+function isCompletedMessage(message: OpenCodeMessage): boolean {
+  const time = typeof message.info.time === "object" && message.info.time !== null
+    ? message.info.time as Record<string, unknown>
+    : null;
+  return typeof message.info.finish === "string" || typeof time?.completed === "number";
+}
+
+function parseFacts(text: string): string[] {
+  const lines = text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("用户") && line.length >= 5 && line.length <= 100);
+  return [...new Set(lines)];
+}
+
+function sliceForPrompt(text: string): string {
+  return text.trim().slice(0, MESSAGE_SLICE_LIMIT);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -1,0 +1,154 @@
+import type { Logger } from "../logging/logger.js";
+import type { OpenCodeClient } from "../opencode/client.js";
+import type { AppConfig } from "../config/schema.js";
+import { MemoryDb } from "./db.js";
+import { OpenCodeMemoryExtractor, type MemoryExtractor } from "./extractor.js";
+
+type LearnTask = {
+  userId: string;
+  userMessage: string;
+  assistantMessage: string;
+};
+
+export class MemoryService {
+  private readonly db: MemoryDb;
+  private readonly extractor: MemoryExtractor;
+  private readonly queue: LearnTask[] = [];
+  private readonly idleWaiters = new Set<() => void>();
+  private processing = false;
+  private closed = false;
+  private closeWhenIdle = false;
+
+  constructor(
+    private readonly config: AppConfig["memory"],
+    client: OpenCodeClient,
+    private readonly logger: Logger,
+    extractor?: MemoryExtractor,
+  ) {
+    this.db = new MemoryDb(config.dbPath, config.maxMemoriesPerUser, config.sourcePreviewLength);
+    this.extractor = extractor ?? new OpenCodeMemoryExtractor(client, logger);
+  }
+
+  buildRecallBlock(userId: string, query: string): string {
+    const facts = this.db.search(userId, query, this.config.searchLimit);
+    this.logger.log("memory/recall", facts.length > 0 ? "hit" : "miss", { userId, count: facts.length });
+    return formatRecallBlock(facts);
+  }
+
+  enqueueLearn(userId: string, userMessage: string, assistantMessage: string): void {
+    if (this.closed) {
+      this.logger.log("memory/learn", "dropped", { userId, reason: "closed" }, "warn");
+      return;
+    }
+
+    if (this.queue.length >= this.config.extractQueueLimit) {
+      this.logger.log("memory/learn", "dropped", { userId, reason: "queue-full", queueSize: this.queue.length }, "warn");
+      return;
+    }
+
+    this.queue.push({ userId, userMessage, assistantMessage });
+    this.logger.log("memory/learn", "queued", { userId, queueSize: this.queue.length });
+    this.ensureWorker();
+  }
+
+  async drain(timeoutMs = this.config.shutdownDrainTimeoutMs): Promise<void> {
+    if (!this.processing && this.queue.length === 0) {
+      return;
+    }
+
+    await Promise.race([
+      new Promise<void>((resolve) => {
+        this.idleWaiters.add(resolve);
+      }),
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, timeoutMs);
+      }),
+    ]);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.queue.length = 0;
+    if (!this.processing) {
+      this.db.close();
+      return;
+    }
+    this.closeWhenIdle = true;
+  }
+
+  private ensureWorker(): void {
+    if (this.processing) {
+      return;
+    }
+
+    this.processing = true;
+    void this.processQueue().finally(() => {
+      this.processing = false;
+      this.notifyIdle();
+    });
+  }
+
+  private async processQueue(): Promise<void> {
+    while (this.queue.length > 0) {
+      const task = this.queue.shift();
+      if (!task) {
+        continue;
+      }
+
+      try {
+        const facts = await this.extractor.extract(task.userMessage, task.assistantMessage);
+        if (this.closed) {
+          this.logger.log("memory/learn", "dropped", { userId: task.userId, reason: "closing" }, "warn");
+          continue;
+        }
+        const result = this.db.add(task.userId, facts, task.userMessage);
+        this.logger.log("memory/learn", "saved", { userId: task.userId, facts: result.saved });
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        this.logger.log("memory/learn", "failed", {
+          userId: task.userId,
+          detail,
+          sourcePreview: createSourcePreview(task.userMessage, this.config.sourcePreviewLength),
+        }, "warn");
+      }
+    }
+  }
+
+  private notifyIdle(): void {
+    if (this.processing || this.queue.length > 0) {
+      return;
+    }
+
+    for (const waiter of this.idleWaiters) {
+      waiter();
+    }
+    this.idleWaiters.clear();
+    if (this.closeWhenIdle) {
+      this.db.close();
+      this.closeWhenIdle = false;
+    }
+  }
+}
+
+export function formatRecallBlock(facts: string[]): string {
+  if (facts.length === 0) {
+    return "";
+  }
+
+  return ["[Memory Recall]", ...facts.map((fact) => `- ${fact}`)].join("\n");
+}
+
+export function appendSystemBlock(systemPrompt: string | undefined, block: string): string | undefined {
+  const normalizedBlock = block.trim();
+  if (!normalizedBlock) {
+    return systemPrompt;
+  }
+
+  const normalizedSystem = systemPrompt?.trim();
+  return normalizedSystem ? `${normalizedSystem}\n\n${normalizedBlock}` : normalizedBlock;
+}
+
+function createSourcePreview(text: string, maxLength: number): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  return normalized.length > maxLength ? normalized.slice(0, maxLength) : normalized;
+}

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -29,6 +29,7 @@ export class MemoryService {
   private readonly queue: LearnTask[] = [];
   private readonly idleWaiters = new Set<() => void>();
   private processing = false;
+  private accepting = true;
   private closed = false;
 
   constructor(
@@ -69,8 +70,9 @@ export class MemoryService {
   }
 
   async stop(): Promise<void> {
-    this.closed = true;
+    this.accepting = false;
     await this.drain(this.config.shutdownDrainTimeoutMs);
+    this.closed = true;
     await this.obsidianSync?.stop();
     this.db.close();
   }
@@ -86,7 +88,7 @@ export class MemoryService {
   }
 
   enqueueLearn(userId: string, userMessage: string, assistantMessage: string): void {
-    if (this.closed) {
+    if (!this.accepting) {
       this.logger.log("memory/learn", "dropped", { userId, reason: "closed" }, "warn");
       return;
     }
@@ -140,16 +142,17 @@ export class MemoryService {
       }
 
       try {
-        const facts = await this.extractor.extract(task.userMessage, task.assistantMessage);
+        const extractedFacts = await this.extractor.extract(task.userMessage, task.assistantMessage);
+        const normalizedFacts = dedupeFacts(extractedFacts);
         if (this.closed) {
-          this.logger.log("memory/learn", "dropped", { userId: task.userId, reason: "closing" }, "warn");
+          this.logger.log("memory/learn", "dropped", { userId: task.userId, reason: "closed" }, "warn");
           continue;
         }
         const ids = this.db.saveFacts(
           task.userId,
-          facts.map((fact) => ({ fact, sourceMessage: task.userMessage })),
+          normalizedFacts.map((fact) => ({ fact, sourceMessage: task.userMessage })),
         );
-        await this.updateEmbeddings(ids, facts);
+        await this.updateEmbeddings(ids, normalizedFacts);
         this.logger.log("memory/learn", "saved", { userId: task.userId, facts: ids.length });
       } catch (error) {
         const detail = error instanceof Error ? error.message : String(error);
@@ -216,4 +219,17 @@ export function appendSystemBlock(systemPrompt: string | undefined, block: strin
 function createSourcePreview(text: string, maxLength: number): string {
   const normalized = text.replace(/\s+/g, " ").trim();
   return normalized.length > maxLength ? normalized.slice(0, maxLength) : normalized;
+}
+
+function dedupeFacts(facts: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const fact of facts.map((value) => value.trim()).filter(Boolean)) {
+    if (seen.has(fact)) {
+      continue;
+    }
+    seen.add(fact);
+    result.push(fact);
+  }
+  return result;
 }

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -3,6 +3,14 @@ import type { OpenCodeClient } from "../opencode/client.js";
 import type { AppConfig } from "../config/schema.js";
 import { MemoryDb } from "./db.js";
 import { OpenCodeMemoryExtractor, type MemoryExtractor } from "./extractor.js";
+import {
+  EmbeddingRetriever,
+  OpenAICompatibleEmbeddingClient,
+  type EmbeddingProviderClient,
+} from "./embedding-retriever.js";
+import { ObsidianSyncService } from "./obsidian-sync.js";
+import { RecentRetriever } from "./recent-retriever.js";
+import type { MemoryRetriever } from "./retriever.js";
 
 type LearnTask = {
   userId: string;
@@ -10,28 +18,70 @@ type LearnTask = {
   assistantMessage: string;
 };
 
+type MemoryServiceConfig = AppConfig["memory"];
+
 export class MemoryService {
   private readonly db: MemoryDb;
   private readonly extractor: MemoryExtractor;
+  private readonly retriever: MemoryRetriever;
+  private readonly embeddingClient: EmbeddingProviderClient | null;
+  private readonly obsidianSync: ObsidianSyncService | null;
   private readonly queue: LearnTask[] = [];
   private readonly idleWaiters = new Set<() => void>();
   private processing = false;
   private closed = false;
-  private closeWhenIdle = false;
 
   constructor(
-    private readonly config: AppConfig["memory"],
+    private readonly config: MemoryServiceConfig,
     client: OpenCodeClient,
     private readonly logger: Logger,
     extractor?: MemoryExtractor,
   ) {
     this.db = new MemoryDb(config.dbPath, config.maxMemoriesPerUser, config.sourcePreviewLength);
     this.extractor = extractor ?? new OpenCodeMemoryExtractor(client, logger);
+
+    const recentRetriever = new RecentRetriever(this.db);
+    if (config.retriever === "embedding" && config.embeddingProvider) {
+      this.embeddingClient = new OpenAICompatibleEmbeddingClient(
+        config.embeddingProvider.baseUrl,
+        config.embeddingProvider.apiKey,
+        config.embeddingProvider.model,
+      );
+      this.retriever = new EmbeddingRetriever(
+        this.db,
+        this.embeddingClient,
+        recentRetriever,
+        config.embeddingSimilarityThreshold,
+        logger,
+      );
+    } else {
+      this.embeddingClient = null;
+      this.retriever = recentRetriever;
+    }
+
+    this.obsidianSync = config.obsidian.enabled
+      ? new ObsidianSyncService(config.obsidian, this.db, logger)
+      : null;
   }
 
-  buildRecallBlock(userId: string, query: string): string {
-    const facts = this.db.search(userId, query, this.config.searchLimit);
-    this.logger.log("memory/recall", facts.length > 0 ? "hit" : "miss", { userId, count: facts.length });
+  async start(): Promise<void> {
+    await this.obsidianSync?.start();
+  }
+
+  async stop(): Promise<void> {
+    this.closed = true;
+    await this.drain(this.config.shutdownDrainTimeoutMs);
+    await this.obsidianSync?.stop();
+    this.db.close();
+  }
+
+  async buildRecallBlock(userId: string, query: string): Promise<string> {
+    const facts = await this.retriever.recall(userId, query, this.config.searchLimit);
+    this.logger.log("memory/recall", facts.length > 0 ? "hit" : "miss", {
+      userId,
+      count: facts.length,
+      retriever: this.config.retriever,
+    });
     return formatRecallBlock(facts);
   }
 
@@ -42,7 +92,11 @@ export class MemoryService {
     }
 
     if (this.queue.length >= this.config.extractQueueLimit) {
-      this.logger.log("memory/learn", "dropped", { userId, reason: "queue-full", queueSize: this.queue.length }, "warn");
+      this.logger.log("memory/learn", "dropped", {
+        userId,
+        reason: "queue-full",
+        queueSize: this.queue.length,
+      }, "warn");
       return;
     }
 
@@ -64,16 +118,6 @@ export class MemoryService {
         setTimeout(resolve, timeoutMs);
       }),
     ]);
-  }
-
-  close(): void {
-    this.closed = true;
-    this.queue.length = 0;
-    if (!this.processing) {
-      this.db.close();
-      return;
-    }
-    this.closeWhenIdle = true;
   }
 
   private ensureWorker(): void {
@@ -101,8 +145,12 @@ export class MemoryService {
           this.logger.log("memory/learn", "dropped", { userId: task.userId, reason: "closing" }, "warn");
           continue;
         }
-        const result = this.db.add(task.userId, facts, task.userMessage);
-        this.logger.log("memory/learn", "saved", { userId: task.userId, facts: result.saved });
+        const ids = this.db.saveFacts(
+          task.userId,
+          facts.map((fact) => ({ fact, sourceMessage: task.userMessage })),
+        );
+        await this.updateEmbeddings(ids, facts);
+        this.logger.log("memory/learn", "saved", { userId: task.userId, facts: ids.length });
       } catch (error) {
         const detail = error instanceof Error ? error.message : String(error);
         this.logger.log("memory/learn", "failed", {
@@ -114,19 +162,37 @@ export class MemoryService {
     }
   }
 
+  private async updateEmbeddings(ids: number[], facts: string[]): Promise<void> {
+    if (!this.embeddingClient) {
+      return;
+    }
+
+    for (let index = 0; index < ids.length; index += 1) {
+      const id = ids[index];
+      const fact = facts[index];
+      if (!id || !fact) {
+        continue;
+      }
+      try {
+        const embedding = await this.embeddingClient.embed(fact);
+        this.db.updateEmbedding(id, embedding, this.embeddingClient.model);
+      } catch (error) {
+        this.logger.log("memory/learn", "embedding failed", {
+          id,
+          detail: error instanceof Error ? error.message : String(error),
+        }, "warn");
+      }
+    }
+  }
+
   private notifyIdle(): void {
     if (this.processing || this.queue.length > 0) {
       return;
     }
-
     for (const waiter of this.idleWaiters) {
       waiter();
     }
     this.idleWaiters.clear();
-    if (this.closeWhenIdle) {
-      this.db.close();
-      this.closeWhenIdle = false;
-    }
   }
 }
 
@@ -134,7 +200,6 @@ export function formatRecallBlock(facts: string[]): string {
   if (facts.length === 0) {
     return "";
   }
-
   return ["[Memory Recall]", ...facts.map((fact) => `- ${fact}`)].join("\n");
 }
 

--- a/src/memory/obsidian-sync.ts
+++ b/src/memory/obsidian-sync.ts
@@ -1,0 +1,161 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import cron, { type ScheduledTask } from "node-cron";
+
+import { createTextPreview, type Logger } from "../logging/logger.js";
+import type { MemoryDb, MemoryFactRecord } from "./db.js";
+
+type ObsidianConfig = {
+  enabled: boolean;
+  vaultPath?: string | undefined;
+  syncCron: string;
+  enableWikiLinks: boolean;
+};
+
+export class ObsidianSyncService {
+  private task: ScheduledTask | null = null;
+  private syncPromise: Promise<void> | null = null;
+
+  constructor(
+    private readonly config: ObsidianConfig,
+    private readonly db: MemoryDb,
+    private readonly logger: Logger,
+  ) {}
+
+  async start(): Promise<void> {
+    if (!this.config.enabled) {
+      return;
+    }
+    if (!this.config.vaultPath) {
+      throw new Error("Obsidian vaultPath 未配置");
+    }
+    if (!cron.validate(this.config.syncCron)) {
+      throw new Error(`Obsidian syncCron 无效：${this.config.syncCron}`);
+    }
+
+    this.task = cron.schedule(this.config.syncCron, () => {
+      void this.sync("cron");
+    }, {
+      noOverlap: true,
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    });
+
+    await this.runStartupCompensation();
+  }
+
+  async stop(): Promise<void> {
+    this.task?.stop();
+    this.task?.destroy();
+    this.task = null;
+    if (this.syncPromise) {
+      await this.syncPromise;
+    }
+  }
+
+  async sync(reason: "cron" | "startup"): Promise<void> {
+    if (this.syncPromise) {
+      return this.syncPromise;
+    }
+
+    this.syncPromise = this.performSync(reason).finally(() => {
+      this.syncPromise = null;
+    });
+    return this.syncPromise;
+  }
+
+  private async runStartupCompensation(): Promise<void> {
+    const lastSyncedAt = this.db.getObsidianLastSyncedAt();
+    if (!lastSyncedAt) {
+      await this.sync("startup");
+      return;
+    }
+
+    const nextRun = this.getNextRunAfter(lastSyncedAt);
+    if (nextRun && nextRun.getTime() <= Date.now()) {
+      await this.sync("startup");
+    }
+  }
+
+  private getNextRunAfter(timestamp: number): Date | null {
+    const matcher = (this.task as ScheduledTask & {
+      timeMatcher?: { getNextMatch(date: Date): Date };
+    } | null)?.timeMatcher;
+    if (!matcher) {
+      return null;
+    }
+    return matcher.getNextMatch(new Date(timestamp));
+  }
+
+  private async performSync(reason: "cron" | "startup"): Promise<void> {
+    const startedAt = Date.now();
+    const userIds = this.db.listUsers();
+
+    for (const userId of userIds) {
+      const facts = this.db.listFactsForUser(userId);
+      await this.writeUserProfile(userId, facts);
+    }
+
+    this.db.setObsidianLastSyncedAt(startedAt);
+    this.logger.log("memory/obsidian", "obsidian sync completed", {
+      reason,
+      userCount: userIds.length,
+      syncedAt: startedAt,
+    });
+  }
+
+  private async writeUserProfile(userId: string, facts: MemoryFactRecord[]): Promise<void> {
+    if (!this.config.vaultPath) {
+      return;
+    }
+
+    const profileDir = path.join(this.config.vaultPath, "memory", userId);
+    await mkdir(profileDir, { recursive: true });
+    const markdown = buildProfileMarkdown(userId, facts, {
+      enableWikiLinks: this.config.enableWikiLinks,
+    });
+    const profilePath = path.join(profileDir, "profile.md");
+    await writeFile(profilePath, markdown, "utf8");
+    this.logger.log("memory/obsidian", "profile synced", {
+      userId,
+      path: profilePath,
+      preview: createTextPreview(markdown),
+    });
+  }
+}
+
+export function buildProfileMarkdown(
+  userId: string,
+  facts: MemoryFactRecord[],
+  options: { enableWikiLinks: boolean },
+): string {
+  const lines = [
+    `# 用户记忆 ${userId}`,
+    "",
+    "## 事实",
+  ];
+
+  if (facts.length === 0) {
+    lines.push("- 暂无记忆");
+  } else {
+    for (const fact of facts) {
+      lines.push(`- ${options.enableWikiLinks ? linkifyFact(fact.fact) : fact.fact}`);
+    }
+  }
+
+  lines.push("", "## 更新时间", formatTimestamp(new Date()));
+  return lines.join("\n");
+}
+
+function linkifyFact(fact: string): string {
+  return fact.replace(/\b([A-Za-z0-9][A-Za-z0-9._/-]*[-_/][A-Za-z0-9._/-]+)\b/g, "[[$1]]");
+}
+
+function formatTimestamp(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hour = String(date.getHours()).padStart(2, "0");
+  const minute = String(date.getMinutes()).padStart(2, "0");
+  return `${year}-${month}-${day} ${hour}:${minute}`;
+}

--- a/src/memory/recent-retriever.ts
+++ b/src/memory/recent-retriever.ts
@@ -1,0 +1,12 @@
+import type { MemoryDb } from "./db.js";
+import type { MemoryRetriever } from "./retriever.js";
+
+export class RecentRetriever implements MemoryRetriever {
+  constructor(private readonly db: MemoryDb) {}
+
+  async recall(userId: string, _query: string, limit: number): Promise<string[]> {
+    const rows = this.db.listRecent(userId, limit);
+    this.db.touch(rows.map((row) => row.id));
+    return rows.map((row) => row.fact);
+  }
+}

--- a/src/memory/retriever.ts
+++ b/src/memory/retriever.ts
@@ -1,0 +1,3 @@
+export interface MemoryRetriever {
+  recall(userId: string, query: string, limit: number): Promise<string[]>;
+}

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -16,6 +16,7 @@ import {
   type TurnStatusCardView,
 } from "../feishu/formatter.js";
 import { createTextPreview, type Logger, type TranscriptType } from "../logging/logger.js";
+import { MemoryService } from "../memory/index.js";
 import {
   OpenCodeClient,
   type OpenCodeMessage,
@@ -38,7 +39,6 @@ import {
   setActiveSession,
   updateSessionLabel,
 } from "./session-windows.js";
-import { appendSystemBlock, MemoryService } from "../memory/index.js";
 
 export type IncomingChatMessage = {
   chatId: string;
@@ -114,6 +114,7 @@ export class BridgeApp {
       throw new Error(`opencode serve 当前在 ${project.worktree}，bridge 配置的是 ${this.config.opencode.directory}，请在正确目录重启 opencode serve`);
     }
     await this.syncStoredSessionLabels();
+    await this.memory?.start();
 
     await this.eventStream.start();
     this.globalEventUnsubscribe = this.eventStream.subscribe(async (event) => {
@@ -139,10 +140,7 @@ export class BridgeApp {
     }
     this.pendingInteractionTimers.clear();
     this.streamFlushStates.clear();
-    if (this.memory) {
-      await this.memory.drain(this.config.memory.shutdownDrainTimeoutMs);
-      this.memory.close();
-    }
+    await this.memory?.stop();
     await this.eventStream.stop();
   }
 
@@ -257,8 +255,8 @@ export class BridgeApp {
       this.logger.log("opencode/events", "reply completed", { turnId: turn.turnId, sessionId, len: reply.length });
       this.logger.logTranscript("opencode-reply", { sessionId, turnId: turn.turnId }, reply);
       await this.maybeUpdateSessionLabel(turn as BridgeTurn & { sessionId: string });
-      if (this.memory && reply) {
-        this.memory.enqueueLearn(turn.senderOpenId, turn.plainText, reply);
+      if (reply) {
+        this.memory?.enqueueLearn(turn.senderOpenId, turn.plainText, reply);
       }
       await this.flushStreamUpdate(turn.turnId, reply, true);
       await this.updateTurnCard(turn.turnId, { status: "已完成", update: `最终回复已生成（${reply.length} 字）`, target: "step" });
@@ -281,6 +279,13 @@ export class BridgeApp {
     const baselineAssistantId = baselineAssistant?.info.id ?? null;
     const baselineAssistantTimestamp = getMessageTimestamp(baselineAssistant);
     const queue = this.queues.get(conversationKey);
+    const bridgeSystemPrompt = this.config.bridge.injectSystemState
+      ? buildBridgeSystemPrompt(turn, this.getSessionWindow(turn.conversationKey, turn.chatType))
+      : undefined;
+    const memoryRecall = this.memory
+      ? await this.memory.buildRecallBlock(turn.senderOpenId, turn.plainText)
+      : "";
+    const systemPrompt = composeSystemPrompt(bridgeSystemPrompt, memoryRecall);
 
     return new Promise<string>((resolve, reject) => {
       let assistantMessageId: string | null = null;
@@ -363,14 +368,7 @@ export class BridgeApp {
       );
 
       watchdog.start();
-      const systemPrompt = this.config.bridge.injectSystemState
-        ? buildBridgeSystemPrompt(turn, this.getSessionWindow(turn.conversationKey, turn.chatType))
-        : undefined;
-      const recallBlock = this.memory
-        ? this.memory.buildRecallBlock(turn.senderOpenId, turn.plainText)
-        : "";
-      const enrichedSystemPrompt = appendSystemBlock(systemPrompt, recallBlock);
-      void this.opencode.promptAsync(turn.sessionId, buildPromptRequest(turn.text, enrichedSystemPrompt))
+      void this.opencode.promptAsync(turn.sessionId, buildPromptRequest(turn.text, systemPrompt))
         .then(() => {
           queue.replaceActive(transitionTurn(turn, "awaiting-sse"));
           void this.updateTurnCard(turn.turnId, { status: "处理中", update: "请求已发送，等待事件流...", target: "step" });
@@ -1152,6 +1150,16 @@ export function buildPromptRequest(text: string, system?: string): { system?: st
     : {
       parts: [{ type: "text", text }],
     };
+}
+
+export function composeSystemPrompt(...sections: Array<string | undefined>): string | undefined {
+  const normalized = sections
+    .map((section) => section?.trim())
+    .filter((section): section is string => Boolean(section));
+  if (normalized.length === 0) {
+    return undefined;
+  }
+  return normalized.join("\n\n");
 }
 
 export function toOpencodePromptText(message: Pick<IncomingChatMessage, "chatType" | "senderOpenId" | "plainText">): string {

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -38,6 +38,7 @@ import {
   setActiveSession,
   updateSessionLabel,
 } from "./session-windows.js";
+import { appendSystemBlock, MemoryService } from "../memory/index.js";
 
 export type IncomingChatMessage = {
   chatId: string;
@@ -94,6 +95,7 @@ export class BridgeApp {
   private readonly turnCards = new Map<string, TurnCardState>();
   private readonly streamFlushStates = new Map<string, StreamFlushState>();
   private readonly sessionStatuses = new Map<string, OpenCodeSessionStatus>();
+  private readonly memory: MemoryService | null;
   private globalEventUnsubscribe: (() => void) | null = null;
 
   constructor(private readonly config: AppConfig, private readonly outbound: OutboundPort, private readonly logger: Logger) {
@@ -101,6 +103,7 @@ export class BridgeApp {
     this.mappings = new MappingStore(config.storage.dataDir, config.storage.mappingsFile, 200, logger);
     this.opencode = new OpenCodeClient(config.opencode.baseUrl);
     this.eventStream = new OpenCodeEventStream(config.opencode.baseUrl, logger);
+    this.memory = config.memory.enabled ? new MemoryService(config.memory, this.opencode, logger) : null;
   }
 
   async start(): Promise<void> {
@@ -136,6 +139,10 @@ export class BridgeApp {
     }
     this.pendingInteractionTimers.clear();
     this.streamFlushStates.clear();
+    if (this.memory) {
+      await this.memory.drain(this.config.memory.shutdownDrainTimeoutMs);
+      this.memory.close();
+    }
     await this.eventStream.stop();
   }
 
@@ -250,6 +257,9 @@ export class BridgeApp {
       this.logger.log("opencode/events", "reply completed", { turnId: turn.turnId, sessionId, len: reply.length });
       this.logger.logTranscript("opencode-reply", { sessionId, turnId: turn.turnId }, reply);
       await this.maybeUpdateSessionLabel(turn as BridgeTurn & { sessionId: string });
+      if (this.memory && reply) {
+        this.memory.enqueueLearn(turn.senderOpenId, turn.plainText, reply);
+      }
       await this.flushStreamUpdate(turn.turnId, reply, true);
       await this.updateTurnCard(turn.turnId, { status: "已完成", update: `最终回复已生成（${reply.length} 字）`, target: "step" });
       queue.replaceActive(transitionTurn({ ...turn, sessionId }, "done"));
@@ -356,7 +366,11 @@ export class BridgeApp {
       const systemPrompt = this.config.bridge.injectSystemState
         ? buildBridgeSystemPrompt(turn, this.getSessionWindow(turn.conversationKey, turn.chatType))
         : undefined;
-      void this.opencode.promptAsync(turn.sessionId, buildPromptRequest(turn.text, systemPrompt))
+      const recallBlock = this.memory
+        ? this.memory.buildRecallBlock(turn.senderOpenId, turn.plainText)
+        : "";
+      const enrichedSystemPrompt = appendSystemBlock(systemPrompt, recallBlock);
+      void this.opencode.promptAsync(turn.sessionId, buildPromptRequest(turn.text, enrichedSystemPrompt))
         .then(() => {
           queue.replaceActive(transitionTurn(turn, "awaiting-sse"));
           void this.updateTurnCard(turn.turnId, { status: "处理中", update: "请求已发送，等待事件流...", target: "step" });

--- a/test/app-helpers.test.ts
+++ b/test/app-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildBridgeSystemPrompt, buildPromptRequest, resolveDisplayLabel } from "../src/runtime/app.js";
+import { buildBridgeSystemPrompt, buildPromptRequest, composeSystemPrompt, resolveDisplayLabel } from "../src/runtime/app.js";
 
 describe("runtime prompt helpers", () => {
   it("adds system state when provided", () => {
@@ -8,6 +8,12 @@ describe("runtime prompt helpers", () => {
       system: "state",
       parts: [{ type: "text", text: "hello" }],
     });
+  });
+
+  it("joins bridge state and memory recall without touching user text", () => {
+    expect(composeSystemPrompt("[Bridge State]\nwindowType: p2p", "[Memory Recall]\n- 用户喜欢 TypeScript")).toBe(
+      "[Bridge State]\nwindowType: p2p\n\n[Memory Recall]\n- 用户喜欢 TypeScript",
+    );
   });
 
   it("builds bridge system state from the current window", () => {

--- a/test/config-loader.test.ts
+++ b/test/config-loader.test.ts
@@ -1,0 +1,84 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { loadConfig } from "../src/config/loader.js";
+
+describe("loadConfig memory settings", () => {
+  it("fills memory defaults from storage.dataDir", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-config-"));
+    const configPath = path.join(dir, "config.json");
+    await writeFile(configPath, JSON.stringify(baseConfig()), "utf8");
+
+    const config = await loadConfig(configPath);
+
+    expect(config.memory.retriever).toBe("recent");
+    expect(config.memory.dbPath).toBe(path.join(dir, "data", "memory.db"));
+    expect(config.memory.obsidian.syncCron).toBe("0 2 * * *");
+  });
+
+  it("rejects embedding retriever without provider config", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-config-"));
+    const configPath = path.join(dir, "config.json");
+    await writeFile(configPath, JSON.stringify({
+      ...baseConfig(),
+      memory: {
+        enabled: true,
+        retriever: "embedding",
+      },
+    }), "utf8");
+
+    await expect(loadConfig(configPath)).rejects.toThrow("embeddingProvider");
+  });
+
+  it("rejects obsidian sync without vaultPath", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-config-"));
+    const configPath = path.join(dir, "config.json");
+    await writeFile(configPath, JSON.stringify({
+      ...baseConfig(),
+      memory: {
+        enabled: true,
+        obsidian: {
+          enabled: true,
+        },
+      },
+    }), "utf8");
+
+    await expect(loadConfig(configPath)).rejects.toThrow("vaultPath");
+  });
+});
+
+function baseConfig(): Record<string, unknown> {
+  return {
+    feishu: {
+      appId: "cli_xxx",
+      appSecret: "secret",
+      botOpenId: "ou_bot",
+      behavior: {
+        enableP2p: true,
+        enableGroup: true,
+        requireBotMentionInGroup: true,
+        strictBotMention: true,
+        ignoreNonUserSenders: true,
+        replyInThread: true,
+      },
+    },
+    opencode: {
+      baseUrl: "http://127.0.0.1:4096/",
+      directory: dirPlaceholder(),
+    },
+    storage: {
+      dataDir: "./data",
+      mappingsFile: "mappings.json",
+    },
+    bridge: {
+      queueLimit: 3,
+    },
+  };
+}
+
+function dirPlaceholder(): string {
+  return process.cwd();
+}

--- a/test/memory-db.test.ts
+++ b/test/memory-db.test.ts
@@ -1,0 +1,57 @@
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+import { MemoryDb } from "../src/memory/db.js";
+
+describe("MemoryDb", () => {
+  it("dedupes by userId and fact while truncating source previews", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-memory-db-"));
+    const dbPath = path.join(dir, "memory.db");
+    const db = new MemoryDb(dbPath, 10, 10);
+
+    db.add("u1", ["用户偏好 TypeScript", "用户偏好 TypeScript"], "0123456789abcdef");
+
+    const raw = new Database(dbPath, { readonly: true });
+    const rows = raw.prepare("SELECT fact, source_message FROM memories").all() as Array<{ fact: string; source_message: string }>;
+    expect(rows).toEqual([{ fact: "用户偏好 TypeScript", source_message: "0123456789" }]);
+
+    raw.close();
+    db.close();
+  });
+
+  it("searches memories within the current user only", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-memory-db-"));
+    const dbPath = path.join(dir, "memory.db");
+    const db = new MemoryDb(dbPath, 10, 50);
+
+    db.add("u1", ["user likes typescript", "user uses vitest"], "source 1");
+    db.add("u2", ["user likes typescript"], "source 2");
+
+    expect(db.search("u1", "typescript", 5)).toEqual(["user likes typescript"]);
+    expect(db.search("u2", "typescript", 5)).toEqual(["user likes typescript"]);
+    expect(db.search("u1", "nonexistent", 5)).toEqual([]);
+
+    db.close();
+  });
+
+  it("evicts least recently accessed facts when over the per-user limit", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-memory-db-"));
+    const dbPath = path.join(dir, "memory.db");
+    const db = new MemoryDb(dbPath, 2, 50);
+
+    db.add("u1", ["fact one"], "source 1");
+    db.add("u1", ["fact two"], "source 2");
+    db.add("u1", ["fact three"], "source 3");
+
+    const raw = new Database(dbPath, { readonly: true });
+    const row = raw.prepare("SELECT COUNT(*) as count FROM memories WHERE user_id = ?").get("u1") as { count: number };
+    expect(row.count).toBe(2);
+
+    raw.close();
+    db.close();
+  });
+});

--- a/test/memory-extractor.test.ts
+++ b/test/memory-extractor.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { OpenCodeMemoryExtractor } from "../src/memory/extractor.js";
+import { OpenCodeClient } from "../src/opencode/client.js";
+
+describe("OpenCodeMemoryExtractor", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to async polling when postMessageSync does not return usable text", async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ id: "ses_sync" }))
+      .mockResolvedValueOnce(jsonResponse({
+        info: { role: "assistant" },
+        parts: [],
+      }))
+      .mockResolvedValueOnce(jsonResponse({ id: "ses_async" }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse([{
+        info: { role: "assistant", finish: "stop" },
+        parts: [{ type: "text", text: "用户偏好 TypeScript" }],
+      }]));
+    vi.stubGlobal("fetch", fetch);
+
+    const extractor = new OpenCodeMemoryExtractor(
+      new OpenCodeClient(new URL("http://127.0.0.1:4096/")),
+      { log() {}, logTranscript() {} } as any,
+    );
+
+    const facts = await extractor.extract("我喜欢 TypeScript", "好的");
+
+    expect(facts).toEqual(["用户偏好 TypeScript"]);
+    expect(fetch.mock.calls.some((call) => String(call[0]).includes("/prompt_async"))).toBe(true);
+    expect(fetch.mock.calls.filter((call) => String(call[0]).includes("/message?limit=50")).length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/test/memory-retriever.test.ts
+++ b/test/memory-retriever.test.ts
@@ -1,0 +1,96 @@
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { MemoryDb } from "../src/memory/db.js";
+import { cosineSimilarity, EmbeddingRetriever, type EmbeddingProviderClient } from "../src/memory/embedding-retriever.js";
+import { RecentRetriever } from "../src/memory/recent-retriever.js";
+
+describe("memory retrievers", () => {
+  it("recent retriever returns most recently accessed facts", async () => {
+    const db = new MemoryDb(await tempDbPath(), 500, 50);
+    db.saveFacts("ou_1", [{ fact: "用户喜欢 TypeScript", sourceMessage: "消息 1" }]);
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    db.saveFacts("ou_1", [{ fact: "用户维护 bridge", sourceMessage: "消息 2" }]);
+
+    const retriever = new RecentRetriever(db);
+    const facts = await retriever.recall("ou_1", "随便", 2);
+    db.close();
+
+    expect(facts).toEqual(["用户维护 bridge", "用户喜欢 TypeScript"]);
+  });
+
+  it("embedding retriever returns semantic hits for the current model", async () => {
+    const db = new MemoryDb(await tempDbPath(), 500, 50);
+    const ids = db.saveFacts("ou_1", [
+      { fact: "用户喜欢 AI 科技新闻", sourceMessage: "科技新闻" },
+      { fact: "用户关注 TypeScript", sourceMessage: "ts" },
+    ]);
+    db.updateEmbedding(ids[0]!, [1, 0], "model-a");
+    db.updateEmbedding(ids[1]!, [0, 1], "model-a");
+
+    const retriever = new EmbeddingRetriever(
+      db,
+      fixedEmbeddingClient("model-a", [1, 0]),
+      new RecentRetriever(db),
+      0.75,
+      logger(),
+    );
+    const facts = await retriever.recall("ou_1", "新闻偏好", 2);
+    db.close();
+
+    expect(facts).toEqual(["用户喜欢 AI 科技新闻"]);
+  });
+
+  it("embedding retriever falls back to recent when query embedding fails", async () => {
+    const db = new MemoryDb(await tempDbPath(), 500, 50);
+    db.saveFacts("ou_1", [{ fact: "用户喜欢 AI 科技新闻", sourceMessage: "科技新闻" }]);
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    db.saveFacts("ou_1", [{ fact: "用户关注 TypeScript", sourceMessage: "ts" }]);
+
+    const retriever = new EmbeddingRetriever(
+      db,
+      {
+        model: "model-a",
+        async embed(): Promise<number[]> {
+          throw new Error("boom");
+        },
+      },
+      new RecentRetriever(db),
+      0.75,
+      logger(),
+    );
+    const facts = await retriever.recall("ou_1", "新闻偏好", 1);
+    db.close();
+
+    expect(facts).toEqual(["用户关注 TypeScript"]);
+  });
+
+  it("calculates cosine similarity", () => {
+    expect(cosineSimilarity([1, 0], [1, 0])).toBeCloseTo(1);
+    expect(cosineSimilarity([1, 0], [0, 1])).toBeCloseTo(0);
+  });
+});
+
+async function tempDbPath(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-memory-retriever-"));
+  return path.join(dir, "memory.db");
+}
+
+function fixedEmbeddingClient(model: string, embedding: number[]): EmbeddingProviderClient {
+  return {
+    model,
+    async embed(): Promise<number[]> {
+      return embedding;
+    },
+  };
+}
+
+function logger() {
+  return {
+    log: vi.fn(),
+    logTranscript: vi.fn(),
+  };
+}

--- a/test/memory-service.test.ts
+++ b/test/memory-service.test.ts
@@ -25,6 +25,13 @@ function makeConfig(dbPath: string, overrides: Partial<{
     extractQueueLimit: overrides.extractQueueLimit ?? 10,
     sourcePreviewLength: overrides.sourcePreviewLength ?? 50,
     shutdownDrainTimeoutMs: overrides.shutdownDrainTimeoutMs ?? 1_000,
+    retriever: "recent" as const,
+    embeddingSimilarityThreshold: 0.75,
+    obsidian: {
+      enabled: false,
+      syncCron: "0 2 * * *",
+      enableWikiLinks: false,
+    },
   };
 }
 
@@ -67,9 +74,9 @@ describe("MemoryService", () => {
     await service.drain(1_000);
 
     expect(events).toEqual(["start:first", "end:first", "start:second", "end:second"]);
-    expect(service.buildRecallBlock("u1", "second")).toContain("用户记录 second");
+    await expect(service.buildRecallBlock("u1", "second")).resolves.toContain("用户记录 second");
 
-    service.close();
+    await service.stop();
   });
 
   it("drops new learn tasks when the queue is full", async () => {
@@ -95,9 +102,9 @@ describe("MemoryService", () => {
     await service.drain(1_000);
 
     expect(seen).toEqual(["first", "second"]);
-    expect(service.buildRecallBlock("u1", "third")).not.toContain("用户记录 third");
+    await expect(service.buildRecallBlock("u1", "third")).resolves.not.toContain("用户记录 third");
 
-    service.close();
+    await service.stop();
   });
 });
 

--- a/test/memory-service.test.ts
+++ b/test/memory-service.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 
 import { MemoryService, appendSystemBlock, formatRecallBlock } from "../src/memory/index.js";
 import type { MemoryExtractor } from "../src/memory/extractor.js";
+import { MemoryDb } from "../src/memory/db.js";
 import { OpenCodeClient } from "../src/opencode/client.js";
 
 const logger = { log() {}, logTranscript() {} };
@@ -103,6 +104,65 @@ describe("MemoryService", () => {
 
     expect(seen).toEqual(["first", "second"]);
     await expect(service.buildRecallBlock("u1", "third")).resolves.not.toContain("用户记录 third");
+
+    await service.stop();
+  });
+
+  it("drains queued learn tasks before shutdown closes the db", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-memory-service-"));
+    const dbPath = path.join(dir, "memory.db");
+    const extractor: MemoryExtractor = {
+      async extract(userMessage) {
+        await sleep(10);
+        return [`用户记录 ${userMessage}`];
+      },
+    };
+    const service = new MemoryService(
+      makeConfig(dbPath),
+      new OpenCodeClient(new URL("http://127.0.0.1:4096/")),
+      logger as any,
+      extractor,
+    );
+
+    service.enqueueLearn("u1", "pending", "reply");
+    await service.stop();
+
+    const db = new MemoryDb(dbPath, 10, 50);
+    expect(db.search("u1", "pending", 5)).toContain("用户记录 pending");
+    db.close();
+  });
+
+  it("updates embeddings against the deduped fact list", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-memory-service-"));
+    const dbPath = path.join(dir, "memory.db");
+    const extractor: MemoryExtractor = {
+      async extract() {
+        return ["重复事实", "重复事实", "唯一事实"];
+      },
+    };
+    const service = new MemoryService(
+      makeConfig(dbPath, {
+      }),
+      new OpenCodeClient(new URL("http://127.0.0.1:4096/")),
+      logger as any,
+      extractor,
+    );
+    (service as any).embeddingClient = {
+      model: "model-a",
+      async embed(text: string) {
+        return text === "重复事实" ? [1, 0] : [0, 1];
+      },
+    };
+
+    service.enqueueLearn("u1", "message", "reply");
+    await service.drain(1_000);
+
+    const candidates = (service as any).db.listEmbeddingCandidates("u1", "model-a");
+    expect(candidates).toHaveLength(2);
+    expect(candidates).toEqual(expect.arrayContaining([
+      expect.objectContaining({ fact: "重复事实", embedding: [1, 0] }),
+      expect.objectContaining({ fact: "唯一事实", embedding: [0, 1] }),
+    ]));
 
     await service.stop();
   });

--- a/test/memory-service.test.ts
+++ b/test/memory-service.test.ts
@@ -1,0 +1,108 @@
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { MemoryService, appendSystemBlock, formatRecallBlock } from "../src/memory/index.js";
+import type { MemoryExtractor } from "../src/memory/extractor.js";
+import { OpenCodeClient } from "../src/opencode/client.js";
+
+const logger = { log() {}, logTranscript() {} };
+
+function makeConfig(dbPath: string, overrides: Partial<{
+  maxMemoriesPerUser: number;
+  searchLimit: number;
+  extractQueueLimit: number;
+  sourcePreviewLength: number;
+  shutdownDrainTimeoutMs: number;
+}> = {}) {
+  return {
+    enabled: true,
+    dbPath,
+    maxMemoriesPerUser: overrides.maxMemoriesPerUser ?? 10,
+    searchLimit: overrides.searchLimit ?? 5,
+    extractQueueLimit: overrides.extractQueueLimit ?? 10,
+    sourcePreviewLength: overrides.sourcePreviewLength ?? 50,
+    shutdownDrainTimeoutMs: overrides.shutdownDrainTimeoutMs ?? 1_000,
+  };
+}
+
+describe("MemoryService", () => {
+  it("formats recall blocks and appends them to existing system prompts", () => {
+    expect(formatRecallBlock(["用户偏好 TypeScript", "用户使用 Vitest"])).toBe([
+      "[Memory Recall]",
+      "- 用户偏好 TypeScript",
+      "- 用户使用 Vitest",
+    ].join("\n"));
+    expect(appendSystemBlock("[Bridge State]\nhello", "[Memory Recall]\n- 用户偏好 TypeScript")).toBe([
+      "[Bridge State]",
+      "hello",
+      "",
+      "[Memory Recall]",
+      "- 用户偏好 TypeScript",
+    ].join("\n"));
+  });
+
+  it("processes learn tasks sequentially and recalls saved facts", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-memory-service-"));
+    const events: string[] = [];
+    const extractor: MemoryExtractor = {
+      async extract(userMessage) {
+        events.push(`start:${userMessage}`);
+        await sleep(10);
+        events.push(`end:${userMessage}`);
+        return [`用户记录 ${userMessage}`];
+      },
+    };
+    const service = new MemoryService(
+      makeConfig(path.join(dir, "memory.db")),
+      new OpenCodeClient(new URL("http://127.0.0.1:4096/")),
+      logger as any,
+      extractor,
+    );
+
+    service.enqueueLearn("u1", "first", "reply 1");
+    service.enqueueLearn("u1", "second", "reply 2");
+    await service.drain(1_000);
+
+    expect(events).toEqual(["start:first", "end:first", "start:second", "end:second"]);
+    expect(service.buildRecallBlock("u1", "second")).toContain("用户记录 second");
+
+    service.close();
+  });
+
+  it("drops new learn tasks when the queue is full", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-memory-service-"));
+    const seen: string[] = [];
+    const extractor: MemoryExtractor = {
+      async extract(userMessage) {
+        seen.push(userMessage);
+        await sleep(20);
+        return [`用户记录 ${userMessage}`];
+      },
+    };
+    const service = new MemoryService(
+      makeConfig(path.join(dir, "memory.db"), { extractQueueLimit: 1 }),
+      new OpenCodeClient(new URL("http://127.0.0.1:4096/")),
+      logger as any,
+      extractor,
+    );
+
+    service.enqueueLearn("u1", "first", "reply 1");
+    service.enqueueLearn("u1", "second", "reply 2");
+    service.enqueueLearn("u1", "third", "reply 3");
+    await service.drain(1_000);
+
+    expect(seen).toEqual(["first", "second"]);
+    expect(service.buildRecallBlock("u1", "third")).not.toContain("用户记录 third");
+
+    service.close();
+  });
+});
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/test/obsidian-sync.test.ts
+++ b/test/obsidian-sync.test.ts
@@ -1,0 +1,56 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { MemoryDb } from "../src/memory/db.js";
+import { buildProfileMarkdown, ObsidianSyncService } from "../src/memory/obsidian-sync.js";
+
+describe("ObsidianSyncService", () => {
+  it("writes profile markdown during startup catch-up", async () => {
+    const dbPath = await tempDbPath();
+    const vaultPath = await mkdtemp(path.join(os.tmpdir(), "bridge-vault-"));
+    const db = new MemoryDb(dbPath, 500, 50);
+    db.saveFacts("ou_1", [{ fact: "用户维护 feishu-opencode-bridge", sourceMessage: "bridge 项目" }]);
+    db.setObsidianLastSyncedAt(0);
+
+    const service = new ObsidianSyncService({
+      enabled: true,
+      vaultPath,
+      syncCron: "0 2 * * *",
+      enableWikiLinks: false,
+    }, db, logger());
+
+    await service.start();
+    await service.stop();
+    db.close();
+
+    const profile = await readFile(path.join(vaultPath, "memory", "ou_1", "profile.md"), "utf8");
+    expect(profile).toContain("# 用户记忆 ou_1");
+    expect(profile).toContain("用户维护 feishu-opencode-bridge");
+  });
+
+  it("optionally adds wiki links in the rendered markdown", () => {
+    const markdown = buildProfileMarkdown("ou_2", [{
+      id: 1,
+      fact: "用户维护 feishu-opencode-bridge",
+      createdAt: 1,
+      accessedAt: 1,
+    }], { enableWikiLinks: true });
+
+    expect(markdown).toContain("[[feishu-opencode-bridge]]");
+  });
+});
+
+async function tempDbPath(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-memory-obsidian-"));
+  return path.join(dir, "memory.db");
+}
+
+function logger() {
+  return {
+    log: vi.fn(),
+    logTranscript: vi.fn(),
+  };
+}


### PR DESCRIPTION
## 变更内容
- 新增长期用户记忆模块，使用 SQLite 按 `senderOpenId` 持久化存储可召回的事实记忆
- 在主回复链路中为 OpenCode 注入独立的 `[Memory Recall]` system 块，并在 turn 成功结束后异步学习新的用户事实
- 增加记忆模块配置项、运行时优雅停机处理，以及配套的中英文文档和示例配置说明
- 补充 memory db、extractor、service 的测试覆盖，并引入 `better-sqlite3` 作为存储依赖

## 变更原因
现有 bridge 只能依赖当前窗口上下文处理消息，缺少跨会话、跨时间维度保留用户事实信息的能力，导致一些稳定偏好或背景信息无法被持续复用。

## 影响
bridge 现在可以在不污染用户正文的前提下，为同一用户注入长期记忆召回结果，并在回复完成后异步沉淀新的事实信息；启用后会额外依赖本地 SQLite 存储，但不会阻塞主回复路径。

## 验证
- `npm test`
- `npm run typecheck`
- `npm run lint`