### PR TITLE
[codex] 新增群聊白名单绑定能力

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It listens to Feishu message events over WebSocket, maps each conversation to an
 - Streams progress into a Feishu interactive card and updates the same message in place
 - Supports strict or relaxed group mention matching through config
 - Supports multiple bot identities and separate self-bot identities
+- Supports per-group whitelist binding so users can continue without re-mentioning the bot
 - Deduplicates repeated Feishu message deliveries by `message_id`
 - Persists Feishu conversation to OpenCode session bindings with LRU trimming
 - Supports OpenCode Basic Auth through `OPENCODE_SERVER_PASSWORD`
@@ -90,6 +91,9 @@ Copy the example config and fill in your real values:
     "dataDir": "./data",
     "mappingsFile": "mappings.json"
   },
+  "whitelist": {
+    "storePath": "whitelist.json"
+  },
   "bridge": {
     "queueLimit": 3,
     "sessions": {
@@ -135,6 +139,13 @@ Copy the example config and fill in your real values:
 When `requireBotMentionInGroup=true`, group messages are handled only when they match your configured bot identity rules.
 
 When `strictBotMention=true`, the bridge only accepts messages that explicitly mention one of the configured bot identities.
+
+### Group whitelist binding
+
+- In `group` and `topic_group`, a user is added to the group whitelist when they send a normal message that mentions the bot.
+- Once bound, the same user can continue in the same Feishu `chat_id` without mentioning the bot again, including inside topic threads.
+- `/leave` removes the current user from the group whitelist.
+- `/who` shows the current group binding count and whether the caller is already bound.
 
 ### Session modes
 
@@ -183,6 +194,8 @@ Supported slash commands:
 - `/status`
 - `/abort`
 - `/models`
+- `/leave`
+- `/who`
 - `/sessions`
 - `/switch <index>`
 - `/sessions <index>`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,6 +13,7 @@ Feishu OpenCode Bridge 是一个独立运行的 TypeScript 服务，用来把飞
 - 使用飞书交互卡片承载过程消息，并持续更新同一条回复
 - 群聊 `@` 规则支持通过配置控制严格或宽松模式
 - 支持多个机器人身份，以及“触发身份”和“自身身份”分离
+- 支持按群维度的白名单绑定，首次 `@ bot` 后可免 `@` 继续对话
 - 按 `message_id` 去重飞书重复投递
 - 通过 LRU 持久化保存飞书对话到 OpenCode session 的绑定关系
 - 支持使用 `OPENCODE_SERVER_PASSWORD` 访问带鉴权的 OpenCode 服务
@@ -90,6 +91,9 @@ npm install
     "dataDir": "./data",
     "mappingsFile": "mappings.json"
   },
+  "whitelist": {
+    "storePath": "whitelist.json"
+  },
   "bridge": {
     "queueLimit": 3,
     "sessions": {
@@ -136,6 +140,13 @@ npm install
 
 当 `strictBotMention=true` 时，只接受明确命中已配置机器人身份的消息。
 
+### 群聊白名单绑定
+
+- 在 `group` 和 `topic_group` 中，用户首次发送普通消息并 `@ bot` 后，会写入当前群的白名单。
+- 绑定后，同一 `chat_id` 下的群主窗口和话题窗口都可以免 `@` 继续对话。
+- `/leave` 用于解除当前用户在该群里的绑定。
+- `/who` 会显示当前群绑定人数，以及你自己是否已绑定。
+
 ### 会话模式
 
 - `p2pMode`、`groupMode`、`topicGroupMode` 用来控制窗口采用 `single` 还是 `multi` 模式。
@@ -181,6 +192,8 @@ npm run dev:once
 - `/status`
 - `/abort`
 - `/models`
+- `/leave`
+- `/who`
 - `/sessions`
 - `/switch <编号>`
 - `/sessions <编号>`

--- a/config.example.json
+++ b/config.example.json
@@ -26,6 +26,9 @@
     "dataDir": "./data",
     "mappingsFile": "mappings.json"
   },
+  "whitelist": {
+    "storePath": "whitelist.json"
+  },
   "bridge": {
     "queueLimit": 3,
     "sessions": {

--- a/src/bridge/router.ts
+++ b/src/bridge/router.ts
@@ -6,6 +6,8 @@ export type RoutedText =
       | { kind: "status" }
       | { kind: "abort" }
       | { kind: "models" }
+      | { kind: "leave" }
+      | { kind: "who" }
       | { kind: "sessions" }
       | { kind: "sessions-select"; index: number }
       | { kind: "allow"; policy: "once" | "always" }
@@ -15,7 +17,7 @@ export type RoutedText =
   | { kind: "message"; text: string };
 
 export function routeIncomingText(text: string): RoutedText {
-  const normalized = text.trim();
+  const normalized = normalizeCommandCandidate(text);
   if (!normalized.startsWith("/")) {
     return { kind: "message", text };
   }
@@ -38,6 +40,14 @@ export function routeIncomingText(text: string): RoutedText {
 
   if (rawCommand === "models" && args.length === 0) {
     return { kind: "command", command: { kind: "models" } };
+  }
+
+  if (rawCommand === "leave" && args.length === 0) {
+    return { kind: "command", command: { kind: "leave" } };
+  }
+
+  if (rawCommand === "who" && args.length === 0) {
+    return { kind: "command", command: { kind: "who" } };
   }
 
   if (rawCommand === "sessions" && args.length === 0) {
@@ -77,4 +87,18 @@ export function routeIncomingText(text: string): RoutedText {
       arguments: args,
     },
   };
+}
+
+function normalizeCommandCandidate(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.startsWith("/")) {
+    return trimmed;
+  }
+
+  const mentionWrapped = trimmed.match(/^@(.+)\s+(\/\S[\s\S]*)$/);
+  if (!mentionWrapped) {
+    return trimmed;
+  }
+
+  return mentionWrapped[2]?.trim() ?? trimmed;
 }

--- a/src/bridge/router.ts
+++ b/src/bridge/router.ts
@@ -90,7 +90,7 @@ export function routeIncomingText(text: string): RoutedText {
 }
 
 function normalizeCommandCandidate(text: string): string {
-  const trimmed = text.trim();
+  const trimmed = stripVisibleMentionPrefix(text.trim());
   if (trimmed.startsWith("/")) {
     return trimmed;
   }
@@ -101,4 +101,9 @@ function normalizeCommandCandidate(text: string): string {
   }
 
   return mentionWrapped[2]?.trim() ?? trimmed;
+}
+
+function stripVisibleMentionPrefix(text: string): string {
+  const match = text.match(/^@.+?\s+(\/.+)$/);
+  return match?.[1]?.trim() ?? text;
 }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -42,6 +42,9 @@ export async function loadConfig(configPath?: string): Promise<AppConfig> {
       dataDir,
       mappingsFile: parsed.storage.mappingsFile,
     },
+    whitelist: {
+      storePath: resolveRelative(dataDir, parsed.whitelist.storePath),
+    },
     bridge: {
       queueLimit: parsed.bridge.queueLimit,
       sessionModes: {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -30,6 +30,9 @@ export const ConfigSchema = z.object({
     dataDir: z.string().min(1).default("./data"),
     mappingsFile: z.string().min(1).default("mappings.json"),
   }),
+  whitelist: z.object({
+    storePath: z.string().min(1).default("whitelist.json"),
+  }).default({}),
   bridge: z.object({
     queueLimit: z.number().int().positive().default(3),
     sessions: z.object({
@@ -83,6 +86,9 @@ export type AppConfig = {
   storage: {
     dataDir: string;
     mappingsFile: string;
+  };
+  whitelist: {
+    storePath: string;
   };
   bridge: {
     queueLimit: number;

--- a/src/feishu/formatter.ts
+++ b/src/feishu/formatter.ts
@@ -27,6 +27,45 @@ export type TurnStatusCardView = {
   output: OutputView;
 };
 
+export type StatusCommandCardView = {
+  currentSession: { sessionId: string; label: string } | null;
+  connectionState: string;
+  sessionMode: string;
+  sessionState: string;
+  queueState: string;
+  pendingCount: number;
+  windowCount: number;
+};
+
+export type SessionListCardView = {
+  items: Array<{
+    index: number;
+    title: string;
+    current?: boolean;
+    archived?: boolean;
+    meta?: string;
+  }>;
+  footer: string;
+  emptyText?: string;
+};
+
+export type SessionTransitionCardView = {
+  title: string;
+  iconToken: string;
+  previousLabel?: string | null;
+  currentLabel: string;
+  footer: string;
+};
+
+export type WhoCommandCardView = {
+  boundCount: number;
+  isBound: boolean;
+};
+
+export type LeaveCommandCardView = {
+  unbound: boolean;
+};
+
 export function buildQueueNoticePayload(notice: QueueNotice): FeishuPostPayload {
   return buildPostMarkdownPayload(notice.message);
 }
@@ -56,9 +95,188 @@ export function buildPostPayload(title: string, text: string): FeishuPostPayload
 }
 
 export function buildTurnStatusCardPayload(view: TurnStatusCardView): FeishuPostPayload {
-  const progressUpdate = formatCurrentProgress(view.progressUpdates);
+  const state = resolveCardState(view.status);
   const toolElements = buildToolElements(view.toolUpdates);
-  const outputElements = buildOutputElements(view.output);
+  const outputElements = buildOutputElements(view.output, state);
+  return buildInteractivePayload({
+    title: state.title,
+    template: state.template,
+    iconToken: state.headerIconToken,
+    bodyElements: buildTurnBodyElements(state, toolElements, outputElements, view),
+  });
+}
+
+export function buildStatusCommandCardPayload(view: StatusCommandCardView): FeishuPostPayload {
+  return buildInteractivePayload({
+    title: "会话状态",
+    template: "wathet",
+    iconToken: "insert-chart_outlined",
+    bodyElements: [
+      buildStatusCurrentSessionBlock(view.currentSession),
+      buildStatusSystemBlock(view),
+      buildDivider(),
+      buildFooterTipBlock("`/sessions` 查看全部   `/new` 新建会话", "efficiency_outlined", "green", "normal_v2"),
+    ],
+  });
+}
+
+export function buildSessionListCardPayload(view: SessionListCardView): FeishuPostPayload {
+  const bodyElements = view.items.length === 0
+    ? [
+      buildEmptyStateBlock(view.emptyText ?? "暂无会话"),
+      buildDivider(),
+      buildFooterTipBlock(view.footer, "efficiency_outlined", "green", "normal_v2"),
+    ]
+    : [
+      ...view.items.map((item) => buildSessionListItemBlock(item)),
+      buildDivider(),
+      buildFooterTipBlock(view.footer, "efficiency_outlined", "green", "normal_v2"),
+    ];
+
+  return buildInteractivePayload({
+    title: "会话列表",
+    template: "wathet",
+    iconToken: "chat_filled",
+    bodyElements,
+  });
+}
+
+export function buildSessionTransitionCardPayload(view: SessionTransitionCardView): FeishuPostPayload {
+  const bodyElements: Array<Record<string, unknown>> = [];
+  if (view.previousLabel) {
+    bodyElements.push(buildSessionTransitionRow("离开", `~~${escapeText(view.previousLabel)}~~`, "grey-50"));
+  }
+  bodyElements.push(buildSessionTransitionRow("当前", `**${escapeText(view.currentLabel)}**`, "green-50"));
+  bodyElements.push(buildDivider());
+  bodyElements.push(buildFooterTipBlock(view.footer, "calendar-add_outlined", "green", "notation"));
+
+  return buildInteractivePayload({
+    title: view.title,
+    template: "green",
+    iconToken: view.iconToken,
+    bodyElements,
+  });
+}
+
+export function buildWhoCommandCardPayload(view: WhoCommandCardView): FeishuPostPayload {
+  return buildInteractivePayload({
+    title: "群聊绑定状态",
+    template: "blue",
+    iconToken: "group_filled",
+    bodyElements: [
+      buildTwoColumnBadgeRow("已绑定人数", `**${view.boundCount} 人**`, "member_filled", "blue", "wathet-100"),
+      buildTwoColumnBadgeRow("你的状态", view.isBound ? "**已绑定**" : "**未绑定**", view.isBound ? "yes_filled" : "error_filled", view.isBound ? "green" : "red", view.isBound ? "green-50" : "red-50"),
+      buildDivider(),
+      buildFooterTipBlock(view.isBound ? "发送 `/leave` 可解除绑定" : "@bot 并发送任意消息即可绑定", "info-hollow_filled", "grey", "notation"),
+    ],
+  });
+}
+
+export function buildLeaveCommandCardPayload(view: LeaveCommandCardView): FeishuPostPayload {
+  return buildInteractivePayload({
+    title: view.unbound ? "已解除绑定" : "无需解除绑定",
+    template: "grey",
+    iconToken: view.unbound ? "leaveroom_filled" : "info_filled",
+    bodyElements: [
+      {
+        tag: "column_set",
+        horizontal_spacing: "8px",
+        horizontal_align: "left",
+        columns: [
+          {
+            tag: "column",
+            width: "auto",
+            elements: [
+              {
+                tag: "markdown",
+                content: view.unbound
+                  ? "后续消息不再响应，发送任意消息并 `@bot` 可重新绑定。"
+                  : "当前群里你尚未绑定，无需解除。",
+                text_align: "left",
+                text_size: "normal_v2",
+                margin: "0px 0px 0px 0px",
+                icon: {
+                  tag: "standard_icon",
+                  token: view.unbound ? "clear_outlined" : "info-hollow_filled",
+                  color: "grey",
+                },
+              },
+            ],
+            padding: "8px 8px 8px 8px",
+            direction: "vertical",
+            horizontal_spacing: "8px",
+            vertical_spacing: "8px",
+            horizontal_align: "left",
+            vertical_align: "top",
+            margin: "0px 0px 0px 0px",
+          },
+        ],
+        margin: "0px 0px 0px 0px",
+      },
+    ],
+  });
+}
+
+function shortSessionId(sessionId: string): string {
+  return sessionId.length <= 12 ? sessionId : sessionId.slice(0, 12);
+}
+
+type CardState = {
+  kind: "running" | "completed" | "error";
+  title: string;
+  template: "blue" | "green" | "red";
+  headerIconToken: string;
+};
+
+function resolveCardState(status: string): CardState {
+  if (status.includes("失败") || status.includes("超时") || status.includes("中止")) {
+    return {
+      kind: "error",
+      title: "出了点问题",
+      template: "red",
+      headerIconToken: "error_filled",
+    };
+  }
+  if (status.includes("完成")) {
+    return {
+      kind: "completed",
+      title: "已完成",
+      template: "green",
+      headerIconToken: "thumbsup_filled",
+    };
+  }
+  return {
+    kind: "running",
+    title: "正在忙",
+    template: "blue",
+    headerIconToken: "external_filled",
+  };
+}
+
+function buildTurnBodyElements(
+  state: CardState,
+  toolElements: Array<Record<string, unknown>>,
+  outputElements: Array<Record<string, unknown>>,
+  view: TurnStatusCardView,
+): Array<Record<string, unknown>> {
+  const elements: Array<Record<string, unknown>> = [];
+
+  if (state.kind !== "completed" && toolElements.length > 0) {
+    elements.push(buildToolBlock(toolElements));
+  }
+
+  elements.push(buildOutputBlock(outputElements));
+  elements.push(buildSpacerBlock());
+  elements.push(buildFooter(view.sessionId, view.durationText));
+  return elements;
+}
+
+function buildInteractivePayload(options: {
+  title: string;
+  template: "blue" | "green" | "red" | "wathet" | "grey";
+  iconToken: string;
+  bodyElements: Array<Record<string, unknown>>;
+}): FeishuPostPayload {
   return {
     msg_type: "interactive",
     content: JSON.stringify({
@@ -69,17 +287,21 @@ export function buildTurnStatusCardPayload(view: TurnStatusCardView): FeishuPost
           text_size: {
             normal_v2: {
               default: "normal",
-              mobile: "normal",
+              mobile: "heading",
               pc: "normal",
             },
           },
         },
       },
       header: {
-        padding: "12px 8px 12px 8px",
+        padding: "12px 12px 12px 12px",
         subtitle: { tag: "plain_text", content: "" },
-        template: mapCardTemplate(view.status),
-        title: { tag: "plain_text", content: mapHeaderTitle(view.status) },
+        template: options.template,
+        title: { tag: "plain_text", content: options.title },
+        icon: {
+          tag: "standard_icon",
+          token: options.iconToken,
+        },
       },
       body: {
         direction: "vertical",
@@ -87,181 +309,512 @@ export function buildTurnStatusCardPayload(view: TurnStatusCardView): FeishuPost
         vertical_spacing: "8px",
         horizontal_align: "left",
         vertical_align: "top",
-        elements: [
-          {
-            tag: "column_set",
-            flex_mode: "stretch",
-            horizontal_spacing: "12px",
-            horizontal_align: "left",
-            margin: "0px 0px 0px 0px",
-            columns: [
-              {
-                tag: "column",
-                width: "weighted",
-                weight: 1,
-                horizontal_align: "left",
-                vertical_align: "top",
-                vertical_spacing: "8px",
-                elements: [{ tag: "markdown", content: `**会话 ID**：\`${escapeText(shortSessionId(view.sessionId))}\``, text_align: "left", text_size: "normal_v2" }],
-              },
-              {
-                tag: "column",
-                width: "weighted",
-                weight: 1,
-                horizontal_align: "left",
-                vertical_align: "top",
-                vertical_spacing: "8px",
-                elements: [{ tag: "markdown", content: view.durationText ? `⏱ **耗时**：${escapeText(view.durationText)}` : "", text_align: "left", text_size: "normal_v2" }],
-              },
-            ],
-          },
-          { tag: "hr", margin: "0px 0px 0px 0px" },
-          { tag: "markdown", content: "📋 **执行进度**", margin: "0px 0px 0px 0px" },
-          {
-            tag: "column_set",
-            flex_mode: "stretch",
-            horizontal_spacing: "12px",
-            horizontal_align: "left",
-            margin: "0px 0px 0px 0px",
-            columns: [{
-              tag: "column",
-              width: "weighted",
-              weight: 1,
-              background_style: mapProgressBackground(view.status),
-              padding: "12px 12px 12px 12px",
-              direction: "vertical",
-              horizontal_align: "left",
-              vertical_align: "top",
-              vertical_spacing: "4px",
-              elements: [{ tag: "markdown", content: progressUpdate, text_align: "left", text_size: "normal_v2" }],
-            }],
-          },
-          ...(toolElements.length > 0
-            ? [
-              { tag: "hr", margin: "0px 0px 0px 0px" },
-              { tag: "markdown", content: "🔧 **工具调用**", margin: "0px 0px 0px 0px" },
-              {
-                tag: "column_set",
-                flex_mode: "stretch",
-                horizontal_spacing: "12px",
-                horizontal_align: "left",
-                margin: "0px 0px 0px 0px",
-                columns: [{
-                  tag: "column",
-                  width: "weighted",
-                  weight: 1,
-                  background_style: "grey-50",
-                  padding: "12px 12px 12px 12px",
-                  horizontal_align: "left",
-                  vertical_align: "top",
-                  vertical_spacing: "4px",
-                  elements: toolElements,
-                }],
-              },
-            ]
-            : []),
-          { tag: "hr", margin: "0px 0px 0px 0px" },
-          { tag: "markdown", content: "💬 **输出结果**", margin: "0px 0px 0px 0px" },
-          {
-            tag: "column_set",
-            flex_mode: "stretch",
-            horizontal_spacing: "12px",
-            horizontal_align: "left",
-            margin: "0px 0px 0px 0px",
-            columns: [{
-              tag: "column",
-              width: "weighted",
-              weight: 1,
-              horizontal_align: "left",
-              vertical_align: "top",
-              vertical_spacing: "8px",
-              elements: outputElements,
-            }],
-          },
-        ],
+        elements: options.bodyElements,
       },
     }),
   };
 }
 
-function mapCardTemplate(status: string): string {
-  if (status.includes("失败") || status.includes("超时") || status.includes("中止")) return "red";
-  if (status.includes("完成")) return "green";
-  return "blue";
-}
-
-function mapHeaderTitle(status: string): string {
-  if (status.includes("失败") || status.includes("超时") || status.includes("中止")) return "任务异常";
-  if (status.includes("完成")) return "任务已完成";
-  return "任务进行中";
-}
-
-function mapProgressBackground(status: string): string {
-  if (status.includes("失败") || status.includes("超时") || status.includes("中止")) return "red-50";
-  if (status.includes("完成")) return "green-50";
-  return "blue-50";
-}
-
-function shortSessionId(sessionId: string): string {
-  return sessionId.length <= 12 ? sessionId : sessionId.slice(0, 12);
-}
-
-function formatCurrentProgress(lines: readonly string[]): string {
-  const line = lines.length === 0 ? "等待 OpenCode 事件" : lines[lines.length - 1] ?? "等待 OpenCode 事件";
-  return toProgressLine(line);
-}
-
-function toProgressLine(line: string): string {
-  if (line.includes("已创建会话")) return "⏳ **已创建会话** — 等待 OpenCode 事件";
-  if (line.includes("最终回复已生成（")) return `✅ **生成最终回复** — ${escapeText(line.replace("最终回复已生成", "").trim())}`;
-  if (line.includes("检索")) return "✅ **检索相关信息** — 已完成";
-  if (line.includes("上下文") || line.includes("整理")) return "✅ **整理上下文** — 已完成";
-  if (line.includes("收到你的回答")) return "✅ **接收补充信息** — 已完成";
-  return `⏳ **${escapeText(line)}** — 处理中`;
-}
-
-function buildToolElements(lines: ReadonlyArray<ToolUpdateView>): Array<Record<string, string>> {
-  return lines.map((line) => ({
+function buildToolElements(lines: ReadonlyArray<ToolUpdateView>): Array<Record<string, unknown>> {
+  return lines.slice(-3).map((line) => ({
     tag: "markdown",
     content: formatToolDisplay(line),
     text_align: "left",
-    text_size: "normal_v2",
+    text_size: "normal",
+    icon: mapToolIcon(line.status),
   }));
 }
 
-function formatToolDisplay(line: ToolUpdateView): string {
-  const icon = mapToolStatusIcon(line.status);
-  return line.detail ? `${icon} **${escapeText(line.label)}**：${escapeText(line.detail)}` : `${icon} **${escapeText(line.label)}**`;
+function buildStatusCurrentSessionBlock(session: StatusCommandCardView["currentSession"]): Record<string, unknown> {
+  return {
+    tag: "column_set",
+    horizontal_spacing: "8px",
+    horizontal_align: "left",
+    columns: [
+      {
+        tag: "column",
+        width: "weighted",
+        elements: [
+          {
+            tag: "markdown",
+            content: "**当前会话**",
+            text_align: "left",
+            text_size: "normal",
+            margin: "0px 0px 0px 0px",
+            icon: {
+              tag: "standard_icon",
+              token: "reply-cn_outlined",
+              color: "grey",
+            },
+          },
+          {
+            tag: "column_set",
+            horizontal_spacing: "8px",
+            horizontal_align: "left",
+            columns: [
+              {
+                tag: "column",
+                width: "weighted",
+                elements: [
+                  {
+                    tag: "markdown",
+                    content: session ? `\`${escapeText(session.sessionId)}\`` : "未绑定",
+                    text_align: "left",
+                    text_size: "notation",
+                    margin: "0px 0px 0px 0px",
+                  },
+                  {
+                    tag: "column_set",
+                    horizontal_spacing: "8px",
+                    horizontal_align: "left",
+                    columns: [
+                      {
+                        tag: "column",
+                        width: "weighted",
+                        background_style: "grey-50",
+                        elements: [
+                          {
+                            tag: "markdown",
+                            content: session ? escapeText(session.label) : "当前窗口暂未绑定会话",
+                            text_align: "left",
+                            text_size: "normal_v2",
+                            margin: "0px 0px 0px 0px",
+                          },
+                        ],
+                        padding: "8px 8px 8px 8px",
+                        direction: "vertical",
+                        horizontal_spacing: "8px",
+                        vertical_spacing: "8px",
+                        horizontal_align: "left",
+                        vertical_align: "top",
+                        margin: "0px 0px 0px 0px",
+                        weight: 1,
+                      },
+                    ],
+                    margin: "0px 0px 0px 0px",
+                  },
+                ],
+                padding: "0px 0px 0px 0px",
+                direction: "vertical",
+                horizontal_spacing: "8px",
+                vertical_spacing: "8px",
+                horizontal_align: "left",
+                vertical_align: "top",
+                margin: "0px 0px 0px 0px",
+                weight: 1,
+              },
+            ],
+            margin: "0px 0px 0px 0px",
+          },
+        ],
+        padding: "8px 8px 8px 8px",
+        direction: "vertical",
+        horizontal_spacing: "8px",
+        vertical_spacing: "8px",
+        horizontal_align: "left",
+        vertical_align: "top",
+        margin: "0px 0px 0px 0px",
+        weight: 1,
+      },
+    ],
+    margin: "0px 0px 0px 0px",
+  };
 }
 
-function mapToolStatusIcon(status: ToolUpdateView["status"]): string {
+function buildStatusSystemBlock(view: StatusCommandCardView): Record<string, unknown> {
+  const chips = [
+    buildStatusChip(view.connectionState, "wathet-50"),
+    buildStatusChip(view.sessionState, mapStatusChipBackground(view.sessionState)),
+    buildStatusChip(view.queueState, view.queueState === "空闲" ? "green-50" : "wathet-50"),
+    buildStatusChip(`排队 ${view.pendingCount}`, "grey-50"),
+    buildStatusChip(`窗口 ${view.windowCount}`, "grey-50"),
+  ];
+
+  return {
+    tag: "column_set",
+    horizontal_spacing: "8px",
+    horizontal_align: "left",
+    columns: [
+      {
+        tag: "column",
+        width: "weighted",
+        elements: [
+          {
+            tag: "markdown",
+            content: "**系统状态**",
+            text_align: "left",
+            text_size: "normal_v2",
+            margin: "0px 0px 0px 0px",
+            icon: {
+              tag: "standard_icon",
+              token: "driveload_outlined",
+              color: "blue",
+            },
+          },
+          {
+            tag: "column_set",
+            flex_mode: "flow",
+            horizontal_spacing: "8px",
+            horizontal_align: "left",
+            columns: chips,
+            margin: "0px 0px 0px 0px",
+          },
+        ],
+        padding: "8px 8px 8px 8px",
+        direction: "vertical",
+        horizontal_spacing: "8px",
+        vertical_spacing: "8px",
+        horizontal_align: "left",
+        vertical_align: "top",
+        margin: "0px 0px 0px 0px",
+        weight: 1,
+      },
+    ],
+    margin: "0px 0px 0px 0px",
+  };
+}
+
+function buildStatusChip(text: string, backgroundStyle: string): Record<string, unknown> {
+  return {
+    tag: "column",
+    width: "weighted",
+    background_style: backgroundStyle,
+    elements: [
+      {
+        tag: "markdown",
+        content: escapeText(text),
+        text_align: "center",
+        text_size: "normal_v2",
+        margin: "0px 0px 0px 0px",
+      },
+    ],
+    padding: "8px 8px 8px 8px",
+    direction: "vertical",
+    horizontal_spacing: "8px",
+    vertical_spacing: "8px",
+    horizontal_align: "left",
+    vertical_align: "top",
+    margin: "0px 0px 0px 0px",
+    weight: 1,
+  };
+}
+
+function buildTwoColumnBadgeRow(
+  label: string,
+  value: string,
+  iconToken: string,
+  iconColor: string,
+  backgroundStyle: string,
+): Record<string, unknown> {
+  return {
+    tag: "column_set",
+    horizontal_spacing: "8px",
+    horizontal_align: "left",
+    columns: [
+      {
+        tag: "column",
+        width: "auto",
+        elements: [
+          {
+            tag: "markdown",
+            content: label,
+            text_align: "left",
+            text_size: "normal_v2",
+            margin: "0px 0px 0px 0px",
+          },
+        ],
+        padding: "8px 8px 8px 8px",
+        direction: "vertical",
+        horizontal_spacing: "8px",
+        vertical_spacing: "8px",
+        horizontal_align: "left",
+        vertical_align: "top",
+        margin: "0px 0px 0px 0px",
+      },
+      {
+        tag: "column",
+        width: "auto",
+        background_style: backgroundStyle,
+        elements: [
+          {
+            tag: "markdown",
+            content: value,
+            text_align: "left",
+            text_size: "normal_v2",
+            margin: "0px 0px 0px 0px",
+            icon: {
+              tag: "standard_icon",
+              token: iconToken,
+              color: iconColor,
+            },
+          },
+        ],
+        padding: "8px 8px 8px 8px",
+        direction: "vertical",
+        horizontal_spacing: "8px",
+        vertical_spacing: "8px",
+        horizontal_align: "left",
+        vertical_align: "top",
+        margin: "0px 0px 0px 0px",
+      },
+    ],
+    margin: "0px 0px 0px 0px",
+  };
+}
+
+function mapStatusChipBackground(status: string): string {
+  if (status === "idle" || status === "空闲") {
+    return "green-50";
+  }
+  if (status === "unbound" || status === "unknown") {
+    return "grey-50";
+  }
+  return "wathet-50";
+}
+
+function buildSessionListItemBlock(item: SessionListCardView["items"][number]): Record<string, unknown> {
+  return {
+    tag: "column_set",
+    horizontal_spacing: "8px",
+    horizontal_align: "left",
+    columns: [
+      {
+        tag: "column",
+        width: "weighted",
+        background_style: item.current ? "wathet-100" : item.archived ? "grey-50" : "bg-white",
+        elements: [
+          {
+            tag: "column_set",
+            horizontal_spacing: "8px",
+            horizontal_align: "left",
+            columns: [
+              {
+                tag: "column",
+                width: "20px",
+                elements: [{
+                  tag: "markdown",
+                  content: `#${item.index}`,
+                  text_align: "left",
+                  text_size: "normal_v2",
+                  margin: "0px 0px 0px 0px",
+                }],
+                vertical_align: "top",
+              },
+              {
+                tag: "column",
+                width: "weighted",
+                elements: [{
+                  tag: "markdown",
+                  content: formatSessionListTitle(item),
+                  text_align: "left",
+                  text_size: "normal_v2",
+                  margin: "0px 0px 0px 0px",
+                }],
+                vertical_align: "top",
+                weight: 1,
+              },
+              {
+                tag: "column",
+                width: "auto",
+                elements: [{
+                  tag: "markdown",
+                  content: item.current ? "当前" : escapeText(item.meta ?? ""),
+                  text_align: "right",
+                  text_size: "normal_v2",
+                  margin: "0px 0px 0px 0px",
+                }],
+                vertical_align: "top",
+              },
+            ],
+            margin: "0px 0px 0px 0px",
+          },
+        ],
+        padding: "8px 8px 8px 8px",
+        direction: "vertical",
+        horizontal_spacing: "8px",
+        vertical_spacing: "8px",
+        horizontal_align: "left",
+        vertical_align: "top",
+        margin: "0px 0px 0px 0px",
+        weight: 1,
+      },
+    ],
+    margin: "0px 0px 0px 0px",
+  };
+}
+
+function formatSessionListTitle(item: SessionListCardView["items"][number]): string {
+  const title = escapeText(item.title);
+  if (item.archived) {
+    return `~~${title}~~`;
+  }
+  if (item.current) {
+    return `**${title}**`;
+  }
+  return title;
+}
+
+function buildEmptyStateBlock(text: string): Record<string, unknown> {
+  return {
+    tag: "column_set",
+    horizontal_spacing: "8px",
+    horizontal_align: "center",
+    columns: [
+      {
+        tag: "column",
+        width: "weighted",
+        elements: [
+          {
+            tag: "markdown",
+            content: escapeText(text),
+            text_align: "center",
+            text_size: "normal_v2",
+            margin: "20px 20px 20px 20px",
+          },
+        ],
+        vertical_align: "top",
+        weight: 1,
+      },
+    ],
+    margin: "0px 0px 0px 0px",
+  };
+}
+
+function buildDivider(): Record<string, unknown> {
+  return {
+    tag: "hr",
+    margin: "0px 0px 0px 0px",
+  };
+}
+
+function buildFooterTipBlock(text: string, iconToken: string, iconColor: string, textSize: "notation" | "normal_v2"): Record<string, unknown> {
+  return {
+    tag: "column_set",
+    flex_mode: "stretch",
+    horizontal_spacing: "8px",
+    horizontal_align: "left",
+    columns: [
+      {
+        tag: "column",
+        width: "weighted",
+        elements: [
+          {
+            tag: "markdown",
+            content: text,
+            text_align: "left",
+            text_size: textSize,
+            margin: "0px 0px 0px 0px",
+            icon: {
+              tag: "standard_icon",
+              token: iconToken,
+              color: iconColor,
+            },
+          },
+        ],
+        padding: "8px 8px 8px 8px",
+        direction: "vertical",
+        horizontal_spacing: "8px",
+        vertical_spacing: "10px",
+        horizontal_align: "left",
+        vertical_align: "top",
+        margin: "0px 0px 0px 0px",
+        weight: 1,
+      },
+    ],
+    margin: "0px 0px 0px 0px",
+  };
+}
+
+function buildSessionTransitionRow(prefix: string, content: string, backgroundStyle: string): Record<string, unknown> {
+  return {
+    tag: "column_set",
+    background_style: backgroundStyle,
+    horizontal_spacing: "8px",
+    horizontal_align: "left",
+    columns: [
+      {
+        tag: "column",
+        width: "50px",
+        elements: [{
+          tag: "markdown",
+          content: prefix,
+          text_align: "center",
+          text_size: "normal_v2",
+          margin: "0px 0px 0px 0px",
+        }],
+        padding: "8px 8px 8px 8px",
+        direction: "vertical",
+        horizontal_spacing: "8px",
+        vertical_spacing: "8px",
+        horizontal_align: "left",
+        vertical_align: "top",
+        margin: "0px 0px 0px 0px",
+      },
+      {
+        tag: "column",
+        width: "weighted",
+        elements: [{
+          tag: "markdown",
+          content,
+          text_align: "left",
+          text_size: "normal_v2",
+          margin: "0px 0px 0px 0px",
+        }],
+        padding: "8px 8px 8px 8px",
+        direction: "vertical",
+        horizontal_spacing: "8px",
+        vertical_spacing: "8px",
+        horizontal_align: "left",
+        vertical_align: "top",
+        margin: "0px 0px 0px 0px",
+        weight: 1,
+      },
+    ],
+    margin: "0px 0px 0px 0px",
+  };
+}
+
+function formatToolDisplay(line: ToolUpdateView): string {
+  return line.detail ? `**${escapeText(line.label)}**：${escapeText(line.detail)}` : `**${escapeText(line.label)}**`;
+}
+
+function mapToolIcon(status: ToolUpdateView["status"]): Record<string, string> {
   switch (status) {
+    case "completed":
+      return { tag: "standard_icon", token: "yes_outlined", color: "green" };
+    case "error":
+      return { tag: "standard_icon", token: "more-close_outlined", color: "red" };
     case "pending":
-    case "running": return "⏳";
-    case "completed": return "✅";
-    case "error": return "❌";
-    default: return "•";
+    case "running":
+      return { tag: "standard_icon", token: "loading_outlined", color: "blue" };
+    default:
+      return { tag: "standard_icon", token: "info_outlined", color: "grey" };
   }
 }
 
-function buildOutputElements(output: OutputView): Array<Record<string, string>> {
-  const elements: Array<Record<string, string>> = [];
+function buildOutputElements(output: OutputView, state: CardState): Array<Record<string, unknown>> {
+  const blocks: string[] = [];
+
   if (output.text) {
-    elements.push({ tag: "markdown", content: formatOutputText(output.text) });
+    blocks.push(formatOutputText(output.text));
   }
   for (const path of output.paths) {
-    elements.push({ tag: "markdown", content: `**${escapeText(fileNameFromPath(path))}**\n\`${escapeText(path)}\`` });
+    blocks.push(`**${escapeText(fileNameFromPath(path))}**\n\`${escapeText(path)}\``);
   }
   if (output.commands.length > 0) {
-    elements.push({ tag: "markdown", content: "执行命令：" });
-    for (const command of output.commands) {
-      elements.push({ tag: "markdown", content: `\`${escapeText(command)}\`` });
-    }
+    blocks.push(output.commands.map((command) => `\`${escapeText(command)}\``).join("\n"));
   }
-  if (elements.length === 0) {
-    elements.push({ tag: "markdown", content: "处理中..." });
+
+  if (blocks.length === 0) {
+    blocks.push(state.kind === "error" ? "问题描述" : "处理中...");
   }
-  return elements;
+
+  return [{
+    tag: "markdown",
+    content: blocks.join("\n\n"),
+    text_align: "left",
+    text_size: "normal_v2",
+  }];
 }
 
 function formatOutputText(text: string): string {
@@ -289,6 +842,99 @@ function formatOutputLine(line: string): string {
 function fileNameFromPath(path: string): string {
   const parts = path.split("\\").filter(Boolean);
   return parts[parts.length - 1] ?? path;
+}
+
+function buildToolBlock(toolElements: Array<Record<string, unknown>>): Record<string, unknown> {
+  return {
+    tag: "column_set",
+    flex_mode: "stretch",
+    horizontal_spacing: "12px",
+    horizontal_align: "left",
+    columns: [
+      {
+        tag: "column",
+        width: "weighted",
+        background_style: "grey-50",
+        elements: toolElements,
+        padding: "12px 12px 12px 12px",
+        direction: "vertical",
+        horizontal_spacing: "8px",
+        vertical_spacing: "4px",
+        horizontal_align: "left",
+        vertical_align: "top",
+        weight: 1,
+      },
+    ],
+    margin: "0px 0px 0px 0px",
+  };
+}
+
+function buildOutputBlock(outputElements: Array<Record<string, unknown>>): Record<string, unknown> {
+  return {
+    tag: "column_set",
+    flex_mode: "stretch",
+    horizontal_spacing: "12px",
+    horizontal_align: "left",
+    columns: [
+      {
+        tag: "column",
+        width: "weighted",
+        elements: outputElements,
+        vertical_spacing: "8px",
+        horizontal_align: "left",
+        vertical_align: "top",
+        weight: 1,
+      },
+    ],
+    margin: "0px 0px 0px 0px",
+  };
+}
+
+function buildSpacerBlock(): Record<string, unknown> {
+  return {
+    tag: "column_set",
+    flex_mode: "stretch",
+    horizontal_spacing: "8px",
+    horizontal_align: "left",
+    columns: [
+      {
+        tag: "column",
+        width: "weighted",
+        elements: [
+          {
+            tag: "markdown",
+            content: "",
+            text_align: "left",
+            text_size: "notation",
+          },
+        ],
+        vertical_spacing: "8px",
+        horizontal_align: "left",
+        vertical_align: "top",
+        weight: 1,
+      },
+    ],
+    margin: "0px 0px 0px 0px",
+  };
+}
+
+function buildFooter(sessionId: string, durationText: string): Record<string, unknown> {
+  const duration = durationText ? `｜耗时：${durationText}` : "";
+  return {
+    tag: "div",
+    text: {
+      tag: "plain_text",
+      content: `ID：${shortSessionId(sessionId)}${duration}`,
+      text_size: "notation",
+      text_align: "left",
+      text_color: "grey",
+    },
+    icon: {
+      tag: "standard_icon",
+      token: "robot_outlined",
+      color: "light_grey",
+    },
+  };
 }
 
 function escapeText(text: string): string {

--- a/src/feishu/ws.ts
+++ b/src/feishu/ws.ts
@@ -269,6 +269,10 @@ async function inspectIncomingMessageForDispatch(
     return parsed;
   }
 
+  if (!options.requireBotMentionInGroup) {
+    return parsed;
+  }
+
   const routed = routeIncomingText(parsed.incoming.plainText);
   const hasBotMention = resolveMentionMatch(parsed, options);
   const isBound = whitelist.isBound(parsed.incoming.chatId, parsed.incoming.senderOpenId);

--- a/src/feishu/ws.ts
+++ b/src/feishu/ws.ts
@@ -87,12 +87,6 @@ type IncomingMessageInspection =
 
 const SUPPORTED_MESSAGE_TYPES = new Set(["text", "post"]);
 const RECENT_MESSAGE_TTL_MS = 24 * 60 * 60 * 1000;
-const NOOP_WHITELIST: ChatWhitelist = {
-  isBound: () => false,
-  bind: async () => {},
-  unbind: async () => false,
-  count: () => 0,
-};
 
 type FeishuIngressOptions = {
   botOpenIds: Set<string>;
@@ -114,9 +108,9 @@ export class FeishuWsClient {
     appId: string,
     appSecret: string,
     private readonly options: FeishuIngressOptions,
+    private readonly whitelist: ChatWhitelist,
     private readonly handler: MessageHandler,
     private readonly logger: LoggerLike,
-    private readonly whitelist: ChatWhitelist = NOOP_WHITELIST,
   ) {
     this.dispatcher = new lark.EventDispatcher({}).register({
       "im.message.receive_v1": async (data: unknown) => {
@@ -156,6 +150,41 @@ export class FeishuWsClient {
       return;
     }
     const incoming = inspection.incoming;
+    const hasAnyMention = inspection.fields?.hasAnyMention === true;
+    const hasExactBotMention = inspection.fields?.hasExactBotMention === true;
+    const mentionMatched = this.options.strictBotMention ? hasExactBotMention : hasExactBotMention || hasAnyMention;
+    const routed = routeIncomingText(incoming.plainText);
+    const isBound = incoming.chatType !== "p2p" && this.whitelist.isBound(incoming.chatId, incoming.senderOpenId);
+    const isSlashCommand = routed.kind === "command";
+    const allowsUnauthedGroupCommand = isSlashCommand && (
+      routed.command.kind === "who" || routed.command.kind === "leave"
+    );
+
+    if (incoming.chatType !== "p2p" && this.options.requireBotMentionInGroup) {
+      if (isSlashCommand) {
+        if (!mentionMatched && !isBound && !allowsUnauthedGroupCommand) {
+          this.logger.log("feishu/ws", "message skipped", {
+            reason: hasAnyMention ? "group-mention-mismatch" : "not-whitelisted",
+            chatId: incoming.chatId,
+            chatType: incoming.chatType,
+            messageId: incoming.messageId,
+            senderId: incoming.senderOpenId,
+          }, "warn");
+          return;
+        }
+      } else if (mentionMatched) {
+        await this.whitelist.bind(incoming.chatId, incoming.senderOpenId);
+      } else if (!isBound) {
+        this.logger.log("feishu/ws", "message skipped", {
+          reason: hasAnyMention ? "group-mention-mismatch" : "not-whitelisted",
+          chatId: incoming.chatId,
+          chatType: incoming.chatType,
+          messageId: incoming.messageId,
+          senderId: incoming.senderOpenId,
+        }, "warn");
+        return;
+      }
+    }
 
     this.logger.log("feishu/ws", "message received", {
       chatId: incoming.chatId,
@@ -170,7 +199,6 @@ export class FeishuWsClient {
       ...(inspection.fields ?? {}),
     });
 
-    const routed = routeIncomingText(incoming.plainText);
     if (
       incoming.chatType !== "p2p"
       && routed.kind === "message"
@@ -232,7 +260,20 @@ export function createFeishuIngressOptions(feishu: AppConfig["feishu"]): FeishuI
 
 export function normalizeIncomingMessage(payload: FeishuReceiveEvent, options: FeishuIngressOptions): IncomingChatMessage | null {
   const inspection = inspectIncomingMessage(payload, options);
-  return inspection.accepted ? inspection.incoming : null;
+  if (!inspection.accepted) {
+    return null;
+  }
+
+  if (inspection.incoming.chatType !== "p2p" && options.requireBotMentionInGroup) {
+    const mentionMatched = options.strictBotMention
+      ? inspection.fields?.hasExactBotMention === true
+      : inspection.fields?.hasExactBotMention === true || inspection.fields?.hasAnyMention === true;
+    if (!mentionMatched) {
+      return null;
+    }
+  }
+
+  return inspection.incoming;
 }
 
 function inspectIncomingMessage(payload: FeishuReceiveEvent, options: FeishuIngressOptions): IncomingMessageInspection {
@@ -278,7 +319,8 @@ async function inspectIncomingMessageForDispatch(
   const isBound = whitelist.isBound(parsed.incoming.chatId, parsed.incoming.senderOpenId);
 
   if (routed.kind === "command") {
-    if (hasBotMention || isBound) {
+    const allowsUnauthedGroupCommand = routed.command.kind === "who" || routed.command.kind === "leave";
+    if (hasBotMention || isBound || allowsUnauthedGroupCommand) {
       return {
         ...parsed,
         fields: {

--- a/src/feishu/ws.ts
+++ b/src/feishu/ws.ts
@@ -1,7 +1,9 @@
 import * as lark from "@larksuiteoapi/node-sdk";
 
+import { routeIncomingText } from "../bridge/router.js";
 import type { AppConfig } from "../config/schema.js";
 import type { IncomingChatMessage } from "../runtime/app.js";
+import type { ChatWhitelist } from "../store/whitelist.js";
 
 type MessageHandler = (message: IncomingChatMessage) => Promise<void>;
 
@@ -65,6 +67,8 @@ type IncomingMessageInspection =
   | {
     accepted: true;
     incoming: IncomingChatMessage;
+    hasAnyMention: boolean;
+    hasExactBotMention: boolean;
     fields?: Record<string, unknown>;
   }
   | {
@@ -76,12 +80,19 @@ type IncomingMessageInspection =
       | "self-bot-sender"
       | "malformed-message"
       | "group-mention-mismatch"
+      | "not-whitelisted"
       | "empty-plain-text";
     fields?: Record<string, unknown>;
   };
 
 const SUPPORTED_MESSAGE_TYPES = new Set(["text", "post"]);
 const RECENT_MESSAGE_TTL_MS = 24 * 60 * 60 * 1000;
+const NOOP_WHITELIST: ChatWhitelist = {
+  isBound: () => false,
+  bind: async () => {},
+  unbind: async () => false,
+  count: () => 0,
+};
 
 type FeishuIngressOptions = {
   botOpenIds: Set<string>;
@@ -105,6 +116,7 @@ export class FeishuWsClient {
     private readonly options: FeishuIngressOptions,
     private readonly handler: MessageHandler,
     private readonly logger: LoggerLike,
+    private readonly whitelist: ChatWhitelist = NOOP_WHITELIST,
   ) {
     this.dispatcher = new lark.EventDispatcher({}).register({
       "im.message.receive_v1": async (data: unknown) => {
@@ -138,7 +150,7 @@ export class FeishuWsClient {
       return;
     }
 
-    const inspection = inspectIncomingMessage(payload, this.options);
+    const inspection = await inspectIncomingMessageForDispatch(payload, this.options, this.whitelist);
     if (!inspection.accepted) {
       this.logger.log("feishu/ws", "message skipped", { reason: inspection.reason, ...(inspection.fields ?? {}) }, "warn");
       return;
@@ -157,6 +169,25 @@ export class FeishuWsClient {
       len: incoming.plainText.length,
       ...(inspection.fields ?? {}),
     });
+
+    const routed = routeIncomingText(incoming.plainText);
+    if (
+      incoming.chatType !== "p2p"
+      && routed.kind === "message"
+      && resolveMentionMatch(inspection, this.options)
+    ) {
+      try {
+        await this.whitelist.bind(incoming.chatId, incoming.senderOpenId);
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        this.logger.log("store/whitelist", "bind failed", {
+          chatId: incoming.chatId,
+          senderOpenId: incoming.senderOpenId,
+          detail,
+        }, "warn");
+      }
+    }
+
     await this.handler(incoming);
   }
 
@@ -205,6 +236,106 @@ export function normalizeIncomingMessage(payload: FeishuReceiveEvent, options: F
 }
 
 function inspectIncomingMessage(payload: FeishuReceiveEvent, options: FeishuIngressOptions): IncomingMessageInspection {
+  const parsed = parseIncomingMessage(payload, options);
+    if (!parsed.accepted) {
+      return parsed;
+    }
+
+  if (parsed.incoming.chatType !== "p2p" && options.requireBotMentionInGroup) {
+    const mentionMatched = resolveMentionMatch(parsed, options);
+    if (!mentionMatched) {
+      return {
+        accepted: false,
+        reason: "group-mention-mismatch",
+        ...(parsed.fields ? { fields: parsed.fields } : {}),
+      };
+    }
+  }
+
+  return parsed;
+}
+
+async function inspectIncomingMessageForDispatch(
+  payload: FeishuReceiveEvent,
+  options: FeishuIngressOptions,
+  whitelist: ChatWhitelist,
+): Promise<IncomingMessageInspection> {
+  const parsed = parseIncomingMessage(payload, options);
+  if (!parsed.accepted) {
+    return parsed;
+  }
+
+  if (parsed.incoming.chatType === "p2p") {
+    return parsed;
+  }
+
+  const routed = routeIncomingText(parsed.incoming.plainText);
+  const hasBotMention = resolveMentionMatch(parsed, options);
+  const isBound = whitelist.isBound(parsed.incoming.chatId, parsed.incoming.senderOpenId);
+
+  if (routed.kind === "command") {
+    if (hasBotMention || isBound) {
+      return {
+        ...parsed,
+        fields: {
+          ...(parsed.fields ?? {}),
+          whitelistMatched: isBound,
+          whitelistSize: whitelist.count(parsed.incoming.chatId),
+        },
+      };
+    }
+
+    return {
+      accepted: false,
+      reason: parsed.hasAnyMention ? "group-mention-mismatch" : "not-whitelisted",
+      fields: {
+        ...(parsed.fields ?? {}),
+        chatId: parsed.incoming.chatId,
+        chatType: parsed.incoming.chatType,
+        messageId: parsed.incoming.messageId,
+        senderOpenId: parsed.incoming.senderOpenId,
+        whitelistChatId: parsed.incoming.chatId,
+      },
+    };
+  }
+
+  if (hasBotMention) {
+    return {
+      ...parsed,
+      fields: {
+        ...(parsed.fields ?? {}),
+        whitelistMatched: isBound,
+        whitelistSize: whitelist.count(parsed.incoming.chatId),
+      },
+    };
+  }
+
+  if (isBound) {
+    return {
+      ...parsed,
+      fields: {
+        ...(parsed.fields ?? {}),
+        whitelistMatched: true,
+        whitelistSize: whitelist.count(parsed.incoming.chatId),
+      },
+    };
+  }
+
+  return {
+    accepted: false,
+    reason: parsed.hasAnyMention ? "group-mention-mismatch" : "not-whitelisted",
+    fields: {
+      ...(parsed.fields ?? {}),
+      chatId: parsed.incoming.chatId,
+      chatType: parsed.incoming.chatType,
+      messageId: parsed.incoming.messageId,
+      senderOpenId: parsed.incoming.senderOpenId,
+      whitelistChatId: parsed.incoming.chatId,
+    },
+  };
+}
+
+function parseIncomingMessage(payload: FeishuReceiveEvent, options: FeishuIngressOptions): IncomingMessageInspection {
   const message = payload.message;
   if (!message) {
     return { accepted: false, reason: "no-message" };
@@ -252,30 +383,6 @@ function inspectIncomingMessage(payload: FeishuReceiveEvent, options: FeishuIngr
     return { accepted: false, reason: "unsupported-message-type", fields: { chatType, messageType } };
   }
 
-  if (chatType !== "p2p" && options.requireBotMentionInGroup) {
-    const mentionMatched = options.strictBotMention
-      ? parsed.hasExactBotMention
-      : parsed.hasExactBotMention || parsed.hasAnyMention;
-    if (!mentionMatched) {
-      return {
-        accepted: false,
-        reason: "group-mention-mismatch",
-        fields: {
-          chatId,
-          chatType,
-          messageId,
-          senderOpenId,
-          configuredBotOpenIds: [...options.botOpenIds],
-          configuredBotMentionNames: [...options.botMentionNames],
-          configuredSelfBotOpenIds: [...options.selfBotOpenIds],
-          mentionIds,
-          hasAnyMention: parsed.hasAnyMention,
-          hasExactBotMention: parsed.hasExactBotMention,
-        },
-      };
-    }
-  }
-
   const threadKey = computeThreadKey({
     chatType,
     messageId,
@@ -306,6 +413,8 @@ function inspectIncomingMessage(payload: FeishuReceiveEvent, options: FeishuIngr
       threadKey,
       conversationKey: buildConversationKey(chatType, chatId, threadKey),
     },
+    hasAnyMention: parsed.hasAnyMention,
+    hasExactBotMention: parsed.hasExactBotMention,
     fields: {
       senderType,
       mentionIds,
@@ -316,6 +425,15 @@ function inspectIncomingMessage(payload: FeishuReceiveEvent, options: FeishuIngr
       hasExactBotMention: parsed.hasExactBotMention,
     },
   };
+}
+
+function resolveMentionMatch(
+  inspection: Extract<IncomingMessageInspection, { accepted: true }>,
+  options: FeishuIngressOptions,
+): boolean {
+  return options.strictBotMention
+    ? inspection.hasExactBotMention
+    : inspection.hasExactBotMention || inspection.hasAnyMention;
 }
 
 function isChatTypeEnabled(chatType: string, options: FeishuIngressOptions): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,9 +17,9 @@ async function main(): Promise<void> {
     config.feishu.appId,
     config.feishu.appSecret,
     createFeishuIngressOptions(config.feishu),
+    whitelist,
     (message) => app.handleIncomingMessage(message),
     logger,
-    whitelist,
   );
   await ws.start();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,15 @@ import { loadConfig } from "./config/loader.js";
 import { BridgeApp } from "./runtime/app.js";
 import { FeishuApiClient } from "./feishu/api.js";
 import { createFeishuIngressOptions, FeishuWsClient } from "./feishu/ws.js";
+import { WhitelistStore } from "./store/whitelist.js";
 
 async function main(): Promise<void> {
   const config = await loadConfig();
   const logger = await createLogger(config.logging.dir);
   const outbound = new FeishuApiClient(config.feishu.appId, config.feishu.appSecret);
-  const app = new BridgeApp(config, outbound, logger);
+  const whitelist = new WhitelistStore(config.whitelist.storePath, logger);
+  await whitelist.load();
+  const app = new BridgeApp(config, outbound, logger, whitelist);
   await app.start();
   const ws = new FeishuWsClient(
     config.feishu.appId,
@@ -16,6 +19,7 @@ async function main(): Promise<void> {
     createFeishuIngressOptions(config.feishu),
     (message) => app.handleIncomingMessage(message),
     logger,
+    whitelist,
   );
   await ws.start();
 }

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -25,6 +25,7 @@ import {
 } from "../opencode/client.js";
 import { getEventSessionId, OpenCodeEventStream, type OpenCodeEvent } from "../opencode/events.js";
 import { MappingStore, type MappingRecord, type SessionBindingRecord, type SessionMode, type SessionWindowRecord } from "../store/mappings.js";
+import type { ChatWhitelist } from "../store/whitelist.js";
 import type { AppConfig } from "../config/schema.js";
 import { cleanAssistantReply } from "./sanitize.js";
 import {
@@ -81,6 +82,12 @@ const STREAM_FLUSH_MIN_CHARS = 120;
 const STREAM_FLUSH_INTERVAL_MS = 750;
 const PERMISSION_TTL_MS = 120_000;
 const SESSION_SELECTION_TTL_MS = 30_000;
+const NOOP_WHITELIST: ChatWhitelist = {
+  isBound: () => false,
+  bind: async () => {},
+  unbind: async () => false,
+  count: () => 0,
+};
 
 export class BridgeApp {
   private readonly queues: QueueRegistry;
@@ -96,7 +103,12 @@ export class BridgeApp {
   private readonly sessionStatuses = new Map<string, OpenCodeSessionStatus>();
   private globalEventUnsubscribe: (() => void) | null = null;
 
-  constructor(private readonly config: AppConfig, private readonly outbound: OutboundPort, private readonly logger: Logger) {
+  constructor(
+    private readonly config: AppConfig,
+    private readonly outbound: OutboundPort,
+    private readonly logger: Logger,
+    private readonly whitelist: ChatWhitelist = NOOP_WHITELIST,
+  ) {
     this.queues = new QueueRegistry(config.bridge.queueLimit, logger);
     this.mappings = new MappingStore(config.storage.dataDir, config.storage.mappingsFile, 200, logger);
     this.opencode = new OpenCodeClient(config.opencode.baseUrl);
@@ -517,7 +529,7 @@ export class BridgeApp {
   }
 
   private async handleCommand(
-    message: Pick<IncomingChatMessage, "chatId" | "chatType" | "messageId" | "conversationKey" | "threadKey">,
+    message: Pick<IncomingChatMessage, "chatId" | "chatType" | "messageId" | "conversationKey" | "threadKey" | "senderOpenId">,
     routed: Extract<RoutedText, { kind: "command" }>,
   ): Promise<void> {
     const { command } = routed;
@@ -569,6 +581,39 @@ export class BridgeApp {
     if (command.kind === "models") {
       const providers = await this.opencode.listProviders();
       await this.sendMarkdown(message.chatId, formatProviders(providers), message.messageId);
+      return;
+    }
+
+    if (command.kind === "leave") {
+      if (!supportsGroupWhitelistCommands(message.chatType)) {
+        await this.sendMarkdown(message.chatId, "该命令仅支持群聊使用。", message.messageId);
+        return;
+      }
+
+      const removed = await this.whitelist.unbind(message.chatId, message.senderOpenId);
+      await this.sendMarkdown(
+        message.chatId,
+        removed ? "已解除绑定，后续消息不再响应。" : "当前群里你尚未绑定，无需解除。",
+        message.messageId,
+      );
+      return;
+    }
+
+    if (command.kind === "who") {
+      if (!supportsGroupWhitelistCommands(message.chatType)) {
+        await this.sendMarkdown(message.chatId, "该命令仅支持群聊使用。", message.messageId);
+        return;
+      }
+
+      const count = this.whitelist.count(message.chatId);
+      const isBound = this.whitelist.isBound(message.chatId, message.senderOpenId);
+      await this.sendMarkdown(
+        message.chatId,
+        isBound
+          ? `当前群已绑定 ${count} 人，你已绑定 ✓`
+          : `当前群已绑定 ${count} 人，你未绑定（发送任意消息并 @ bot 即可绑定）`,
+        message.messageId,
+      );
       return;
     }
 
@@ -1206,6 +1251,10 @@ function formatSingleSessionStatus(mode: SessionMode, session: SessionBindingRec
     `当前会话：${escapeMarkdownText(session.label)}`,
     `Session ID：\`${session.sessionId}\``,
   ].join("\n");
+}
+
+function supportsGroupWhitelistCommands(chatType: string): boolean {
+  return chatType === "group" || chatType === "topic_group";
 }
 
 export function buildBridgeSystemPrompt(

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -1,15 +1,20 @@
 import crypto from "node:crypto";
 
 import { QueueRegistry } from "../bridge/queue.js";
-import { type PendingInteraction, type PendingPermissionInteraction, type PendingQuestionInteraction, type PendingSessionSelectionInteraction } from "../bridge/state.js";
+import { type PendingInteraction, type PendingPermissionInteraction, type PendingQuestionInteraction } from "../bridge/state.js";
 import { routeIncomingText, type RoutedText } from "../bridge/router.js";
 import { transitionTurn } from "../bridge/state-machine.js";
 import { TurnWatchdog } from "../bridge/watchdog.js";
 import type { BridgeTurn } from "../bridge/turn.js";
 import {
   buildPostMarkdownPayload,
+  buildLeaveCommandCardPayload,
   buildQueueNoticePayload,
+  buildSessionListCardPayload,
+  buildSessionTransitionCardPayload,
+  buildStatusCommandCardPayload,
   buildTurnStatusCardPayload,
+  buildWhoCommandCardPayload,
   type FeishuPostPayload,
   type OutputView,
   type ToolUpdateView,
@@ -24,8 +29,8 @@ import {
   type OpenCodeSessionStatus,
 } from "../opencode/client.js";
 import { getEventSessionId, OpenCodeEventStream, type OpenCodeEvent } from "../opencode/events.js";
-import { MappingStore, type MappingRecord, type SessionBindingRecord, type SessionMode, type SessionWindowRecord } from "../store/mappings.js";
-import type { ChatWhitelist } from "../store/whitelist.js";
+import { MappingStore, type MappingRecord, type SessionBindingRecord, type SessionWindowRecord } from "../store/mappings.js";
+import type { WhitelistStore } from "../store/whitelist.js";
 import type { AppConfig } from "../config/schema.js";
 import { cleanAssistantReply } from "./sanitize.js";
 import {
@@ -82,12 +87,6 @@ const STREAM_FLUSH_MIN_CHARS = 120;
 const STREAM_FLUSH_INTERVAL_MS = 750;
 const PERMISSION_TTL_MS = 120_000;
 const SESSION_SELECTION_TTL_MS = 30_000;
-const NOOP_WHITELIST: ChatWhitelist = {
-  isBound: () => false,
-  bind: async () => {},
-  unbind: async () => false,
-  count: () => 0,
-};
 
 export class BridgeApp {
   private readonly queues: QueueRegistry;
@@ -107,7 +106,7 @@ export class BridgeApp {
     private readonly config: AppConfig,
     private readonly outbound: OutboundPort,
     private readonly logger: Logger,
-    private readonly whitelist: ChatWhitelist = NOOP_WHITELIST,
+    private readonly whitelist: Pick<WhitelistStore, "count" | "isBound" | "unbind">,
   ) {
     this.queues = new QueueRegistry(config.bridge.queueLimit, logger);
     this.mappings = new MappingStore(config.storage.dataDir, config.storage.mappingsFile, 200, logger);
@@ -534,8 +533,20 @@ export class BridgeApp {
   ): Promise<void> {
     const { command } = routed;
     if (command.kind === "new") {
+      const previousSession = getActiveSession(this.getSessionWindow(message.conversationKey, message.chatType));
       const entry = await this.createAndBindSession(message);
-      await this.sendMarkdown(message.chatId, `已创建并切换到新会话 \`${entry.sessionId}\`。`, message.messageId);
+      await this.sendPayload(message.chatId, buildSessionTransitionCardPayload({
+        title: "已创建新会话",
+        iconToken: "add-bold_outlined",
+        previousLabel: previousSession?.label ?? null,
+        currentLabel: entry.label,
+        footer: "刚刚创建 · 发送第一条消息开始",
+      }), {
+        event: "final message sent",
+        transcriptType: "outbound-final",
+        textPreview: "已创建新会话",
+        len: 6,
+      }, { replyToMessageId: message.messageId });
       return;
     }
 
@@ -555,16 +566,20 @@ export class BridgeApp {
       const window = this.getSessionWindow(message.conversationKey, message.chatType);
       const currentSession = getActiveSession(window);
       const status = currentSession ? this.sessionStatuses.get(currentSession.sessionId)?.type ?? "unknown" : "unbound";
-      const statusText = [
-        `事件流状态：${this.eventStream.getConnectionState()}`,
-        `会话模式：${window.mode}`,
-        `当前会话：${currentSession ? `${escapeMarkdownText(currentSession.label)} \`${currentSession.sessionId}\`` : "未绑定"}`,
-        `Session 状态：${status}`,
-        `队列状态：${active ? `处理中 ${createTextPreview(active.text)}` : "空闲"}`,
-        `排队数量：${queue.pendingCount()}`,
-        `窗口会话数：${window.sessions.length}`,
-      ].join("\n");
-      await this.sendMarkdown(message.chatId, statusText, message.messageId);
+      await this.sendPayload(message.chatId, buildStatusCommandCardPayload({
+        currentSession: currentSession ? { sessionId: currentSession.sessionId, label: currentSession.label } : null,
+        connectionState: this.eventStream.getConnectionState(),
+        sessionMode: window.mode,
+        sessionState: status,
+        queueState: active ? "处理中" : "空闲",
+        pendingCount: queue.pendingCount(),
+        windowCount: window.sessions.length,
+      }), {
+        event: "final message sent",
+        transcriptType: "outbound-final",
+        textPreview: "会话状态",
+        len: 4,
+      }, { replyToMessageId: message.messageId });
       return;
     }
 
@@ -584,53 +599,42 @@ export class BridgeApp {
       return;
     }
 
-    if (command.kind === "leave") {
-      if (!supportsGroupWhitelistCommands(message.chatType)) {
-        await this.sendMarkdown(message.chatId, "该命令仅支持群聊使用。", message.messageId);
-        return;
-      }
-
-      const removed = await this.whitelist.unbind(message.chatId, message.senderOpenId);
-      await this.sendMarkdown(
-        message.chatId,
-        removed ? "已解除绑定，后续消息不再响应。" : "当前群里你尚未绑定，无需解除。",
-        message.messageId,
-      );
-      return;
-    }
-
-    if (command.kind === "who") {
-      if (!supportsGroupWhitelistCommands(message.chatType)) {
-        await this.sendMarkdown(message.chatId, "该命令仅支持群聊使用。", message.messageId);
-        return;
-      }
-
-      const count = this.whitelist.count(message.chatId);
-      const isBound = this.whitelist.isBound(message.chatId, message.senderOpenId);
-      await this.sendMarkdown(
-        message.chatId,
-        isBound
-          ? `当前群已绑定 ${count} 人，你已绑定 ✓`
-          : `当前群已绑定 ${count} 人，你未绑定（发送任意消息并 @ bot 即可绑定）`,
-        message.messageId,
-      );
-      return;
-    }
-
     if (command.kind === "sessions") {
       const window = this.getSessionWindow(message.conversationKey, message.chatType);
       const currentSession = getActiveSession(window);
       if (window.mode === "single") {
-        const text = currentSession
-          ? formatSingleSessionStatus(window.mode, currentSession)
-          : "当前窗口为单会话模式，暂未绑定会话。";
-        await this.sendMarkdown(message.chatId, text, message.messageId);
+        await this.sendPayload(message.chatId, buildSessionListCardPayload({
+          items: currentSession ? [{
+            index: 1,
+            title: currentSession.label,
+            current: true,
+            meta: "当前",
+          }] : [],
+          footer: currentSession
+            ? "当前窗口为单会话模式，不支持切换"
+            : "发送 `/new` 创建第一个会话",
+          emptyText: "暂无会话",
+        }), {
+          event: "final message sent",
+          transcriptType: "outbound-final",
+          textPreview: "会话列表",
+          len: 4,
+        }, { replyToMessageId: message.messageId });
         return;
       }
 
       const visibleSessions = getVisibleSessions(window).slice(0, this.config.bridge.sessionListLimit);
       if (visibleSessions.length === 0) {
-        await this.sendMarkdown(message.chatId, "当前窗口暂无可切换的会话。", message.messageId);
+        await this.sendPayload(message.chatId, buildSessionListCardPayload({
+          items: [],
+          footer: "发送 `/new` 创建第一个会话",
+          emptyText: "暂无会话",
+        }), {
+          event: "final message sent",
+          transcriptType: "outbound-final",
+          textPreview: "会话列表",
+          len: 4,
+        }, { replyToMessageId: message.messageId });
         return;
       }
 
@@ -645,7 +649,20 @@ export class BridgeApp {
         options,
         expiresAt: Date.now() + SESSION_SELECTION_TTL_MS,
       });
-      await this.sendMarkdown(message.chatId, formatSessionList(options), message.messageId);
+      await this.sendPayload(message.chatId, buildSessionListCardPayload({
+        items: options.map((option) => ({
+          index: option.index,
+          title: option.title,
+          current: option.current,
+          meta: option.current ? "当前" : formatSessionTimestamp(findSessionMeta(window, option.sessionId)?.lastUsedAt),
+        })),
+        footer: "发送 `/switch <编号>` 切换 · 30s 内有效",
+      }), {
+        event: "final message sent",
+        transcriptType: "outbound-final",
+        textPreview: "会话列表",
+        len: 4,
+      }, { replyToMessageId: message.messageId });
       return;
     }
 
@@ -684,7 +701,55 @@ export class BridgeApp {
       nextWindow = updateSessionLabel(nextWindow, match.sessionId, fallbackLabel, this.config.bridge.maxSessionsPerWindow);
       await this.saveSessionWindow(message.conversationKey, nextWindow);
       this.clearPendingInteraction(message.conversationKey, false);
-      await this.sendMarkdown(message.chatId, `已切换到会话 ${escapeMarkdownText(fallbackLabel)} \`${match.sessionId}\`。`, message.messageId);
+      const previous = getActiveSession(window);
+      const current = getActiveSession(nextWindow);
+      const messageCount = await this.getSessionMessageCount(match.sessionId);
+      await this.sendPayload(message.chatId, buildSessionTransitionCardPayload({
+        title: "已切换会话",
+        iconToken: "sheet-iconsets-check_filled",
+        previousLabel: previous?.sessionId === current?.sessionId ? null : previous?.label ?? null,
+        currentLabel: current?.label ?? fallbackLabel,
+        footer: `创建于 ${formatSessionTimestamp(current?.createdAt ?? sessionMeta?.time?.created ?? Date.now())} · 共 ${messageCount} 条消息`,
+      }), {
+        event: "final message sent",
+        transcriptType: "outbound-final",
+        textPreview: "已切换会话",
+        len: 5,
+      }, { replyToMessageId: message.messageId });
+      return;
+    }
+
+    if (command.kind === "who") {
+      if (message.chatType !== "group" && message.chatType !== "topic_group") {
+        await this.sendMarkdown(message.chatId, "该命令仅支持群聊使用", message.messageId);
+        return;
+      }
+
+      await this.sendPayload(message.chatId, buildWhoCommandCardPayload({
+        boundCount: this.whitelist.count(message.chatId),
+        isBound: this.whitelist.isBound(message.chatId, message.senderOpenId),
+      }), {
+        event: "final message sent",
+        transcriptType: "outbound-final",
+        textPreview: "群聊绑定状态",
+        len: 6,
+      }, { replyToMessageId: message.messageId });
+      return;
+    }
+
+    if (command.kind === "leave") {
+      if (message.chatType !== "group" && message.chatType !== "topic_group") {
+        await this.sendMarkdown(message.chatId, "该命令仅支持群聊使用", message.messageId);
+        return;
+      }
+
+      const unbound = await this.whitelist.unbind(message.chatId, message.senderOpenId);
+      await this.sendPayload(message.chatId, buildLeaveCommandCardPayload({ unbound }), {
+        event: "final message sent",
+        transcriptType: "outbound-final",
+        textPreview: unbound ? "已解除绑定" : "无需解除绑定",
+        len: unbound ? 5 : 6,
+      }, { replyToMessageId: message.messageId });
       return;
     }
 
@@ -936,6 +1001,14 @@ export class BridgeApp {
   private async listOpenCodeSessionsById(): Promise<Map<string, OpenCodeSession>> {
     const sessions = await this.opencode.listSessions();
     return new Map(sessions.map((session) => [session.id, session]));
+  }
+
+  private async getSessionMessageCount(sessionId: string): Promise<number> {
+    try {
+      return (await this.opencode.getSessionMessages(sessionId, 200)).length;
+    } catch {
+      return 0;
+    }
   }
 
   private async syncStoredSessionLabels(): Promise<void> {
@@ -1236,27 +1309,6 @@ function formatProviders(providers: OpenCodeProvidersResponse): string {
   return lines.join("\n");
 }
 
-function formatSessionList(options: PendingSessionSelectionInteraction["options"]): string {
-  return [
-    "当前窗口会话：",
-    ...options.map((option) => `${option.index}. ${escapeMarkdownText(option.title)}${option.current ? " ← 当前" : ""}\n   \`${option.sessionId}\``),
-    "",
-    "30 秒内可用 `/switch <编号>` 或 `/sessions <编号>` 切换。",
-  ].join("\n");
-}
-
-function formatSingleSessionStatus(mode: SessionMode, session: SessionBindingRecord): string {
-  return [
-    `当前窗口为${mode}会话模式。`,
-    `当前会话：${escapeMarkdownText(session.label)}`,
-    `Session ID：\`${session.sessionId}\``,
-  ].join("\n");
-}
-
-function supportsGroupWhitelistCommands(chatType: string): boolean {
-  return chatType === "group" || chatType === "topic_group";
-}
-
 export function buildBridgeSystemPrompt(
   turn: Pick<BridgeTurn, "chatType" | "conversationKey" | "senderOpenId" | "sessionId">,
   window: SessionWindowRecord,
@@ -1421,6 +1473,23 @@ function formatToolTarget(title: string | undefined): string {
 
 function formatDuration(ms: number): string {
   return `约 ${Math.max(1, Math.round(ms / 1000))}s`;
+}
+
+function formatSessionTimestamp(timestamp: number | undefined): string {
+  if (!timestamp || !Number.isFinite(timestamp)) {
+    return "--";
+  }
+
+  const date = new Date(timestamp);
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${month}-${day} ${hours}:${minutes}`;
+}
+
+function findSessionMeta(window: SessionWindowRecord, sessionId: string): SessionBindingRecord | null {
+  return window.sessions.find((session) => session.sessionId === sessionId) ?? null;
 }
 
 function isFinalStatus(status: string): boolean {

--- a/src/store/whitelist.ts
+++ b/src/store/whitelist.ts
@@ -1,0 +1,108 @@
+import path from "node:path";
+
+import { JsonStore } from "./json-store.js";
+
+export type ChatWhitelist = {
+  isBound(chatId: string, senderOpenId: string): boolean;
+  bind(chatId: string, senderOpenId: string): Promise<void>;
+  unbind(chatId: string, senderOpenId: string): Promise<boolean>;
+  count(chatId: string): number;
+};
+
+type LoggerLike = {
+  log: (scope: string, message: string, fields?: Record<string, unknown>, level?: "debug" | "info" | "warn" | "error") => void;
+};
+
+type WhitelistFile = {
+  version: 1;
+  bindings: Record<string, string[]>;
+};
+
+const WHITELIST_VERSION = 1 as const;
+
+export class WhitelistStore extends JsonStore<unknown> implements ChatWhitelist {
+  private bindings = new Map<string, Set<string>>();
+
+  constructor(
+    storePath: string,
+    private readonly logger?: LoggerLike,
+  ) {
+    super(path.dirname(storePath), path.basename(storePath), { version: WHITELIST_VERSION, bindings: {} } satisfies WhitelistFile);
+  }
+
+  async load(): Promise<Map<string, Set<string>>> {
+    const loaded = await super.load();
+    this.bindings = isWhitelistFile(loaded)
+      ? normalizeBindings(loaded.bindings)
+      : new Map();
+    return this.bindings;
+  }
+
+  isBound(chatId: string, senderOpenId: string): boolean {
+    return this.bindings.get(chatId)?.has(senderOpenId) ?? false;
+  }
+
+  async bind(chatId: string, senderOpenId: string): Promise<void> {
+    const members = this.bindings.get(chatId) ?? new Set<string>();
+    if (!this.bindings.has(chatId)) {
+      this.bindings.set(chatId, members);
+    }
+    members.add(senderOpenId);
+    await this.persist();
+  }
+
+  async unbind(chatId: string, senderOpenId: string): Promise<boolean> {
+    const members = this.bindings.get(chatId);
+    if (!members?.has(senderOpenId)) {
+      return false;
+    }
+
+    members.delete(senderOpenId);
+    if (members.size === 0) {
+      this.bindings.delete(chatId);
+    }
+    await this.persist();
+    return true;
+  }
+
+  count(chatId: string): number {
+    return this.bindings.get(chatId)?.size ?? 0;
+  }
+
+  private async persist(): Promise<void> {
+    const file = {
+      version: WHITELIST_VERSION,
+      bindings: Object.fromEntries(
+        [...this.bindings.entries()]
+          .filter(([, members]) => members.size > 0)
+          .map(([chatId, members]) => [chatId, [...members].sort()]),
+      ),
+    } satisfies WhitelistFile;
+    await super.save(file);
+    this.logger?.log("store/whitelist", "whitelist saved", {
+      chatCount: Object.keys(file.bindings).length,
+    }, "debug");
+  }
+}
+
+function isWhitelistFile(value: unknown): value is WhitelistFile {
+  return isRecord(value) && value.version === WHITELIST_VERSION && isRecord(value.bindings);
+}
+
+function normalizeBindings(bindings: Record<string, unknown>): Map<string, Set<string>> {
+  return new Map(
+    Object.entries(bindings)
+      .map(([chatId, members]) => {
+        if (!Array.isArray(members)) {
+          return null;
+        }
+        const normalizedMembers = members.filter((member): member is string => typeof member === "string" && member.length > 0);
+        return [chatId, new Set(normalizedMembers)] as const;
+      })
+      .filter((entry): entry is readonly [string, Set<string>] => entry !== null),
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/test/app-whitelist-commands.test.ts
+++ b/test/app-whitelist-commands.test.ts
@@ -52,11 +52,9 @@ describe("BridgeApp whitelist commands", () => {
       command: { kind: "leave" },
     });
 
-    const texts = getReplyPayloads(outbound).map((payload) => extractMarkdown(payload));
-    expect(texts).toEqual([
-      "已解除绑定，后续消息不再响应。",
-      "当前群里你尚未绑定，无需解除。",
-    ]);
+    const texts = getReplyPayloads(outbound).map((payload) => extractInteractiveText(payload));
+    expect(texts[0]).toContain("后续消息不再响应");
+    expect(texts[1]).toContain("尚未绑定");
   });
 
   it("reports group binding status for /who", async () => {
@@ -85,7 +83,9 @@ describe("BridgeApp whitelist commands", () => {
       command: { kind: "who" },
     });
 
-    expect(extractMarkdown(getReplyPayloads(outbound)[0])).toBe("当前群已绑定 2 人，你已绑定 ✓");
+    const text = extractInteractiveText(getReplyPayloads(outbound)[0]);
+    expect(text).toContain("**2 人**");
+    expect(text).toContain("**已绑定**");
   });
 
   it("rejects /who outside group chats", async () => {
@@ -113,7 +113,7 @@ describe("BridgeApp whitelist commands", () => {
       command: { kind: "who" },
     });
 
-    expect(extractMarkdown(getReplyPayloads(outbound)[0])).toBe("该命令仅支持群聊使用。");
+    expect(extractMarkdown(getReplyPayloads(outbound)[0])).toBe("该命令仅支持群聊使用");
   });
 });
 
@@ -225,6 +225,14 @@ function extractMarkdown(payload: { content: string } | undefined): string {
     };
   };
   return parsed.zh_cn?.content?.[0]?.[0]?.text ?? "";
+}
+
+function extractInteractiveText(payload: { content: string } | undefined): string {
+  if (!payload) {
+    return "";
+  }
+  const parsed = JSON.parse(payload.content) as { body?: { elements?: unknown[] } };
+  return JSON.stringify(parsed.body?.elements ?? []);
 }
 
 function getReplyPayloads(outbound: ReturnType<typeof createOutbound>): Array<{ content: string } | undefined> {

--- a/test/app-whitelist-commands.test.ts
+++ b/test/app-whitelist-commands.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { BridgeApp } from "../src/runtime/app.js";
+import type { AppConfig } from "../src/config/schema.js";
+import type { ChatWhitelist } from "../src/store/whitelist.js";
+
+describe("BridgeApp whitelist commands", () => {
+  it("handles /leave for bound and unbound group users", async () => {
+    const outbound = createOutbound();
+    const whitelist = createWhitelist([["oc_group_1", new Set(["ou_123"])]]);
+    const app = new BridgeApp(baseConfig(), outbound, logger(), whitelist);
+
+    await (app as unknown as {
+      handleCommand(message: {
+        chatId: string;
+        chatType: string;
+        messageId: string;
+        conversationKey: string;
+        threadKey: string;
+        senderOpenId: string;
+      }, routed: { kind: "command"; command: { kind: "leave" } }): Promise<void>;
+    }).handleCommand({
+      chatId: "oc_group_1",
+      chatType: "group",
+      messageId: "om_1",
+      conversationKey: "oc_group_1:om_1",
+      threadKey: "om_1",
+      senderOpenId: "ou_123",
+    }, {
+      kind: "command",
+      command: { kind: "leave" },
+    });
+
+    await (app as unknown as {
+      handleCommand(message: {
+        chatId: string;
+        chatType: string;
+        messageId: string;
+        conversationKey: string;
+        threadKey: string;
+        senderOpenId: string;
+      }, routed: { kind: "command"; command: { kind: "leave" } }): Promise<void>;
+    }).handleCommand({
+      chatId: "oc_group_1",
+      chatType: "group",
+      messageId: "om_2",
+      conversationKey: "oc_group_1:om_2",
+      threadKey: "om_2",
+      senderOpenId: "ou_123",
+    }, {
+      kind: "command",
+      command: { kind: "leave" },
+    });
+
+    const texts = getReplyPayloads(outbound).map((payload) => extractMarkdown(payload));
+    expect(texts).toEqual([
+      "已解除绑定，后续消息不再响应。",
+      "当前群里你尚未绑定，无需解除。",
+    ]);
+  });
+
+  it("reports group binding status for /who", async () => {
+    const outbound = createOutbound();
+    const whitelist = createWhitelist([["oc_group_1", new Set(["ou_123", "ou_456"])]]);
+    const app = new BridgeApp(baseConfig(), outbound, logger(), whitelist);
+
+    await (app as unknown as {
+      handleCommand(message: {
+        chatId: string;
+        chatType: string;
+        messageId: string;
+        conversationKey: string;
+        threadKey: string;
+        senderOpenId: string;
+      }, routed: { kind: "command"; command: { kind: "who" } }): Promise<void>;
+    }).handleCommand({
+      chatId: "oc_group_1",
+      chatType: "group",
+      messageId: "om_1",
+      conversationKey: "oc_group_1:om_1",
+      threadKey: "om_1",
+      senderOpenId: "ou_123",
+    }, {
+      kind: "command",
+      command: { kind: "who" },
+    });
+
+    expect(extractMarkdown(getReplyPayloads(outbound)[0])).toBe("当前群已绑定 2 人，你已绑定 ✓");
+  });
+
+  it("rejects /who outside group chats", async () => {
+    const outbound = createOutbound();
+    const app = new BridgeApp(baseConfig(), outbound, logger(), createWhitelist());
+
+    await (app as unknown as {
+      handleCommand(message: {
+        chatId: string;
+        chatType: string;
+        messageId: string;
+        conversationKey: string;
+        threadKey: string;
+        senderOpenId: string;
+      }, routed: { kind: "command"; command: { kind: "who" } }): Promise<void>;
+    }).handleCommand({
+      chatId: "oc_p2p_1",
+      chatType: "p2p",
+      messageId: "om_1",
+      conversationKey: "oc_p2p_1",
+      threadKey: "om_1",
+      senderOpenId: "ou_123",
+    }, {
+      kind: "command",
+      command: { kind: "who" },
+    });
+
+    expect(extractMarkdown(getReplyPayloads(outbound)[0])).toBe("该命令仅支持群聊使用。");
+  });
+});
+
+function baseConfig(): AppConfig {
+  return {
+    feishu: {
+      appId: "app",
+      appSecret: "secret",
+      botOpenIds: new Set(["ou_bot"]),
+      botMentionNames: new Set(["opencode"]),
+      selfBotOpenIds: new Set(["ou_bot"]),
+      wsUrl: new URL("wss://open.feishu.cn/open-apis/ws/v2"),
+      allowedOpenIds: new Set(),
+      behavior: {
+        enableP2p: true,
+        enableGroup: true,
+        requireBotMentionInGroup: true,
+        strictBotMention: true,
+        ignoreNonUserSenders: true,
+        replyInThread: true,
+      },
+    },
+    opencode: {
+      baseUrl: new URL("http://127.0.0.1:4096/"),
+      directory: process.cwd(),
+    },
+    storage: {
+      dataDir: process.cwd(),
+      mappingsFile: "mappings.json",
+    },
+    whitelist: {
+      storePath: "whitelist.json",
+    },
+    bridge: {
+      queueLimit: 3,
+      sessionModes: {
+        p2p: "multi",
+        group: "single",
+        topicGroup: "single",
+      },
+      maxSessionsPerWindow: 20,
+      sessionListLimit: 10,
+      injectSystemState: true,
+      firstEventTimeoutMs: 30_000,
+      eventGapTimeoutMs: 120_000,
+      totalTimeoutMs: 300_000,
+    },
+    logging: {
+      dir: process.cwd(),
+      level: "info",
+      enableTranscript: true,
+      enableConsole: true,
+      enableColor: true,
+      rotateDaily: true,
+    },
+  };
+}
+
+function createOutbound() {
+  return {
+    sendMessage: vi.fn(async () => ({ messageId: "om_send" })),
+    replyMessage: vi.fn(async () => ({ messageId: "om_reply" })),
+    updateMessage: vi.fn(async () => ({ messageId: "om_update" })),
+  };
+}
+
+function createWhitelist(entries: Array<[string, Set<string>]> = []): ChatWhitelist {
+  const bindings = new Map(entries);
+  return {
+    isBound(chatId, senderOpenId) {
+      return bindings.get(chatId)?.has(senderOpenId) ?? false;
+    },
+    async bind(chatId, senderOpenId) {
+      const members = bindings.get(chatId) ?? new Set<string>();
+      members.add(senderOpenId);
+      bindings.set(chatId, members);
+    },
+    async unbind(chatId, senderOpenId) {
+      const members = bindings.get(chatId);
+      if (!members?.has(senderOpenId)) {
+        return false;
+      }
+      members.delete(senderOpenId);
+      if (members.size === 0) {
+        bindings.delete(chatId);
+      }
+      return true;
+    },
+    count(chatId) {
+      return bindings.get(chatId)?.size ?? 0;
+    },
+  };
+}
+
+function logger() {
+  return {
+    log() {},
+    logTranscript() {},
+  };
+}
+
+function extractMarkdown(payload: { content: string } | undefined): string {
+  if (!payload) {
+    return "";
+  }
+  const parsed = JSON.parse(payload.content) as {
+    zh_cn?: {
+      content?: Array<Array<{ text?: string }>>;
+    };
+  };
+  return parsed.zh_cn?.content?.[0]?.[0]?.text ?? "";
+}
+
+function getReplyPayloads(outbound: ReturnType<typeof createOutbound>): Array<{ content: string } | undefined> {
+  return (outbound.replyMessage.mock.calls as unknown[][]).map((call) => call[1] as { content: string } | undefined);
+}

--- a/test/config-loader.test.ts
+++ b/test/config-loader.test.ts
@@ -1,0 +1,31 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { loadConfig } from "../src/config/loader.js";
+
+describe("loadConfig", () => {
+  it("resolves whitelist.storePath under storage.dataDir by default", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-config-"));
+    const configPath = path.join(dir, "config.json");
+
+    await writeFile(configPath, JSON.stringify({
+      feishu: {
+        appId: "app",
+        appSecret: "secret",
+      },
+      opencode: {
+        baseUrl: "http://127.0.0.1:4096/",
+        directory: process.cwd(),
+      },
+      storage: {},
+      bridge: {},
+    }), "utf8");
+
+    const config = await loadConfig(configPath);
+
+    expect(config.whitelist.storePath).toBe(path.join(dir, "data", "whitelist.json"));
+  });
+});

--- a/test/formatter.test.ts
+++ b/test/formatter.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
 
-import { buildPostMarkdownPayload, buildPostPayload, buildTurnStatusCardPayload } from "../src/feishu/formatter.js";
+import {
+  buildLeaveCommandCardPayload,
+  buildPostMarkdownPayload,
+  buildPostPayload,
+  buildSessionListCardPayload,
+  buildSessionTransitionCardPayload,
+  buildStatusCommandCardPayload,
+  buildTurnStatusCardPayload,
+  buildWhoCommandCardPayload,
+} from "../src/feishu/formatter.js";
 
 describe("buildPostPayload", () => {
   it("renders a post message payload", () => {
@@ -34,15 +43,111 @@ describe("buildPostPayload", () => {
       },
     });
     const content = JSON.parse(payload.content) as any;
-    const outputContents = content.body.elements[9].columns[0].elements.map((item: { content: string }) => item.content).join("\n");
-    expect(content.header.title.content).toBe("任务进行中");
-    expect(content.body.elements[0].columns[0].elements[0].content).toContain("会话 ID");
-    expect(content.body.elements[0].columns[1].elements[0].content).toContain("约 8s");
-    expect(content.body.elements[3].columns[0].elements[0].content).toContain("生成最终回复");
-    expect(content.body.elements[6].columns[0].elements[0].content).toContain("✅ **读取文件**：package.json");
-    expect(content.body.elements[6].columns[0].elements[1].content).toContain("⏳ **执行命令**：npm run dev");
-    expect(outputContents).toContain("[工业和信息化部办公厅关于开展普惠算力赋能中小企业发展专项行动的通知](https://www.miit.gov.cn/example)");
-    expect(outputContents).toContain("**今日新闻五条_正式版.md**");
-    expect(outputContents).toContain("`C:\\Users\\LENOVO\\Desktop\\今日新闻五条_正式版.md`");
+    const serialized = JSON.stringify(content);
+    expect(content.header.title.content).toBe("正在忙");
+    expect(serialized).toContain("读取文件");
+    expect(serialized).toContain("package.json");
+    expect(serialized).toContain("执行命令");
+    expect(serialized).toContain("npm run dev");
+    expect(serialized).toContain("https://www.miit.gov.cn/example");
+    expect(serialized).toContain("今日新闻五条_正式版.md");
+    expect(serialized).toContain("约 8s");
+  });
+
+  it("renders a status command card", () => {
+    const payload = buildStatusCommandCardPayload({
+      currentSession: {
+        sessionId: "ses_2988a201effeCaZpLXXjarY0pM",
+        label: "能不能获取舆论新闻",
+      },
+      connectionState: "connected",
+      sessionMode: "multi",
+      sessionState: "idle",
+      queueState: "空闲",
+      pendingCount: 0,
+      windowCount: 1,
+    });
+    const content = JSON.parse(payload.content) as any;
+    expect(content.header.title.content).toBe("会话状态");
+    expect(content.header.template).toBe("wathet");
+    expect(content.body.elements[0].columns[0].elements[0].content).toBe("**当前会话**");
+    expect(content.body.elements[0].columns[0].elements[1].columns[0].elements[0].content).toContain("ses_2988a201effeCaZpLXXjarY0pM");
+    expect(content.body.elements[1].columns[0].elements[1].columns).toHaveLength(5);
+    expect(content.body.elements[1].columns[0].elements[1].columns[0].elements[0].content).toBe("connected");
+    expect(content.body.elements[3].columns[0].elements[0].content).toContain("`/sessions` 查看全部");
+  });
+
+  it("renders a non-empty sessions command card", () => {
+    const payload = buildSessionListCardPayload({
+      items: [
+        { index: 1, title: "开一个新闻获取的话题", current: true, meta: "当前" },
+        { index: 2, title: "帮我写个单测", meta: "04-06 15:10" },
+        { index: 3, title: "代码审查", archived: true, meta: "04-06 15:10" },
+      ],
+      footer: "发送 `/switch <编号>` 切换 · 30s 内有效",
+    });
+    const content = JSON.parse(payload.content) as any;
+    expect(content.header.title.content).toBe("会话列表");
+    expect(content.body.elements[0].columns[0].background_style).toBe("wathet-100");
+    expect(content.body.elements[0].columns[0].elements[0].columns[1].elements[0].content).toBe("**开一个新闻获取的话题**");
+    expect(content.body.elements[2].columns[0].background_style).toBe("grey-50");
+    expect(content.body.elements[2].columns[0].elements[0].columns[1].elements[0].content).toBe("~~代码审查~~");
+  });
+
+  it("renders an empty sessions command card", () => {
+    const payload = buildSessionListCardPayload({
+      items: [],
+      footer: "发送 `/new` 创建第一个会话",
+      emptyText: "暂无会话",
+    });
+    const content = JSON.parse(payload.content) as any;
+    expect(content.body.elements[0].columns[0].elements[0].content).toBe("暂无会话");
+    expect(content.body.elements[2].columns[0].elements[0].content).toContain("`/new`");
+  });
+
+  it("renders a session transition command card", () => {
+    const payload = buildSessionTransitionCardPayload({
+      title: "已切换会话",
+      iconToken: "sheet-iconsets-check_filled",
+      previousLabel: "帮我写个单测",
+      currentLabel: "开一个新闻获取的话题",
+      footer: "创建于 04-06 14:32 · 共 8 条消息",
+    });
+    const content = JSON.parse(payload.content) as any;
+    expect(content.header.title.content).toBe("已切换会话");
+    expect(content.body.elements[0].columns[1].elements[0].content).toBe("~~帮我写个单测~~");
+    expect(content.body.elements[1].columns[1].elements[0].content).toBe("**开一个新闻获取的话题**");
+    expect(content.body.elements[3].columns[0].elements[0].content).toContain("共 8 条消息");
+  });
+
+  it("renders a bound who command card", () => {
+    const payload = buildWhoCommandCardPayload({ boundCount: 2, isBound: true });
+    const content = JSON.parse(payload.content) as any;
+    expect(content.header.title.content).toBe("群聊绑定状态");
+    expect(content.body.elements[0].columns[1].elements[0].content).toBe("**2 人**");
+    expect(content.body.elements[1].columns[1].elements[0].content).toBe("**已绑定**");
+    expect(content.body.elements[3].columns[0].elements[0].content).toContain("`/leave`");
+  });
+
+  it("renders an unbound who command card", () => {
+    const payload = buildWhoCommandCardPayload({ boundCount: 0, isBound: false });
+    const content = JSON.parse(payload.content) as any;
+    expect(content.body.elements[0].columns[1].elements[0].content).toBe("**0 人**");
+    expect(content.body.elements[1].columns[1].elements[0].content).toBe("**未绑定**");
+    expect(content.body.elements[3].columns[0].elements[0].content).toContain("@bot");
+  });
+
+  it("renders a successful leave card", () => {
+    const payload = buildLeaveCommandCardPayload({ unbound: true });
+    const content = JSON.parse(payload.content) as any;
+    expect(content.header.title.content).toBe("已解除绑定");
+    expect(content.body.elements[0].columns[0].elements[0].content).toContain("后续消息不再响应");
+  });
+
+  it("renders an idempotent leave card", () => {
+    const payload = buildLeaveCommandCardPayload({ unbound: false });
+    const content = JSON.parse(payload.content) as any;
+    expect(content.header.title.content).toBe("无需解除绑定");
+    expect(content.body.elements[0].columns[0].elements[0].content).toContain("尚未绑定");
   });
 });

--- a/test/group-chat.test.ts
+++ b/test/group-chat.test.ts
@@ -17,6 +17,7 @@ vi.mock("@larksuiteoapi/node-sdk", () => {
 
 import { FeishuWsClient, buildConversationKey, computeThreadKey, createFeishuIngressOptions, normalizeIncomingMessage } from "../src/feishu/ws.js";
 import { toOpencodePromptText } from "../src/runtime/app.js";
+import type { ChatWhitelist } from "../src/store/whitelist.js";
 
 function makeOptions(overrides?: Partial<ReturnType<typeof createFeishuIngressOptions>>) {
   return {
@@ -40,6 +41,31 @@ function makeOptions(overrides?: Partial<ReturnType<typeof createFeishuIngressOp
       },
     }),
     ...overrides,
+  };
+}
+
+function createWhitelist(): ChatWhitelist & { bindings: Map<string, Set<string>> } {
+  const bindings = new Map<string, Set<string>>();
+  return {
+    bindings,
+    isBound(chatId, senderOpenId) {
+      return bindings.get(chatId)?.has(senderOpenId) ?? false;
+    },
+    async bind(chatId, senderOpenId) {
+      const members = bindings.get(chatId) ?? new Set<string>();
+      members.add(senderOpenId);
+      bindings.set(chatId, members);
+    },
+    async unbind(chatId, senderOpenId) {
+      const members = bindings.get(chatId);
+      if (!members?.has(senderOpenId)) return false;
+      members.delete(senderOpenId);
+      if (members.size === 0) bindings.delete(chatId);
+      return true;
+    },
+    count(chatId) {
+      return bindings.get(chatId)?.size ?? 0;
+    },
   };
 }
 
@@ -448,5 +474,119 @@ describe("group chat support", () => {
     await (client as unknown as { handleEvent(payload: unknown): Promise<void> }).handleEvent(payload);
 
     expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("binds a sender after an @bot message and then allows non-mentioned follow-ups", async () => {
+    const handler = vi.fn(async () => {});
+    const logger = { log: vi.fn() };
+    const whitelist = createWhitelist();
+    const client = new FeishuWsClient("app", "secret", makeOptions(), handler, logger, whitelist);
+
+    await (client as unknown as { handleEvent(payload: unknown): Promise<void> }).handleEvent({
+      message: {
+        chat_id: "oc_group_bind_1",
+        chat_type: "group",
+        message_id: "om_bind_1",
+        message_type: "text",
+        content: JSON.stringify({ text: '<at user_id="ou_bot">机器人</at> 帮我分析一下' }),
+        mentions: [{ id: { open_id: "ou_bot" }, name: "机器人" }],
+      },
+      sender: { sender_id: { open_id: "ou_123" } },
+    });
+
+    await (client as unknown as { handleEvent(payload: unknown): Promise<void> }).handleEvent({
+      message: {
+        chat_id: "oc_group_bind_1",
+        chat_type: "group",
+        message_id: "om_bind_2",
+        message_type: "text",
+        content: JSON.stringify({ text: "继续刚才的话题" }),
+      },
+      sender: { sender_id: { open_id: "ou_123" } },
+    });
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(whitelist.isBound("oc_group_bind_1", "ou_123")).toBe(true);
+  });
+
+  it("skips unbound non-mentioned group messages with not-whitelisted", async () => {
+    const handler = vi.fn(async () => {});
+    const logger = { log: vi.fn() };
+    const client = new FeishuWsClient("app", "secret", makeOptions(), handler, logger, createWhitelist());
+
+    await (client as unknown as { handleEvent(payload: unknown): Promise<void> }).handleEvent({
+      message: {
+        chat_id: "oc_group_skip_1",
+        chat_type: "group",
+        message_id: "om_skip_1",
+        message_type: "text",
+        content: JSON.stringify({ text: "这条不该触发" }),
+      },
+      sender: { sender_id: { open_id: "ou_123" } },
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(logger.log).toHaveBeenCalledWith("feishu/ws", "message skipped", expect.objectContaining({
+      reason: "not-whitelisted",
+      chatId: "oc_group_skip_1",
+    }), "warn");
+  });
+
+  it("allows slash commands with @bot without auto-binding the sender", async () => {
+    const handler = vi.fn(async () => {});
+    const whitelist = createWhitelist();
+    const client = new FeishuWsClient("app", "secret", makeOptions(), handler, { log() {} }, whitelist);
+
+    await (client as unknown as { handleEvent(payload: unknown): Promise<void> }).handleEvent({
+      message: {
+        chat_id: "oc_group_cmd_1",
+        chat_type: "group",
+        message_id: "om_cmd_1",
+        message_type: "text",
+        content: JSON.stringify({ text: '<at user_id="ou_bot">机器人</at> /status' }),
+        mentions: [{ id: { open_id: "ou_bot" }, name: "机器人" }],
+      },
+      sender: { sender_id: { open_id: "ou_123" } },
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ plainText: "/status" }));
+    expect(whitelist.isBound("oc_group_cmd_1", "ou_123")).toBe(false);
+  });
+
+  it("shares the same whitelist across group and topic_group windows", async () => {
+    const handler = vi.fn(async () => {});
+    const whitelist = createWhitelist();
+    const client = new FeishuWsClient("app", "secret", makeOptions(), handler, { log() {} }, whitelist);
+
+    await (client as unknown as { handleEvent(payload: unknown): Promise<void> }).handleEvent({
+      message: {
+        chat_id: "oc_group_shared_1",
+        chat_type: "group",
+        message_id: "om_shared_1",
+        message_type: "text",
+        content: JSON.stringify({ text: '<at user_id="ou_bot">机器人</at> 帮我看一下' }),
+        mentions: [{ id: { open_id: "ou_bot" }, name: "机器人" }],
+      },
+      sender: { sender_id: { open_id: "ou_123" } },
+    });
+
+    await (client as unknown as { handleEvent(payload: unknown): Promise<void> }).handleEvent({
+      message: {
+        chat_id: "oc_group_shared_1",
+        chat_type: "topic_group",
+        message_id: "om_shared_2",
+        root_id: "om_root_1",
+        message_type: "text",
+        content: JSON.stringify({ text: "话题里继续说" }),
+      },
+      sender: { sender_id: { open_id: "ou_123" } },
+    });
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler).toHaveBeenLastCalledWith(expect.objectContaining({
+      chatType: "topic_group",
+      conversationKey: "oc_group_shared_1:om_root_1",
+    }));
   });
 });

--- a/test/group-chat.test.ts
+++ b/test/group-chat.test.ts
@@ -532,6 +532,35 @@ describe("group chat support", () => {
     }), "warn");
   });
 
+  it("preserves permissive group mode when requireBotMentionInGroup is false", async () => {
+    const handler = vi.fn(async () => {});
+    const client = new FeishuWsClient(
+      "app",
+      "secret",
+      makeOptions({ requireBotMentionInGroup: false }),
+      handler,
+      { log() {} },
+      createWhitelist(),
+    );
+
+    await (client as unknown as { handleEvent(payload: unknown): Promise<void> }).handleEvent({
+      message: {
+        chat_id: "oc_group_loose_1",
+        chat_type: "group",
+        message_id: "om_loose_1",
+        message_type: "text",
+        content: JSON.stringify({ text: "不带 @ 也应该继续通过" }),
+      },
+      sender: { sender_id: { open_id: "ou_123" } },
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({
+      chatId: "oc_group_loose_1",
+      plainText: "不带 @ 也应该继续通过",
+    }));
+  });
+
   it("allows slash commands with @bot without auto-binding the sender", async () => {
     const handler = vi.fn(async () => {});
     const whitelist = createWhitelist();

--- a/test/group-chat.test.ts
+++ b/test/group-chat.test.ts
@@ -19,6 +19,33 @@ import { FeishuWsClient, buildConversationKey, computeThreadKey, createFeishuIng
 import { toOpencodePromptText } from "../src/runtime/app.js";
 import type { ChatWhitelist } from "../src/store/whitelist.js";
 
+function createWhitelistStub(initial: Record<string, string[]> = {}) {
+  const map = new Map<string, Set<string>>(
+    Object.entries(initial).map(([chatId, members]) => [chatId, new Set(members)]),
+  );
+
+  return {
+    isBound(chatId: string, senderOpenId: string) {
+      return map.get(chatId)?.has(senderOpenId) ?? false;
+    },
+    async bind(chatId: string, senderOpenId: string) {
+      const members = map.get(chatId) ?? new Set<string>();
+      members.add(senderOpenId);
+      map.set(chatId, members);
+    },
+    async unbind(chatId: string, senderOpenId: string) {
+      const members = map.get(chatId);
+      if (!members?.has(senderOpenId)) return false;
+      members.delete(senderOpenId);
+      if (members.size === 0) map.delete(chatId);
+      return true;
+    },
+    count(chatId: string) {
+      return map.get(chatId)?.size ?? 0;
+    },
+  };
+}
+
 function makeOptions(overrides?: Partial<ReturnType<typeof createFeishuIngressOptions>>) {
   return {
     ...createFeishuIngressOptions({
@@ -73,7 +100,7 @@ describe("group chat support", () => {
   it("normalizes group text messages using nested mentions and thread keys", async () => {
     const handler = vi.fn(async () => {});
     const logger = { log() {} };
-    const client = new FeishuWsClient("app", "secret", makeOptions(), handler, logger);
+    const client = new FeishuWsClient("app", "secret", makeOptions(), createWhitelistStub(), handler, logger);
 
     await (client as unknown as { handleEvent(payload: unknown): Promise<void> }).handleEvent({
       message: {
@@ -454,7 +481,7 @@ describe("group chat support", () => {
   it("deduplicates repeated deliveries with the same message id", async () => {
     const handler = vi.fn(async () => {});
     const logger = { log() {} };
-    const client = new FeishuWsClient("app", "secret", makeOptions(), handler, logger);
+    const client = new FeishuWsClient("app", "secret", makeOptions(), createWhitelistStub(), handler, logger);
     const payload = {
       message: {
         chat_id: "oc_p2p_1",
@@ -476,11 +503,45 @@ describe("group chat support", () => {
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
+  it("allows bound group members to continue without mention", async () => {
+    const handler = vi.fn(async () => {});
+    const logger = { log() {} };
+    const client = new FeishuWsClient(
+      "app",
+      "secret",
+      makeOptions(),
+      createWhitelistStub({ oc_group_1: ["ou_123"] }),
+      handler,
+      logger,
+    );
+
+    await (client as unknown as { handleEvent(payload: unknown): Promise<void> }).handleEvent({
+      message: {
+        chat_id: "oc_group_1",
+        chat_type: "group",
+        message_id: "om_bound_1",
+        message_type: "text",
+        content: JSON.stringify({ text: "继续刚才的话题" }),
+      },
+      sender: {
+        sender_id: {
+          open_id: "ou_123",
+        },
+      },
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({
+      plainText: "继续刚才的话题",
+      senderOpenId: "ou_123",
+    }));
+  });
+
   it("binds a sender after an @bot message and then allows non-mentioned follow-ups", async () => {
     const handler = vi.fn(async () => {});
     const logger = { log: vi.fn() };
     const whitelist = createWhitelist();
-    const client = new FeishuWsClient("app", "secret", makeOptions(), handler, logger, whitelist);
+    const client = new FeishuWsClient("app", "secret", makeOptions(), whitelist, handler, logger);
 
     await (client as unknown as { handleEvent(payload: unknown): Promise<void> }).handleEvent({
       message: {
@@ -512,7 +573,7 @@ describe("group chat support", () => {
   it("skips unbound non-mentioned group messages with not-whitelisted", async () => {
     const handler = vi.fn(async () => {});
     const logger = { log: vi.fn() };
-    const client = new FeishuWsClient("app", "secret", makeOptions(), handler, logger, createWhitelist());
+    const client = new FeishuWsClient("app", "secret", makeOptions(), createWhitelist(), handler, logger);
 
     await (client as unknown as { handleEvent(payload: unknown): Promise<void> }).handleEvent({
       message: {
@@ -538,9 +599,9 @@ describe("group chat support", () => {
       "app",
       "secret",
       makeOptions({ requireBotMentionInGroup: false }),
+      createWhitelist(),
       handler,
       { log() {} },
-      createWhitelist(),
     );
 
     await (client as unknown as { handleEvent(payload: unknown): Promise<void> }).handleEvent({
@@ -564,7 +625,7 @@ describe("group chat support", () => {
   it("allows slash commands with @bot without auto-binding the sender", async () => {
     const handler = vi.fn(async () => {});
     const whitelist = createWhitelist();
-    const client = new FeishuWsClient("app", "secret", makeOptions(), handler, { log() {} }, whitelist);
+    const client = new FeishuWsClient("app", "secret", makeOptions(), whitelist, handler, { log() {} });
 
     await (client as unknown as { handleEvent(payload: unknown): Promise<void> }).handleEvent({
       message: {
@@ -586,7 +647,7 @@ describe("group chat support", () => {
   it("shares the same whitelist across group and topic_group windows", async () => {
     const handler = vi.fn(async () => {});
     const whitelist = createWhitelist();
-    const client = new FeishuWsClient("app", "secret", makeOptions(), handler, { log() {} }, whitelist);
+    const client = new FeishuWsClient("app", "secret", makeOptions(), whitelist, handler, { log() {} });
 
     await (client as unknown as { handleEvent(payload: unknown): Promise<void> }).handleEvent({
       message: {
@@ -617,5 +678,72 @@ describe("group chat support", () => {
       chatType: "topic_group",
       conversationKey: "oc_group_shared_1:om_root_1",
     }));
+  });
+
+  it("allows /who for unbound users without mention", async () => {
+    const handler = vi.fn(async () => {});
+    const logger = { log() {} };
+    const whitelist = {
+      isBound() { return false; },
+      bind: vi.fn(async () => {}),
+      async unbind() { return false; },
+      count() { return 0; },
+    };
+    const client = new FeishuWsClient("app", "secret", makeOptions(), whitelist, handler, logger);
+
+    await (client as unknown as { handleEvent(payload: unknown): Promise<void> }).handleEvent({
+      message: {
+        chat_id: "oc_group_1",
+        chat_type: "group",
+        message_id: "om_who_1",
+        message_type: "text",
+        content: JSON.stringify({ text: "/who" }),
+      },
+      sender: {
+        sender_id: {
+          open_id: "ou_999",
+        },
+      },
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(whitelist.bind).not.toHaveBeenCalled();
+  });
+
+  it("does not bind users for @bot /who", async () => {
+    const handler = vi.fn(async () => {});
+    const logger = { log() {} };
+    const whitelist = {
+      isBound() { return false; },
+      bind: vi.fn(async () => {}),
+      async unbind() { return false; },
+      count() { return 0; },
+    };
+    const client = new FeishuWsClient("app", "secret", makeOptions(), whitelist, handler, logger);
+
+    await (client as unknown as { handleEvent(payload: unknown): Promise<void> }).handleEvent({
+      message: {
+        chat_id: "oc_group_1",
+        chat_type: "group",
+        message_id: "om_who_2",
+        message_type: "text",
+        content: JSON.stringify({ text: '<at user_id="ou_bot">OpenCode</at> /who' }),
+        mentions: [
+          {
+            id: { open_id: "ou_bot" },
+            name: "OpenCode",
+          },
+        ],
+      },
+      sender: {
+        sender_id: {
+          open_id: "ou_999",
+        },
+      },
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ plainText: "/who" }));
+    expect(whitelist.bind).not.toHaveBeenCalled();
   });
 });

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -43,19 +43,23 @@ describe("routeIncomingText", () => {
     });
   });
 
-  it("routes whitelist management commands", () => {
-    expect(routeIncomingText("/leave")).toEqual({
-      kind: "command",
-      command: { kind: "leave" },
-    });
+  it("routes group whitelist commands", () => {
     expect(routeIncomingText("/who")).toEqual({
       kind: "command",
       command: { kind: "who" },
     });
+    expect(routeIncomingText("/leave")).toEqual({
+      kind: "command",
+      command: { kind: "leave" },
+    });
   });
 
-  it("recognizes commands wrapped by a visible leading mention", () => {
+  it("routes slash commands with a visible mention prefix", () => {
     expect(routeIncomingText("@机器人 /who")).toEqual({
+      kind: "command",
+      command: { kind: "who" },
+    });
+    expect(routeIncomingText("@OpenCode /who")).toEqual({
       kind: "command",
       command: { kind: "who" },
     });

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -3,6 +3,17 @@ import { describe, expect, it } from "vitest";
 import { routeIncomingText } from "../src/bridge/router.js";
 
 describe("routeIncomingText", () => {
+  it("routes built-in session and status commands", () => {
+    expect(routeIncomingText("/status")).toEqual({
+      kind: "command",
+      command: { kind: "status" },
+    });
+    expect(routeIncomingText("/new")).toEqual({
+      kind: "command",
+      command: { kind: "new" },
+    });
+  });
+
   it("routes /sessions <index> without accepting bare numbers", () => {
     expect(routeIncomingText("/sessions 3")).toEqual({
       kind: "command",
@@ -29,6 +40,28 @@ describe("routeIncomingText", () => {
     expect(routeIncomingText("/deny")).toEqual({
       kind: "command",
       command: { kind: "deny" },
+    });
+  });
+
+  it("routes whitelist management commands", () => {
+    expect(routeIncomingText("/leave")).toEqual({
+      kind: "command",
+      command: { kind: "leave" },
+    });
+    expect(routeIncomingText("/who")).toEqual({
+      kind: "command",
+      command: { kind: "who" },
+    });
+  });
+
+  it("recognizes commands wrapped by a visible leading mention", () => {
+    expect(routeIncomingText("@机器人 /who")).toEqual({
+      kind: "command",
+      command: { kind: "who" },
+    });
+    expect(routeIncomingText("@Open Code /status")).toEqual({
+      kind: "command",
+      command: { kind: "status" },
     });
   });
 

--- a/test/whitelist.test.ts
+++ b/test/whitelist.test.ts
@@ -1,0 +1,40 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { WhitelistStore } from "../src/store/whitelist.js";
+
+describe("WhitelistStore", () => {
+  it("loads persisted chat bindings", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-whitelist-"));
+    const storePath = path.join(dir, "whitelist.json");
+    const store = new WhitelistStore(storePath);
+
+    await store.bind("oc_group_1", "ou_1");
+    await store.bind("oc_group_1", "ou_2");
+
+    const reloaded = new WhitelistStore(storePath);
+    await reloaded.load();
+
+    expect(reloaded.isBound("oc_group_1", "ou_1")).toBe(true);
+    expect(reloaded.count("oc_group_1")).toBe(2);
+  });
+
+  it("removes empty chat bindings from disk when the last member leaves", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-whitelist-"));
+    const storePath = path.join(dir, "whitelist.json");
+    const store = new WhitelistStore(storePath);
+
+    await store.bind("oc_group_1", "ou_1");
+    expect(await store.unbind("oc_group_1", "ou_1")).toBe(true);
+
+    const raw = JSON.parse(await readFile(storePath, "utf8")) as {
+      version: number;
+      bindings: Record<string, string[]>;
+    };
+    expect(raw.version).toBe(1);
+    expect(raw.bindings.oc_group_1).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 变更内容
- 新增按群维度持久化的白名单绑定存储，支持用户在群里首次 `@ bot` 后免 `@` 继续对话
- 调整飞书入站消息检查逻辑，在 `group` 和 `topic_group` 中引入白名单命中、绑定、解绑与查询能力
- 新增 `/leave` 和 `/who` 命令，并支持带可见 mention 前缀的命令文本解析
- 更新配置、示例和中英文文档，补充群聊白名单、路由和运行时行为的测试覆盖

## 变更原因
现有群聊模式下，用户每次发言都必须重新 `@ bot` 才能继续对话，连续交流成本较高，也不利于在线程或同群后续消息里自然延续上下文。

## 影响
群聊用户在首次显式触发后，可以在同一 `chat_id` 下继续无 `@` 对话，话题窗口也会共享同一份群白名单；同时用户可以主动退出绑定，群内权限边界会更清晰。

## 验证
- `npm test`
- `npm run typecheck`
- `npm run lint`