### PR TITLE
[codex] 新增会话命令卡片与模型切换能力

### DIFF
--- a/src/bridge/router.ts
+++ b/src/bridge/router.ts
@@ -16,6 +16,7 @@ export type RoutedText =
       | { kind: "sessions-select"; index: number }
       | { kind: "allow"; policy: "once" | "always" }
       | { kind: "deny" }
+      | { kind: "invalid"; message: string }
       | { kind: "passthrough"; name: string; arguments: string[] };
   }
   | { kind: "message"; text: string };
@@ -33,13 +34,22 @@ export function routeIncomingText(text: string): RoutedText {
   if (rawCommand === "new" && args.length === 0) {
     return { kind: "command", command: { kind: "new" } };
   }
+  if (rawCommand === "new") {
+    return invalidCommand("用法：/new");
+  }
 
   if (rawCommand === "status" && args.length === 0) {
     return { kind: "command", command: { kind: "status" } };
   }
+  if (rawCommand === "status") {
+    return invalidCommand("用法：/status");
+  }
 
   if (rawCommand === "current" && args.length === 0) {
     return { kind: "command", command: { kind: "status" } };
+  }
+  if (rawCommand === "current") {
+    return invalidCommand("用法：/current");
   }
 
   if (rawCommand === "rename" && args.length > 0) {
@@ -47,6 +57,9 @@ export function routeIncomingText(text: string): RoutedText {
       kind: "command",
       command: { kind: "rename", label: args.join(" ").trim() },
     };
+  }
+  if (rawCommand === "rename") {
+    return invalidCommand("用法：/rename <新名称>");
   }
 
   if (rawCommand === "close" && args.length === 0) {
@@ -59,6 +72,9 @@ export function routeIncomingText(text: string): RoutedText {
       command: { kind: "close", index: Number(args[0]) },
     };
   }
+  if (rawCommand === "close") {
+    return invalidCommand("用法：/close [编号]");
+  }
 
   if (rawCommand === "delete" && args.length === 0) {
     return { kind: "command", command: { kind: "close" } };
@@ -70,43 +86,67 @@ export function routeIncomingText(text: string): RoutedText {
       command: { kind: "close", index: Number(args[0]) },
     };
   }
+  if (rawCommand === "delete") {
+    return invalidCommand("用法：/delete [编号]");
+  }
 
   if (rawCommand === "abort" && args.length === 0) {
     return { kind: "command", command: { kind: "abort" } };
   }
+  if (rawCommand === "abort") {
+    return invalidCommand("用法：/abort");
+  }
 
   if (rawCommand === "models" && args.length === 0) {
     return { kind: "command", command: { kind: "models" } };
+  }
+  if (rawCommand === "models" && args.length === 1) {
+    return { kind: "command", command: { kind: "models", provider: args[0] } };
+  }
+  if (rawCommand === "models") {
+    return invalidCommand("用法：/models [provider]");
   }
 
   if (rawCommand === "model" && args.length === 0) {
     return { kind: "command", command: { kind: "models" } };
   }
 
-  if (rawCommand === "models" && args.length === 1) {
-    return { kind: "command", command: { kind: "models", provider: args[0] } };
+  if (rawCommand === "model" && args[0] === "use") {
+    if (args.length >= 2 && args.slice(1).join(" ").trim().length > 0) {
+      return {
+        kind: "command",
+        command: { kind: "model-use", model: args.slice(1).join(" ").trim() },
+      };
+    }
+    return invalidCommand("用法：/model use <provider/model>");
+  }
+
+  if (rawCommand === "model" && args[0] === "reset") {
+    if (args.length === 1) {
+      return { kind: "command", command: { kind: "model-reset" } };
+    }
+    return invalidCommand("用法：/model reset");
   }
 
   if (rawCommand === "model" && args.length === 1) {
-    if (args[0] === "reset") {
-      return { kind: "command", command: { kind: "model-reset" } };
-    }
     return { kind: "command", command: { kind: "models", provider: args[0] } };
   }
-
-  if (rawCommand === "model" && args.length >= 2 && args[0] === "use") {
-    return {
-      kind: "command",
-      command: { kind: "model-use", model: args.slice(1).join(" ").trim() },
-    };
+  if (rawCommand === "model") {
+    return invalidCommand("用法：/model [provider]\n或：/model use <provider/model>\n或：/model reset");
   }
 
   if (rawCommand === "leave" && args.length === 0) {
     return { kind: "command", command: { kind: "leave" } };
   }
+  if (rawCommand === "leave") {
+    return invalidCommand("用法：/leave");
+  }
 
   if (rawCommand === "who" && args.length === 0) {
     return { kind: "command", command: { kind: "who" } };
+  }
+  if (rawCommand === "who") {
+    return invalidCommand("用法：/who");
   }
 
   if (rawCommand === "sessions" && args.length === 0) {
@@ -119,12 +159,18 @@ export function routeIncomingText(text: string): RoutedText {
       command: { kind: "sessions-select", index: Number(args[0]) },
     };
   }
+  if (rawCommand === "sessions") {
+    return invalidCommand("用法：/sessions [编号]");
+  }
 
   if (rawCommand === "switch" && args.length === 1 && /^\d+$/.test(args[0] ?? "")) {
     return {
       kind: "command",
       command: { kind: "sessions-select", index: Number(args[0]) },
     };
+  }
+  if (rawCommand === "switch") {
+    return invalidCommand("用法：/switch <编号>");
   }
 
   if (rawCommand === "allow" && (args[0] === "once" || args[0] === "always") && args.length === 1) {
@@ -133,9 +179,15 @@ export function routeIncomingText(text: string): RoutedText {
       command: { kind: "allow", policy: args[0] },
     };
   }
+  if (rawCommand === "allow") {
+    return invalidCommand("用法：/allow <once|always>");
+  }
 
   if (rawCommand === "deny" && args.length === 0) {
     return { kind: "command", command: { kind: "deny" } };
+  }
+  if (rawCommand === "deny") {
+    return invalidCommand("用法：/deny");
   }
 
   return {
@@ -165,4 +217,11 @@ function normalizeCommandCandidate(text: string): string {
 function stripVisibleMentionPrefix(text: string): string {
   const match = text.match(/^@.+?\s+(\/.+)$/);
   return match?.[1]?.trim() ?? text;
+}
+
+function invalidCommand(message: string): RoutedText {
+  return {
+    kind: "command",
+    command: { kind: "invalid", message },
+  };
 }

--- a/src/bridge/router.ts
+++ b/src/bridge/router.ts
@@ -4,8 +4,12 @@ export type RoutedText =
     command:
       | { kind: "new" }
       | { kind: "status" }
+      | { kind: "rename"; label: string }
+      | { kind: "close"; index?: number | undefined }
       | { kind: "abort" }
-      | { kind: "models" }
+      | { kind: "models"; provider?: string | undefined }
+      | { kind: "model-use"; model: string }
+      | { kind: "model-reset" }
       | { kind: "leave" }
       | { kind: "who" }
       | { kind: "sessions" }
@@ -34,12 +38,67 @@ export function routeIncomingText(text: string): RoutedText {
     return { kind: "command", command: { kind: "status" } };
   }
 
+  if (rawCommand === "current" && args.length === 0) {
+    return { kind: "command", command: { kind: "status" } };
+  }
+
+  if (rawCommand === "rename" && args.length > 0) {
+    return {
+      kind: "command",
+      command: { kind: "rename", label: args.join(" ").trim() },
+    };
+  }
+
+  if (rawCommand === "close" && args.length === 0) {
+    return { kind: "command", command: { kind: "close" } };
+  }
+
+  if (rawCommand === "close" && args.length === 1 && /^\d+$/.test(args[0] ?? "")) {
+    return {
+      kind: "command",
+      command: { kind: "close", index: Number(args[0]) },
+    };
+  }
+
+  if (rawCommand === "delete" && args.length === 0) {
+    return { kind: "command", command: { kind: "close" } };
+  }
+
+  if (rawCommand === "delete" && args.length === 1 && /^\d+$/.test(args[0] ?? "")) {
+    return {
+      kind: "command",
+      command: { kind: "close", index: Number(args[0]) },
+    };
+  }
+
   if (rawCommand === "abort" && args.length === 0) {
     return { kind: "command", command: { kind: "abort" } };
   }
 
   if (rawCommand === "models" && args.length === 0) {
     return { kind: "command", command: { kind: "models" } };
+  }
+
+  if (rawCommand === "model" && args.length === 0) {
+    return { kind: "command", command: { kind: "models" } };
+  }
+
+  if (rawCommand === "models" && args.length === 1) {
+    return { kind: "command", command: { kind: "models", provider: args[0] } };
+  }
+
+  if (rawCommand === "model" && args.length === 1) {
+    if (args[0] === "reset") {
+      return { kind: "command", command: { kind: "model-reset" } };
+    }
+    return { kind: "command", command: { kind: "models", provider: args[0] } };
+  }
+
+  if (rawCommand === "model" && args.length >= 2 && args[0] === "use") {
+    return {
+      kind: "command",
+      command: { kind: "model-use", model: args.slice(1).join(" ").trim() },
+    };
   }
 
   if (rawCommand === "leave" && args.length === 0) {

--- a/src/feishu/formatter.ts
+++ b/src/feishu/formatter.ts
@@ -66,6 +66,42 @@ export type LeaveCommandCardView = {
   unbound: boolean;
 };
 
+export type RenameCommandCardView = {
+  previousLabel: string;
+  currentLabel: string;
+};
+
+export type CloseCommandCardView = {
+  closedLabel: string;
+  nextLabel?: string | null;
+  footer: string;
+};
+
+export type ModelCommandCardView = {
+  providers: Array<{
+    title: string;
+    highlightStyle?: string | null;
+    models: Array<{
+      label: string;
+      current?: boolean;
+      default?: boolean;
+    }>;
+  }>;
+  footer: string;
+};
+
+export type NoticeCardView = {
+  title: string;
+  message: string;
+  template: "blue" | "yellow" | "red" | "grey" | "orange";
+  iconToken: string;
+};
+
+export type PermissionNoticeCardView = {
+  command: string;
+  timeoutText: string;
+};
+
 export function buildQueueNoticePayload(notice: QueueNotice): FeishuPostPayload {
   return buildPostMarkdownPayload(notice.message);
 }
@@ -217,6 +253,190 @@ export function buildLeaveCommandCardPayload(view: LeaveCommandCardView): Feishu
   });
 }
 
+export function buildRenameCommandCardPayload(view: RenameCommandCardView): FeishuPostPayload {
+  return buildInteractivePayload({
+    title: "已重命名会话",
+    template: "green",
+    iconToken: "edit_filled",
+    bodyElements: [
+      buildSessionTransitionRow("原名", `~~${escapeText(view.previousLabel)}~~`, "grey-50"),
+      buildSessionTransitionRow("当前", `**${escapeText(view.currentLabel)}**`, "green-50"),
+      buildDivider(),
+      buildFooterTipBlock("后续 `/sessions` 将显示新的会话名称", "efficiency_outlined", "green", "notation"),
+    ],
+  });
+}
+
+export function buildCloseCommandCardPayload(view: CloseCommandCardView): FeishuPostPayload {
+  const bodyElements: Array<Record<string, unknown>> = [
+    buildSessionTransitionRow("删除", `~~${escapeText(view.closedLabel)}~~`, "grey-50"),
+  ];
+  if (view.nextLabel) {
+    bodyElements.push(buildSessionTransitionRow("当前", `**${escapeText(view.nextLabel)}**`, "green-50"));
+  }
+  bodyElements.push(buildDivider());
+  bodyElements.push(buildFooterTipBlock(view.footer, "calendar-add_outlined", "green", "notation"));
+
+  return buildInteractivePayload({
+    title: "已关闭会话",
+    template: "green",
+    iconToken: "close-bold_outlined",
+    bodyElements,
+  });
+}
+
+export function buildModelCommandCardPayload(view: ModelCommandCardView): FeishuPostPayload {
+  const bodyElements: Array<Record<string, unknown>> = [];
+
+  view.providers.forEach((provider, index) => {
+    if (index > 0) {
+      bodyElements.push(buildDivider());
+    }
+    bodyElements.push(buildModelProviderBlock(provider));
+  });
+
+  bodyElements.push(buildDivider());
+  bodyElements.push({
+    tag: "markdown",
+    content: view.footer,
+    text_align: "left",
+    text_size: "notation",
+    margin: "0px 0px 0px 0px",
+  });
+
+  return buildInteractivePayload({
+    title: "可用模型",
+    template: "indigo",
+    iconToken: "ai-common_colorful",
+    bodyElements,
+  });
+}
+
+export function buildNoticeCardPayload(view: NoticeCardView): FeishuPostPayload {
+  return buildInteractivePayload({
+    title: view.title,
+    template: view.template,
+    iconToken: view.iconToken,
+    bodyElements: [
+      {
+        tag: "column_set",
+        horizontal_spacing: "8px",
+        horizontal_align: "left",
+        columns: [
+          {
+            tag: "column",
+            width: "auto",
+            elements: [
+              {
+                tag: "markdown",
+                content: view.message,
+                text_align: "left",
+                text_size: "normal_v2",
+                margin: "0px 0px 0px 0px",
+              },
+            ],
+            padding: "8px 8px 8px 8px",
+            direction: "vertical",
+            horizontal_spacing: "8px",
+            vertical_spacing: "8px",
+            horizontal_align: "left",
+            vertical_align: "top",
+            margin: "0px 0px 0px 0px",
+          },
+        ],
+        margin: "0px 0px 0px 0px",
+      },
+    ],
+  });
+}
+
+export function buildPermissionNoticeCardPayload(view: PermissionNoticeCardView): FeishuPostPayload {
+  return buildInteractivePayload({
+    title: "权限请求",
+    template: "purple",
+    iconToken: "lock_filled",
+    bodyElements: [
+      {
+        tag: "column_set",
+        horizontal_spacing: "8px",
+        horizontal_align: "left",
+        columns: [
+          {
+            tag: "column",
+            width: "weighted",
+            elements: [
+              {
+                tag: "markdown",
+                content: "OpenCode 想执行：",
+                text_align: "left",
+                text_size: "normal_v2",
+                margin: "0px 0px 0px 0px",
+              },
+              {
+                tag: "column_set",
+                horizontal_spacing: "8px",
+                horizontal_align: "left",
+                columns: [
+                  {
+                    tag: "column",
+                    width: "weighted",
+                    elements: [
+                      {
+                        tag: "markdown",
+                        content: `\`\`\`\n${escapeText(view.command)}\n\`\`\``,
+                        text_align: "left",
+                        text_size: "normal_v2",
+                        margin: "0px 0px 0px 0px",
+                      },
+                    ],
+                    vertical_align: "top",
+                    weight: 1,
+                  },
+                ],
+                margin: "0px 0px 0px 0px",
+              },
+            ],
+            padding: "8px 8px 8px 8px",
+            direction: "vertical",
+            horizontal_spacing: "8px",
+            vertical_spacing: "8px",
+            horizontal_align: "left",
+            vertical_align: "top",
+            margin: "0px 0px 0px 0px",
+            weight: 1,
+          },
+        ],
+        margin: "0px 0px 0px 0px",
+      },
+      buildDivider(),
+      {
+        tag: "column_set",
+        flex_mode: "stretch",
+        horizontal_spacing: "8px",
+        horizontal_align: "left",
+        columns: [
+          buildFakeButtonColumn("/allow once · 仅此一次", "primary_filled", "fill"),
+          buildFakeButtonColumn("/allow always · 始终允许", "primary", "default"),
+          buildFakeButtonColumn("/deny · 拒绝", "danger", "default"),
+        ],
+        margin: "0px 0px 0px 0px",
+      },
+      {
+        tag: "markdown",
+        content: view.timeoutText,
+        text_align: "left",
+        text_size: "notation",
+        margin: "8px 8px 8px 8px",
+        icon: {
+          tag: "standard_icon",
+          token: "alarm-clock_outlined",
+          color: "grey",
+        },
+      },
+    ],
+  });
+}
+
 function shortSessionId(sessionId: string): string {
   return sessionId.length <= 12 ? sessionId : sessionId.slice(0, 12);
 }
@@ -273,8 +493,8 @@ function buildTurnBodyElements(
 
 function buildInteractivePayload(options: {
   title: string;
-  template: "blue" | "green" | "red" | "wathet" | "grey";
-  iconToken: string;
+  template: "blue" | "green" | "red" | "wathet" | "grey" | "yellow" | "orange" | "purple" | "indigo";
+  iconToken?: string;
   bodyElements: Array<Record<string, unknown>>;
 }): FeishuPostPayload {
   return {
@@ -298,10 +518,14 @@ function buildInteractivePayload(options: {
         subtitle: { tag: "plain_text", content: "" },
         template: options.template,
         title: { tag: "plain_text", content: options.title },
-        icon: {
-          tag: "standard_icon",
-          token: options.iconToken,
-        },
+        ...(options.iconToken
+          ? {
+            icon: {
+              tag: "standard_icon",
+              token: options.iconToken,
+            },
+          }
+          : {}),
       },
       body: {
         direction: "vertical",
@@ -558,6 +782,102 @@ function buildTwoColumnBadgeRow(
         margin: "0px 0px 0px 0px",
       },
     ],
+    margin: "0px 0px 0px 0px",
+  };
+}
+
+function buildFakeButtonColumn(
+  text: string,
+  buttonType: "primary_filled" | "primary" | "danger",
+  width: "fill" | "default",
+): Record<string, unknown> {
+  return {
+    tag: "column",
+    width: "auto",
+    elements: [
+      {
+        tag: "button",
+        text: {
+          tag: "plain_text",
+          content: text,
+        },
+        type: buttonType,
+        width,
+        size: "medium",
+        margin: "0px 0px 0px 0px",
+      },
+    ],
+    vertical_align: "top",
+  };
+}
+
+function buildModelProviderBlock(provider: ModelCommandCardView["providers"][number]): Record<string, unknown> {
+  return {
+    tag: "column_set",
+    flex_mode: "stretch",
+    horizontal_spacing: "12px",
+    horizontal_align: "left",
+    columns: [
+      {
+        tag: "column",
+        width: "weighted",
+        elements: [
+          {
+            tag: "markdown",
+            content: escapeText(provider.title),
+            text_align: "left",
+            text_size: "normal",
+          },
+          {
+            tag: "column_set",
+            flex_mode: "flow",
+            horizontal_spacing: "8px",
+            horizontal_align: "left",
+            columns: provider.models.map((model) => buildModelChip(model, provider.highlightStyle ?? null)),
+            margin: "0px 0px 0px 0px",
+          },
+        ],
+        padding: "8px 8px 8px 8px",
+        direction: "vertical",
+        horizontal_spacing: "8px",
+        vertical_spacing: "4px",
+        horizontal_align: "left",
+        vertical_align: "top",
+        margin: "0px 0px 0px 0px",
+        weight: 1,
+      },
+    ],
+    margin: "0px 0px 0px 0px",
+  };
+}
+
+function buildModelChip(
+  model: ModelCommandCardView["providers"][number]["models"][number],
+  highlightStyle: string | null,
+): Record<string, unknown> {
+  const markers: string[] = [];
+  if (model.current) markers.push("当前");
+  if (model.default) markers.push("默认");
+  const suffix = markers.length > 0 ? ` ← ${markers.join(" / ")}` : "";
+  return {
+    tag: "column",
+    width: "auto",
+    ...(model.current && highlightStyle ? { background_style: highlightStyle } : {}),
+    elements: [
+      {
+        tag: "markdown",
+        content: `${model.current ? "**" : ""}${escapeText(model.label)}${suffix}${model.current ? "**" : ""}`,
+        text_align: "left",
+        text_size: "notation",
+        margin: "0px 0px 0px 0px",
+      },
+    ],
+    padding: "4px 4px 4px 4px",
+    direction: "vertical",
+    horizontal_spacing: "8px",
+    vertical_spacing: "8px",
+    horizontal_align: "left",
+    vertical_align: "top",
     margin: "0px 0px 0px 0px",
   };
 }

--- a/src/opencode/client.ts
+++ b/src/opencode/client.ts
@@ -80,7 +80,17 @@ export type OpenCodeCommandRequest = {
 };
 
 export type OpenCodeProvidersResponse = {
-  providers: Array<Record<string, unknown>>;
+  providers: Array<Record<string, unknown> & {
+    id?: string;
+    providerID?: string;
+    name?: string;
+    models?: Record<string, Record<string, unknown> & {
+      id?: string;
+      name?: string;
+      status?: string;
+      release_date?: string;
+    }>;
+  }>;
   default: Record<string, string>;
 };
 

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -542,6 +542,16 @@ export class BridgeApp {
     routed: Extract<RoutedText, { kind: "command" }>,
   ): Promise<void> {
     const { command } = routed;
+    if (command.kind === "invalid") {
+      await this.sendNoticeCard(message.chatId, {
+        title: "信息提示",
+        message: command.message,
+        template: "blue",
+        iconToken: "info_outlined",
+      }, message.messageId);
+      return;
+    }
+
     if (command.kind === "new") {
       const previousSession = getActiveSession(this.getSessionWindow(message.conversationKey, message.chatType));
       const entry = await this.createAndBindSession(message);
@@ -633,6 +643,7 @@ export class BridgeApp {
 
     if (command.kind === "close") {
       const window = this.getSessionWindow(message.conversationKey, message.chatType);
+      const currentSession = getActiveSession(window);
       let targetSession = getActiveSession(window);
 
       if (command.index !== undefined) {
@@ -665,6 +676,22 @@ export class BridgeApp {
           message: "当前没有可关闭的会话。",
           template: "blue",
           iconToken: "info_outlined",
+        }, message.messageId);
+        return;
+      }
+
+      const activeTurn = this.queues.get(message.conversationKey).peek();
+      const closingRunningSession = activeTurn
+        && (
+          activeTurn.sessionId === targetSession.sessionId
+          || (!activeTurn.sessionId && currentSession?.sessionId === targetSession.sessionId)
+        );
+      if (closingRunningSession) {
+        await this.sendNoticeCard(message.chatId, {
+          title: "提醒",
+          message: "该会话有任务正在执行，请先 /abort 再关闭。",
+          template: "yellow",
+          iconToken: "maybe_outlined",
         }, message.messageId);
         return;
       }
@@ -1726,8 +1753,8 @@ export function buildBridgeSystemPrompt(
       : ["- none"]),
     `senderOpenId: ${turn.senderOpenId}`,
     "rules:",
-    "- Bridge owns /new /sessions /switch /status and all runtime progress or reply messages.",
-    "- Do not pretend to switch, create, close, or rename bridge sessions yourself.",
+    "- Bridge owns /new /sessions /switch /status /rename /close /model and all runtime progress or reply messages.",
+    "- Do not pretend to switch, create, close, rename, or change bridge session models yourself.",
     "- Use lark-cli only when the user explicitly asks to operate on Feishu or Lark resources.",
   ];
   return lines.join("\n");

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -7,9 +7,14 @@ import { transitionTurn } from "../bridge/state-machine.js";
 import { TurnWatchdog } from "../bridge/watchdog.js";
 import type { BridgeTurn } from "../bridge/turn.js";
 import {
+  buildCloseCommandCardPayload,
   buildPostMarkdownPayload,
   buildLeaveCommandCardPayload,
+  buildModelCommandCardPayload,
+  buildNoticeCardPayload,
+  buildPermissionNoticeCardPayload,
   buildQueueNoticePayload,
+  buildRenameCommandCardPayload,
   buildSessionListCardPayload,
   buildSessionTransitionCardPayload,
   buildStatusCommandCardPayload,
@@ -43,6 +48,7 @@ import {
   resolveSessionMode,
   setActiveSession,
   updateSessionLabel,
+  updateWindowModel,
 } from "./session-windows.js";
 
 export type IncomingChatMessage = {
@@ -364,10 +370,11 @@ export class BridgeApp {
       );
 
       watchdog.start();
+      const window = this.getSessionWindow(turn.conversationKey, turn.chatType);
       const systemPrompt = this.config.bridge.injectSystemState
-        ? buildBridgeSystemPrompt(turn, this.getSessionWindow(turn.conversationKey, turn.chatType))
+        ? buildBridgeSystemPrompt(turn, window)
         : undefined;
-      void this.opencode.promptAsync(turn.sessionId, buildPromptRequest(turn.text, systemPrompt))
+      void this.opencode.promptAsync(turn.sessionId, buildPromptRequest(turn.text, systemPrompt, window.model ?? undefined))
         .then(() => {
           queue.replaceActive(transitionTurn(turn, "awaiting-sse"));
           void this.updateTurnCard(turn.turnId, { status: "处理中", update: "请求已发送，等待事件流...", target: "step" });
@@ -492,11 +499,14 @@ export class BridgeApp {
         update: `请求权限：${permissionName}，请回复 /allow once、/allow always 或 /deny`,
         target: "step",
       });
-      await this.sendPayload(turn.chatId, buildPostMarkdownPayload(`OpenCode 请求权限 \`${escapeMarkdownText(permissionName)}\`，请回复 \`/allow once\`、\`/allow always\` 或 \`/deny\`。`), {
+      await this.sendPayload(turn.chatId, buildPermissionNoticeCardPayload({
+        command: permissionName,
+        timeoutText: "120s 后自动拒绝",
+      }), {
         event: "final message sent",
         transcriptType: "outbound-final",
         textPreview: `权限请求：${permissionName}`,
-        len: permissionName.length + 16,
+        len: permissionName.length + 5,
       }, { replyToMessageId: turn.inboundMessageId });
       return;
     }
@@ -583,19 +593,188 @@ export class BridgeApp {
       return;
     }
 
-    if (command.kind === "abort") {
+    if (command.kind === "rename") {
       const window = this.getSessionWindow(message.conversationKey, message.chatType);
       const currentSession = getActiveSession(window);
-      if (currentSession) {
-        await this.opencode.abort(currentSession.sessionId);
+      if (!currentSession) {
+        await this.sendNoticeCard(message.chatId, {
+          title: "信息提示",
+          message: "当前没有可重命名的会话。",
+          template: "blue",
+          iconToken: "info_outlined",
+        }, message.messageId);
+        return;
       }
-      await this.sendMarkdown(message.chatId, "已请求中止当前任务。", message.messageId);
+
+      const nextLabel = command.label.trim();
+      if (!nextLabel || nextLabel === currentSession.label) {
+        await this.sendNoticeCard(message.chatId, {
+          title: "信息提示",
+          message: nextLabel ? "当前会话已经是这个名称。" : "请输入新的会话名称。",
+          template: "blue",
+          iconToken: "info_outlined",
+        }, message.messageId);
+        return;
+      }
+
+      const nextWindow = updateSessionLabel(window, currentSession.sessionId, nextLabel, this.config.bridge.maxSessionsPerWindow);
+      await this.saveSessionWindow(message.conversationKey, nextWindow);
+      await this.sendPayload(message.chatId, buildRenameCommandCardPayload({
+        previousLabel: currentSession.label,
+        currentLabel: nextLabel,
+      }), {
+        event: "final message sent",
+        transcriptType: "outbound-final",
+        textPreview: `已重命名会话 ${nextLabel}`,
+        len: nextLabel.length + 6,
+      }, { replyToMessageId: message.messageId });
+      return;
+    }
+
+    if (command.kind === "close") {
+      const window = this.getSessionWindow(message.conversationKey, message.chatType);
+      let targetSession = getActiveSession(window);
+
+      if (command.index !== undefined) {
+        if (window.mode === "single") {
+          await this.sendNoticeCard(message.chatId, {
+            title: "提醒",
+            message: "当前窗口为单会话模式，不支持按编号关闭。",
+            template: "yellow",
+            iconToken: "maybe_outlined",
+          }, message.messageId);
+          return;
+        }
+
+        const visibleSessions = getVisibleSessions(window);
+        targetSession = visibleSessions[command.index - 1] ?? null;
+        if (!targetSession) {
+          await this.sendNoticeCard(message.chatId, {
+            title: "提醒",
+            message: "无效的会话编号，请重新执行 `/sessions` 查看列表。",
+            template: "yellow",
+            iconToken: "maybe_outlined",
+          }, message.messageId);
+          return;
+        }
+      }
+
+      if (!targetSession) {
+        await this.sendNoticeCard(message.chatId, {
+          title: "信息提示",
+          message: "当前没有可关闭的会话。",
+          template: "blue",
+          iconToken: "info_outlined",
+        }, message.messageId);
+        return;
+      }
+
+      const nextWindow = removeSession(window, targetSession.sessionId, this.config.bridge.maxSessionsPerWindow);
+      await this.saveSessionWindow(message.conversationKey, nextWindow);
+      this.clearPendingSessionSelection(message.conversationKey);
+      const nextActiveSession = getActiveSession(nextWindow);
+      await this.sendPayload(message.chatId, buildCloseCommandCardPayload({
+        closedLabel: targetSession.label,
+        nextLabel: nextActiveSession?.label ?? null,
+        footer: nextActiveSession
+          ? `当前已切换到「${nextActiveSession.label}」`
+          : "当前窗口暂无会话，发送 `/new` 或直接发送消息开始",
+      }), {
+        event: "final message sent",
+        transcriptType: "outbound-final",
+        textPreview: `已关闭会话 ${targetSession.label}`,
+        len: targetSession.label.length + 6,
+      }, { replyToMessageId: message.messageId });
+      return;
+    }
+
+    if (command.kind === "abort") {
+      const queue = this.queues.get(message.conversationKey);
+      const activeTurn = queue.peek();
+      const window = this.getSessionWindow(message.conversationKey, message.chatType);
+      const currentSession = getActiveSession(window);
+      if (activeTurn && currentSession) {
+        await this.opencode.abort(currentSession.sessionId);
+        await this.sendNoticeCard(message.chatId, {
+          title: "任务已中止",
+          message: "当前任务已中止，可发送新消息继续对话。",
+          template: "orange",
+          iconToken: "stop-record_filled",
+        }, message.messageId);
+        return;
+      }
+      await this.sendNoticeCard(message.chatId, {
+        title: "无任务可中止",
+        message: "当前没有正在执行的任务。",
+        template: "grey",
+        iconToken: "info-hollow_filled",
+      }, message.messageId);
       return;
     }
 
     if (command.kind === "models") {
       const providers = await this.opencode.listProviders();
-      await this.sendMarkdown(message.chatId, formatProviders(providers), message.messageId);
+      const window = this.getSessionWindow(message.conversationKey, message.chatType);
+      const card = buildModelCardView(providers, {
+        providerFilter: command.provider,
+        currentModel: window.model ?? null,
+      });
+      if (!card) {
+        await this.sendNoticeCard(message.chatId, {
+          title: "提醒",
+          message: "没有找到匹配的模型提供方，请先发送 `/model` 查看全部可切换模型。",
+          template: "yellow",
+          iconToken: "maybe_outlined",
+        }, message.messageId);
+        return;
+      }
+      await this.sendPayload(message.chatId, buildModelCommandCardPayload(card), {
+        event: "final message sent",
+        transcriptType: "outbound-final",
+        textPreview: "可用模型",
+        len: 4,
+      }, { replyToMessageId: message.messageId });
+      return;
+    }
+
+    if (command.kind === "model-use") {
+      const providers = await this.opencode.listProviders();
+      const catalog = buildModelCatalog(providers);
+      const normalizedModel = command.model.trim();
+      const matchedModel = catalog.get(normalizedModel);
+      if (!matchedModel) {
+        await this.sendNoticeCard(message.chatId, {
+          title: "提醒",
+          message: "目标模型不存在，请先发送 `/model` 查看可切换模型。",
+          template: "yellow",
+          iconToken: "maybe_outlined",
+        }, message.messageId);
+        return;
+      }
+
+      const window = this.getSessionWindow(message.conversationKey, message.chatType);
+      const resolvedModel = `${matchedModel.providerId}/${matchedModel.modelId}`;
+      const nextWindow = updateWindowModel(window, resolvedModel, this.config.bridge.maxSessionsPerWindow);
+      await this.saveSessionWindow(message.conversationKey, nextWindow);
+      await this.sendNoticeCard(message.chatId, {
+        title: "信息提示",
+        message: `当前窗口模型已切换为 \`${escapeMarkdownText(resolvedModel)}\`。`,
+        template: "blue",
+        iconToken: "info_outlined",
+      }, message.messageId);
+      return;
+    }
+
+    if (command.kind === "model-reset") {
+      const window = this.getSessionWindow(message.conversationKey, message.chatType);
+      const nextWindow = updateWindowModel(window, null, this.config.bridge.maxSessionsPerWindow);
+      await this.saveSessionWindow(message.conversationKey, nextWindow);
+      await this.sendNoticeCard(message.chatId, {
+        title: "信息提示",
+        message: "当前窗口已恢复默认模型。",
+        template: "blue",
+        iconToken: "info_outlined",
+      }, message.messageId);
       return;
     }
 
@@ -669,20 +848,35 @@ export class BridgeApp {
     if (command.kind === "sessions-select") {
       const window = this.getSessionWindow(message.conversationKey, message.chatType);
       if (window.mode === "single") {
-        await this.sendMarkdown(message.chatId, "当前窗口为单会话模式，不支持切换。", message.messageId);
+        await this.sendNoticeCard(message.chatId, {
+          title: "提醒",
+          message: "当前窗口为单会话模式，不支持切换。",
+          template: "yellow",
+          iconToken: "maybe_outlined",
+        }, message.messageId);
         return;
       }
 
       const pending = this.pendingInteractions.get(message.conversationKey);
       if (!pending || pending.kind !== "session-select" || pending.expiresAt <= Date.now()) {
         this.clearPendingInteraction(message.conversationKey, false);
-        await this.sendMarkdown(message.chatId, "会话列表已过期，请先重新执行 `/sessions`。", message.messageId);
+        await this.sendNoticeCard(message.chatId, {
+          title: "提醒",
+          message: "会话列表已过期，请先重新执行 `/sessions`。",
+          template: "yellow",
+          iconToken: "maybe_outlined",
+        }, message.messageId);
         return;
       }
 
       const match = pending.options.find((option) => option.index === command.index);
       if (!match) {
-        await this.sendMarkdown(message.chatId, "无效的会话编号，请重新执行 `/sessions` 查看列表。", message.messageId);
+        await this.sendNoticeCard(message.chatId, {
+          title: "提醒",
+          message: "无效的会话编号，请重新执行 `/sessions` 查看列表。",
+          template: "yellow",
+          iconToken: "maybe_outlined",
+        }, message.messageId);
         return;
       }
 
@@ -691,7 +885,12 @@ export class BridgeApp {
         const nextWindow = removeSession(window, match.sessionId, this.config.bridge.maxSessionsPerWindow);
         await this.saveSessionWindow(message.conversationKey, nextWindow);
         this.clearPendingInteraction(message.conversationKey, false);
-        await this.sendMarkdown(message.chatId, "目标会话已失效，已从当前窗口列表移除，请重新执行 `/sessions`。", message.messageId);
+        await this.sendNoticeCard(message.chatId, {
+          title: "错误",
+          message: "目标会话已失效，已从当前窗口列表移除，请重新执行 `/sessions`。",
+          template: "red",
+          iconToken: "more-close_outlined",
+        }, message.messageId);
         return;
       }
 
@@ -756,7 +955,12 @@ export class BridgeApp {
     if (command.kind === "allow" || command.kind === "deny") {
       const pending = this.pendingInteractions.get(message.conversationKey);
       if (!pending || pending.kind !== "permission") {
-        await this.sendMarkdown(message.chatId, "当前没有待确认的权限请求。", message.messageId);
+        await this.sendNoticeCard(message.chatId, {
+          title: "信息提示",
+          message: "当前没有待确认的权限请求。",
+          template: "blue",
+          iconToken: "info_outlined",
+        }, message.messageId);
         return;
       }
 
@@ -770,9 +974,11 @@ export class BridgeApp {
     }
 
     const sessionId = await this.ensureSession(message);
+    const window = this.getSessionWindow(message.conversationKey, message.chatType);
     const result = await this.opencode.runCommand(sessionId, {
       command: command.name,
       arguments: command.arguments,
+      ...(window.model ? { model: window.model } : {}),
     });
     const text = extractAssistantText(result) || "命令已执行。";
     await this.sendMarkdown(message.chatId, text, message.messageId);
@@ -795,7 +1001,12 @@ export class BridgeApp {
     }
 
     if (pending.kind === "permission") {
-      await this.sendMarkdown(message.chatId, "当前有待确认的权限请求，请先回复 `/allow once`、`/allow always` 或 `/deny`。", message.messageId);
+      await this.sendNoticeCard(message.chatId, {
+        title: "信息提示",
+        message: "当前有待确认的权限请求，请先回复 `/allow once`、`/allow always` 或 `/deny`。",
+        template: "blue",
+        iconToken: "info_outlined",
+      }, message.messageId);
       return true;
     }
 
@@ -835,7 +1046,12 @@ export class BridgeApp {
       await this.opencode.health();
       return true;
     } catch {
-      await this.sendMarkdown(message.chatId, "OpenCode 服务不可用，请先确认 `opencode serve` 正在运行。", message.messageId);
+      await this.sendNoticeCard(message.chatId, {
+        title: "错误",
+        message: "OpenCode 服务不可用，请先确认 `opencode serve` 正在运行。",
+        template: "red",
+        iconToken: "more-close_outlined",
+      }, message.messageId);
       return false;
     }
   }
@@ -963,7 +1179,7 @@ export class BridgeApp {
   }
 
   private async saveSessionWindow(conversationKey: string, window: SessionWindowRecord): Promise<void> {
-    if (window.sessions.length === 0) {
+    if (window.sessions.length === 0 && !window.model) {
       delete this.sessionMap[conversationKey];
     } else {
       this.sessionMap[conversationKey] = window;
@@ -1073,6 +1289,13 @@ export class BridgeApp {
     this.pendingInteractions.delete(conversationKey);
   }
 
+  private clearPendingSessionSelection(conversationKey: string): void {
+    const current = this.pendingInteractions.get(conversationKey);
+    if (current?.kind === "session-select") {
+      this.clearPendingInteraction(conversationKey, false);
+    }
+  }
+
   private async handlePermissionTimeout(conversationKey: string, pending: PendingPermissionInteraction): Promise<void> {
     const current = this.pendingInteractions.get(conversationKey);
     if (!current || current.kind !== "permission" || current.permissionId !== pending.permissionId) {
@@ -1089,7 +1312,12 @@ export class BridgeApp {
     }
 
     await this.updateTurnCard(current.turnId, { status: "处理中", update: "权限请求已超时，已默认拒绝", target: "step" });
-    await this.sendMarkdown(current.chatId, "权限请求已超时，已默认拒绝。", current.replyToMessageId);
+    await this.sendNoticeCard(current.chatId, {
+      title: "提醒",
+      message: "权限请求已超时，已默认拒绝。",
+      template: "yellow",
+      iconToken: "maybe_outlined",
+    }, current.replyToMessageId);
   }
 
   private async createTurnCard(chatId: string, turnId: string, sessionId: string, replyToMessageId: string): Promise<TurnCardState | null> {
@@ -1231,6 +1459,19 @@ export class BridgeApp {
     }, replyToMessageId ? { replyToMessageId } : undefined);
   }
 
+  private async sendNoticeCard(
+    chatId: string,
+    view: Parameters<typeof buildNoticeCardPayload>[0],
+    replyToMessageId?: string,
+  ): Promise<void> {
+    await this.sendPayload(chatId, buildNoticeCardPayload(view), {
+      event: "final message sent",
+      transcriptType: "outbound-final",
+      textPreview: `${view.title} ${createTextPreview(view.message)}`.trim(),
+      len: view.title.length + view.message.length,
+    }, replyToMessageId ? { replyToMessageId } : undefined);
+  }
+
   private async sendPayload(
     chatId: string,
     payload: FeishuPostPayload,
@@ -1247,10 +1488,11 @@ export class BridgeApp {
   }
 }
 
-export function buildPromptRequest(text: string, system?: string): { system?: string; parts: Array<{ type: "text"; text: string }> } {
-  return system
+export function buildPromptRequest(text: string, system?: string, model?: string): { system?: string; model?: string; parts: Array<{ type: "text"; text: string }> } {
+  return system || model
     ? {
-      system,
+      ...(system ? { system } : {}),
+      ...(model ? { model } : {}),
       parts: [{ type: "text", text }],
     }
     : {
@@ -1294,19 +1536,176 @@ function formatQuestionPrompt(questions: PendingQuestionInteraction["questions"]
   return ["OpenCode 需要你回答：", ...questions.map((question, index) => `${index + 1}. ${escapeMarkdownText(question.header)}\n${escapeMarkdownText(question.question)}`)].join("\n\n");
 }
 
-function formatProviders(providers: OpenCodeProvidersResponse): string {
-  const lines = ["可用模型提供方："];
+function buildModelCardView(
+  providers: OpenCodeProvidersResponse,
+  options?: { providerFilter?: string | undefined; currentModel?: string | null },
+): {
+  providers: Array<{
+    title: string;
+    highlightStyle?: string | null;
+    models: Array<{ label: string; current?: boolean; default?: boolean }>;
+  }>;
+  footer: string;
+} | null {
+  const filter = options?.providerFilter?.trim().toLowerCase();
+  const catalog = [...buildProviderCatalog(providers).values()]
+    .filter((provider) => !filter || provider.id.toLowerCase() === filter || provider.name.toLowerCase() === filter);
+
+  if (catalog.length === 0) {
+    return null;
+  }
+
+  const providersView = catalog.map((provider) => {
+    const models = selectModelsForCard(provider, options?.currentModel ?? null, !filter)
+      .map((model) => ({
+        label: model.id,
+        current: options?.currentModel === model.fullId,
+        default: provider.defaultModel === model.id,
+      }));
+
+    return {
+      title: `${provider.name} 模型`,
+      highlightStyle: provider.id === "openai" ? "purple-50" : provider.id === "opencode" ? "blue-50" : "grey-50",
+      models,
+    };
+  });
+
+  const footerLines = [
+    "`/model use <provider/model>` 切换当前窗口模型",
+    "`/model reset` 恢复默认模型",
+  ];
+  if (!filter) {
+    footerLines.push("当前仅展示每个提供方最近 5 个模型；发送 `/model <provider>` 查看更多。");
+  }
+
+  return {
+    providers: providersView,
+    footer: footerLines.join("\n"),
+  };
+}
+
+function buildModelCatalog(providers: OpenCodeProvidersResponse): Map<string, { providerId: string; modelId: string; providerName: string }> {
+  const catalog = new Map<string, { providerId: string; modelId: string; providerName: string }>();
+  const bareIdCounts = new Map<string, number>();
+  const entries: Array<{ fullId: string; providerId: string; modelId: string; providerName: string }> = [];
+
+  for (const provider of buildProviderCatalog(providers).values()) {
+    for (const model of provider.models) {
+      entries.push({
+        fullId: model.fullId,
+        providerId: provider.id,
+        modelId: model.id,
+        providerName: provider.name,
+      });
+      bareIdCounts.set(model.id, (bareIdCounts.get(model.id) ?? 0) + 1);
+    }
+  }
+
+  for (const entry of entries) {
+    const value = {
+      providerId: entry.providerId,
+      modelId: entry.modelId,
+      providerName: entry.providerName,
+    };
+    catalog.set(entry.fullId, value);
+    if ((bareIdCounts.get(entry.modelId) ?? 0) === 1) {
+      catalog.set(entry.modelId, value);
+    }
+  }
+
+  return catalog;
+}
+
+function buildProviderCatalog(providers: OpenCodeProvidersResponse): Map<string, {
+  id: string;
+  name: string;
+  defaultModel: string | null;
+  models: Array<{ id: string; fullId: string; name: string; releaseDate: string | null }>;
+}> {
   const defaults = providers.default;
+  const catalog = new Map<string, {
+    id: string;
+    name: string;
+    defaultModel: string | null;
+    models: Array<{ id: string; fullId: string; name: string; releaseDate: string | null }>;
+  }>();
+
   for (const provider of providers.providers) {
     const id = typeof provider.id === "string" ? provider.id : typeof provider.providerID === "string" ? provider.providerID : "unknown";
     const name = typeof provider.name === "string" ? provider.name : id;
-    const model = defaults[id];
-    lines.push(`- ${name}${model ? `：默认 \`${model}\`` : ""}`);
+    const rawModels = provider.models && typeof provider.models === "object" ? provider.models : {};
+    const models = Object.entries(rawModels)
+      .map(([modelId, model]) => {
+        const resolvedId = typeof model?.id === "string" ? model.id : modelId;
+        const resolvedName = typeof model?.name === "string" ? model.name : resolvedId;
+        return {
+          id: resolvedId,
+          fullId: `${id}/${resolvedId}`,
+          name: resolvedName,
+          releaseDate: typeof model?.release_date === "string" ? model.release_date : null,
+        };
+      })
+      .sort((a, b) => a.id.localeCompare(b.id));
+
+    catalog.set(id, {
+      id,
+      name,
+      defaultModel: typeof defaults[id] === "string" ? defaults[id] : null,
+      models,
+    });
   }
-  if (lines.length === 1) {
-    lines.push("- 当前没有 provider 信息");
+
+  return catalog;
+}
+
+function selectModelsForCard(
+  provider: {
+    defaultModel: string | null;
+    models: Array<{ id: string; fullId: string; name: string; releaseDate: string | null }>;
+  },
+  currentModel: string | null,
+  limitRecent: boolean,
+): Array<{ id: string; fullId: string; name: string; releaseDate: string | null }> {
+  const sorted = [...provider.models].sort((a, b) => compareModelsForDisplay(a, b, provider.defaultModel, currentModel));
+  if (!limitRecent) {
+    return sorted;
   }
-  return lines.join("\n");
+  return sorted.slice(0, 5);
+}
+
+function compareModelsForDisplay(
+  left: { id: string; fullId: string; releaseDate: string | null },
+  right: { id: string; fullId: string; releaseDate: string | null },
+  defaultModel: string | null,
+  currentModel: string | null,
+): number {
+  const leftPriority = getModelDisplayPriority(left, defaultModel, currentModel);
+  const rightPriority = getModelDisplayPriority(right, defaultModel, currentModel);
+  if (leftPriority !== rightPriority) {
+    return leftPriority - rightPriority;
+  }
+
+  const leftTimestamp = left.releaseDate ? Date.parse(left.releaseDate) : 0;
+  const rightTimestamp = right.releaseDate ? Date.parse(right.releaseDate) : 0;
+  if (leftTimestamp !== rightTimestamp) {
+    return rightTimestamp - leftTimestamp;
+  }
+
+  return left.id.localeCompare(right.id);
+}
+
+function getModelDisplayPriority(
+  model: { id: string; fullId: string },
+  defaultModel: string | null,
+  currentModel: string | null,
+): number {
+  if (currentModel && model.fullId === currentModel) {
+    return 0;
+  }
+  if (defaultModel && model.id === defaultModel) {
+    return 1;
+  }
+  return 2;
 }
 
 export function buildBridgeSystemPrompt(
@@ -1319,6 +1718,7 @@ export function buildBridgeSystemPrompt(
     `windowType: ${turn.chatType ?? "p2p"}`,
     `conversationKey: ${turn.conversationKey}`,
     `sessionMode: ${window.mode}`,
+    `currentModel: ${window.model ?? "default"}`,
     `activeSessionId: ${window.activeSessionId ?? "none"}`,
     "visibleSessions:",
     ...(visibleSessions.length > 0

--- a/src/runtime/session-windows.ts
+++ b/src/runtime/session-windows.ts
@@ -26,6 +26,7 @@ export function normalizeSessionWindowRecord(
     const active = findSessionById(sessions, record?.activeSessionId) ?? sessions[0] ?? null;
     return {
       mode,
+      model: record?.model ?? null,
       activeSessionId: active?.sessionId ?? null,
       sessions: active ? [active] : [],
     };
@@ -35,6 +36,7 @@ export function normalizeSessionWindowRecord(
   const active = findSessionById(uniqueSessions, record?.activeSessionId) ?? uniqueSessions[0] ?? null;
   return {
     mode,
+    model: record?.model ?? null,
     activeSessionId: active?.sessionId ?? null,
     sessions: uniqueSessions,
   };
@@ -68,6 +70,7 @@ export function setActiveSession(
 
   return normalizeSessionWindowRecord({
     mode: window.mode,
+    model: window.model ?? null,
     activeSessionId: sessionId,
     sessions: updatedSessions,
   }, window.mode, maxSessions);
@@ -80,6 +83,7 @@ export function addSession(
 ): SessionWindowRecord {
   return normalizeSessionWindowRecord({
     mode: window.mode,
+    model: window.model ?? null,
     activeSessionId: session.sessionId,
     sessions: [session, ...window.sessions.filter((item) => item.sessionId !== session.sessionId)],
   }, window.mode, maxSessions);
@@ -96,6 +100,7 @@ export function removeSession(
     : window.activeSessionId;
   return normalizeSessionWindowRecord({
     mode: window.mode,
+    model: window.model ?? null,
     activeSessionId: nextActive,
     sessions: remaining,
   }, window.mode, maxSessions);
@@ -114,6 +119,7 @@ export function updateSessionLabel(
 
   return normalizeSessionWindowRecord({
     mode: window.mode,
+    model: window.model ?? null,
     activeSessionId: window.activeSessionId,
     sessions: window.sessions.map((session) => (
       session.sessionId === sessionId
@@ -125,6 +131,15 @@ export function updateSessionLabel(
 
 export function getVisibleSessions(window: SessionWindowRecord): SessionBindingRecord[] {
   return sortSessionsByLastUsed(window.sessions);
+}
+
+export function updateWindowModel(window: SessionWindowRecord, model: string | null, maxSessions: number): SessionWindowRecord {
+  return normalizeSessionWindowRecord({
+    mode: window.mode,
+    model: model?.trim() || null,
+    activeSessionId: window.activeSessionId,
+    sessions: window.sessions,
+  }, window.mode, maxSessions);
 }
 
 export function hasSession(window: SessionWindowRecord, sessionId: string): boolean {

--- a/src/store/mappings.ts
+++ b/src/store/mappings.ts
@@ -11,6 +11,7 @@ export type SessionBindingRecord = {
 
 export type SessionWindowRecord = {
   mode: SessionMode;
+  model?: string | null;
   activeSessionId: string | null;
   sessions: SessionBindingRecord[];
 };
@@ -177,6 +178,7 @@ function normalizeWindowRecord(value: unknown): SessionWindowRecord | null {
   if (sessions.length === 0) {
     return {
       mode,
+      model: typeof value.model === "string" && value.model.trim().length > 0 ? value.model.trim() : null,
       activeSessionId: null,
       sessions: [],
     };
@@ -189,11 +191,13 @@ function normalizeWindowRecord(value: unknown): SessionWindowRecord | null {
   return mode === "single"
     ? {
       mode,
+      model: typeof value.model === "string" && value.model.trim().length > 0 ? value.model.trim() : null,
       activeSessionId,
       sessions: [findSessionById(sessions, activeSessionId) ?? pickMostRecentSession(sessions)!],
     }
     : {
       mode,
+      model: typeof value.model === "string" && value.model.trim().length > 0 ? value.model.trim() : null,
       activeSessionId,
       sessions: sessions.sort((a, b) => b.lastUsedAt - a.lastUsedAt),
     };
@@ -218,6 +222,7 @@ function normalizeSessionBindingRecord(value: unknown, now: number): SessionBind
 function createSingleWindow(sessionId: string, now: number, label: string): SessionWindowRecord {
   return {
     mode: "single",
+    model: null,
     activeSessionId: sessionId,
     sessions: [{
       sessionId,

--- a/test/app-helpers.test.ts
+++ b/test/app-helpers.test.ts
@@ -10,6 +10,14 @@ describe("runtime prompt helpers", () => {
     });
   });
 
+  it("adds model override when provided", () => {
+    expect(buildPromptRequest("hello", "state", "openai/gpt-5.4")).toEqual({
+      system: "state",
+      model: "openai/gpt-5.4",
+      parts: [{ type: "text", text: "hello" }],
+    });
+  });
+
   it("builds bridge system state from the current window", () => {
     const prompt = buildBridgeSystemPrompt({
       chatType: "group",
@@ -27,6 +35,7 @@ describe("runtime prompt helpers", () => {
 
     expect(prompt).toContain("windowType: group");
     expect(prompt).toContain("sessionMode: multi");
+    expect(prompt).toContain("currentModel: default");
     expect(prompt).toContain("activeSessionId: ses_2");
     expect(prompt).toContain("* 当前会话 (ses_2)");
     expect(prompt).toContain("Bridge owns /new /sessions /switch /status");

--- a/test/app-session-commands.test.ts
+++ b/test/app-session-commands.test.ts
@@ -91,6 +91,46 @@ describe("BridgeApp session commands", () => {
     expect(text).toContain("当前窗口为单会话模式，不支持按编号关闭");
   });
 
+  it("blocks closing a session with an in-flight turn", async () => {
+    const outbound = createOutbound();
+    const app = createApp(outbound);
+    setSessionMap(app, {
+      oc_p2p_1: {
+        mode: "multi",
+        activeSessionId: "ses_2",
+        sessions: [
+          { sessionId: "ses_2", label: "帮我写个单测", createdAt: 2, lastUsedAt: 20 },
+          { sessionId: "ses_1", label: "代码审查", createdAt: 1, lastUsedAt: 10 },
+        ],
+      },
+    });
+    setActiveTurn(app, "oc_p2p_1", {
+      turnId: "turn_1",
+      chatId: "oc_p2p_1",
+      conversationKey: "oc_p2p_1",
+      threadKey: "om_1",
+      senderOpenId: "ou_123",
+      inboundMessageId: "om_1",
+      plainText: "继续执行",
+      text: "继续执行",
+      sessionId: "ses_2",
+      state: "running",
+    });
+
+    await invokeCommand(app, {
+      chatId: "oc_p2p_1",
+      chatType: "p2p",
+      messageId: "om_2",
+      conversationKey: "oc_p2p_1",
+      threadKey: "om_2",
+      senderOpenId: "ou_123",
+    }, { kind: "close" });
+
+    expect(getSessionMap(app).oc_p2p_1?.sessions).toHaveLength(2);
+    const text = extractInteractiveText(getReplyPayloads(outbound)[0]);
+    expect(text).toContain("该会话有任务正在执行，请先 /abort 再关闭。");
+  });
+
   it("stores a window model override via /model use", async () => {
     const outbound = createOutbound();
     const app = createApp(outbound);
@@ -179,6 +219,32 @@ describe("BridgeApp session commands", () => {
     expect(JSON.stringify(parsed?.body?.elements ?? [])).toContain("gpt-5.4-mini");
     expect(JSON.stringify(parsed?.body?.elements ?? [])).not.toContain("gpt-5-codex");
   });
+
+  it("shows usage notice for invalid built-in commands instead of passthrough", async () => {
+    const outbound = createOutbound();
+    const app = createApp(outbound);
+    const runCommand = vi.fn(async () => ({ info: {}, parts: [] }));
+    (app as unknown as { opencode: Record<string, unknown> }).opencode = {
+      ...((app as unknown as { opencode: Record<string, unknown> }).opencode),
+      runCommand,
+    };
+
+    await app.handleIncomingMessage({
+      chatId: "oc_p2p_1",
+      chatType: "p2p",
+      messageId: "om_1",
+      conversationKey: "oc_p2p_1",
+      threadKey: "om_1",
+      senderOpenId: "ou_123",
+      messageType: "text",
+      rawContent: "/model use",
+      plainText: "/model use",
+    });
+
+    expect(runCommand).not.toHaveBeenCalled();
+    const text = extractInteractiveText(getReplyPayloads(outbound)[0]);
+    expect(text).toContain("用法：/model use <provider/model>");
+  });
 });
 
 function createApp(outbound: ReturnType<typeof createOutbound>): BridgeApp {
@@ -203,6 +269,30 @@ function setSessionMap(app: BridgeApp, value: MappingRecord): void {
 
 function getSessionMap(app: BridgeApp): MappingRecord {
   return (app as unknown as { sessionMap: MappingRecord }).sessionMap;
+}
+
+function setActiveTurn(
+  app: BridgeApp,
+  conversationKey: string,
+  turn: {
+    turnId: string;
+    chatId: string;
+    conversationKey: string;
+    threadKey: string;
+    senderOpenId: string;
+    inboundMessageId: string;
+    plainText: string;
+    text: string;
+    sessionId: string;
+    state: "running";
+  },
+): void {
+  const queue = (app as unknown as {
+    queues: {
+      get(key: string): { replaceActive(nextTurn: typeof turn): void };
+    };
+  }).queues.get(conversationKey);
+  queue.replaceActive(turn);
 }
 
 async function invokeCommand(

--- a/test/app-session-commands.test.ts
+++ b/test/app-session-commands.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { BridgeApp } from "../src/runtime/app.js";
+import type { AppConfig } from "../src/config/schema.js";
+import type { MappingRecord } from "../src/store/mappings.js";
+import type { ChatWhitelist } from "../src/store/whitelist.js";
+
+describe("BridgeApp session commands", () => {
+  it("renames the active session", async () => {
+    const outbound = createOutbound();
+    const app = createApp(outbound);
+    setSessionMap(app, {
+      oc_p2p_1: {
+        mode: "multi",
+        activeSessionId: "ses_2",
+        sessions: [
+          { sessionId: "ses_2", label: "帮我写个单测", createdAt: 2, lastUsedAt: 20 },
+          { sessionId: "ses_1", label: "代码审查", createdAt: 1, lastUsedAt: 10 },
+        ],
+      },
+    });
+
+    await invokeCommand(app, {
+      chatId: "oc_p2p_1",
+      chatType: "p2p",
+      messageId: "om_1",
+      conversationKey: "oc_p2p_1",
+      threadKey: "om_1",
+      senderOpenId: "ou_123",
+    }, { kind: "rename", label: "新的会话名" });
+
+    expect(getSessionMap(app).oc_p2p_1?.sessions[0]?.label).toBe("新的会话名");
+    const text = extractInteractiveText(getReplyPayloads(outbound)[0]);
+    expect(text).toContain("已重命名会话");
+    expect(text).toContain("新的会话名");
+  });
+
+  it("closes the active session and switches to the next one", async () => {
+    const outbound = createOutbound();
+    const app = createApp(outbound);
+    setSessionMap(app, {
+      oc_p2p_1: {
+        mode: "multi",
+        activeSessionId: "ses_2",
+        sessions: [
+          { sessionId: "ses_2", label: "帮我写个单测", createdAt: 2, lastUsedAt: 20 },
+          { sessionId: "ses_1", label: "代码审查", createdAt: 1, lastUsedAt: 10 },
+        ],
+      },
+    });
+
+    await invokeCommand(app, {
+      chatId: "oc_p2p_1",
+      chatType: "p2p",
+      messageId: "om_1",
+      conversationKey: "oc_p2p_1",
+      threadKey: "om_1",
+      senderOpenId: "ou_123",
+    }, { kind: "close" });
+
+    expect(getSessionMap(app).oc_p2p_1?.activeSessionId).toBe("ses_1");
+    expect(getSessionMap(app).oc_p2p_1?.sessions).toHaveLength(1);
+    const text = extractInteractiveText(getReplyPayloads(outbound)[0]);
+    expect(text).toContain("已关闭会话");
+    expect(text).toContain("代码审查");
+  });
+
+  it("rejects indexed close in single-session mode", async () => {
+    const outbound = createOutbound();
+    const app = createApp(outbound);
+    setSessionMap(app, {
+      "oc_group_1:om_1": {
+        mode: "single",
+        activeSessionId: "ses_1",
+        sessions: [
+          { sessionId: "ses_1", label: "群聊会话", createdAt: 1, lastUsedAt: 1 },
+        ],
+      },
+    });
+
+    await invokeCommand(app, {
+      chatId: "oc_group_1",
+      chatType: "group",
+      messageId: "om_1",
+      conversationKey: "oc_group_1:om_1",
+      threadKey: "om_1",
+      senderOpenId: "ou_123",
+    }, { kind: "close", index: 1 });
+
+    const text = extractInteractiveText(getReplyPayloads(outbound)[0]);
+    expect(text).toContain("当前窗口为单会话模式，不支持按编号关闭");
+  });
+
+  it("stores a window model override via /model use", async () => {
+    const outbound = createOutbound();
+    const app = createApp(outbound);
+    setSessionMap(app, {
+      oc_p2p_1: {
+        mode: "multi",
+        model: null,
+        activeSessionId: "ses_2",
+        sessions: [
+          { sessionId: "ses_2", label: "帮我写个单测", createdAt: 2, lastUsedAt: 20 },
+        ],
+      },
+    });
+    setProviders(app, {
+      providers: [
+        {
+          id: "openai",
+          name: "OpenAI",
+          models: {
+            "gpt-5.4": { id: "gpt-5.4", name: "GPT-5.4" },
+          },
+        },
+      ],
+      default: { openai: "gpt-5.4-mini" },
+    });
+
+    await invokeCommand(app, {
+      chatId: "oc_p2p_1",
+      chatType: "p2p",
+      messageId: "om_1",
+      conversationKey: "oc_p2p_1",
+      threadKey: "om_1",
+      senderOpenId: "ou_123",
+    }, { kind: "model-use", model: "openai/gpt-5.4" });
+
+    expect(getSessionMap(app).oc_p2p_1?.model).toBe("openai/gpt-5.4");
+    const text = extractInteractiveText(getReplyPayloads(outbound)[0]);
+    expect(text).toContain("当前窗口模型已切换为");
+    expect(text).toContain("openai/gpt-5.4");
+  });
+
+  it("renders a model card for /model", async () => {
+    const outbound = createOutbound();
+    const app = createApp(outbound);
+    setProviders(app, {
+      providers: [
+        {
+          id: "openai",
+          name: "OpenAI",
+          models: {
+            "gpt-5.4-mini": { id: "gpt-5.4-mini", name: "GPT-5.4 mini", release_date: "2026-03-17" },
+            "gpt-5.4": { id: "gpt-5.4", name: "GPT-5.4", release_date: "2026-03-05" },
+            "gpt-5.3-codex": { id: "gpt-5.3-codex", name: "GPT-5.3 Codex", release_date: "2026-02-05" },
+            "gpt-5.2": { id: "gpt-5.2", name: "GPT-5.2", release_date: "2025-12-11" },
+            "gpt-5.1-codex": { id: "gpt-5.1-codex", name: "GPT-5.1 Codex", release_date: "2025-11-13" },
+            "gpt-5-codex": { id: "gpt-5-codex", name: "GPT-5-Codex", release_date: "2025-09-15" },
+          },
+        },
+      ],
+      default: { openai: "gpt-5.4-mini" },
+    });
+    setSessionMap(app, {
+      oc_p2p_1: {
+        mode: "multi",
+        model: "openai/gpt-5.4-mini",
+        activeSessionId: "ses_2",
+        sessions: [
+          { sessionId: "ses_2", label: "帮我写个单测", createdAt: 2, lastUsedAt: 20 },
+        ],
+      },
+    });
+
+    await invokeCommand(app, {
+      chatId: "oc_p2p_1",
+      chatType: "p2p",
+      messageId: "om_1",
+      conversationKey: "oc_p2p_1",
+      threadKey: "om_1",
+      senderOpenId: "ou_123",
+    }, { kind: "models" });
+
+    const payload = getReplyPayloads(outbound)[0];
+    const parsed = payload ? JSON.parse(payload.content) as { msg_type?: string; header?: { title?: { content?: string } }; body?: { elements?: unknown[] } } : null;
+    expect(parsed?.header?.title?.content).toBe("可用模型");
+    expect(JSON.stringify(parsed?.body?.elements ?? [])).toContain("最近 5 个模型");
+    expect(JSON.stringify(parsed?.body?.elements ?? [])).toContain("gpt-5.4-mini");
+    expect(JSON.stringify(parsed?.body?.elements ?? [])).not.toContain("gpt-5-codex");
+  });
+});
+
+function createApp(outbound: ReturnType<typeof createOutbound>): BridgeApp {
+  const app = new BridgeApp(baseConfig(), outbound, logger(), createWhitelist());
+  (app as unknown as { mappings: { save: ReturnType<typeof vi.fn> } }).mappings = {
+    save: vi.fn(async () => undefined),
+  };
+  setProviders(app, { providers: [], default: {} });
+  return app;
+}
+
+function setProviders(app: BridgeApp, providers: { providers: Array<Record<string, unknown>>; default: Record<string, string> }): void {
+  (app as unknown as { opencode: { listProviders: ReturnType<typeof vi.fn> } }).opencode = {
+    ...((app as unknown as { opencode: Record<string, unknown> }).opencode),
+    listProviders: vi.fn(async () => providers),
+  };
+}
+
+function setSessionMap(app: BridgeApp, value: MappingRecord): void {
+  (app as unknown as { sessionMap: MappingRecord }).sessionMap = value;
+}
+
+function getSessionMap(app: BridgeApp): MappingRecord {
+  return (app as unknown as { sessionMap: MappingRecord }).sessionMap;
+}
+
+async function invokeCommand(
+  app: BridgeApp,
+  message: {
+    chatId: string;
+    chatType: string;
+    messageId: string;
+    conversationKey: string;
+    threadKey: string;
+    senderOpenId: string;
+  },
+  command:
+    | { kind: "rename"; label: string }
+    | { kind: "close"; index?: number | undefined }
+    | { kind: "model-use"; model: string }
+    | { kind: "models"; provider?: string | undefined },
+): Promise<void> {
+  await (app as unknown as {
+    handleCommand(
+      nextMessage: typeof message,
+      routed: { kind: "command"; command: typeof command },
+    ): Promise<void>;
+  }).handleCommand(message, { kind: "command", command });
+}
+
+function baseConfig(): AppConfig {
+  return {
+    feishu: {
+      appId: "app",
+      appSecret: "secret",
+      botOpenIds: new Set(["ou_bot"]),
+      botMentionNames: new Set(["opencode"]),
+      selfBotOpenIds: new Set(["ou_bot"]),
+      wsUrl: new URL("wss://open.feishu.cn/open-apis/ws/v2"),
+      allowedOpenIds: new Set(),
+      behavior: {
+        enableP2p: true,
+        enableGroup: true,
+        requireBotMentionInGroup: true,
+        strictBotMention: true,
+        ignoreNonUserSenders: true,
+        replyInThread: true,
+      },
+    },
+    opencode: {
+      baseUrl: new URL("http://127.0.0.1:4096/"),
+      directory: process.cwd(),
+    },
+    storage: {
+      dataDir: process.cwd(),
+      mappingsFile: "mappings.json",
+    },
+    whitelist: {
+      storePath: "whitelist.json",
+    },
+    bridge: {
+      queueLimit: 3,
+      sessionModes: {
+        p2p: "multi",
+        group: "single",
+        topicGroup: "single",
+      },
+      maxSessionsPerWindow: 20,
+      sessionListLimit: 10,
+      injectSystemState: true,
+      firstEventTimeoutMs: 30_000,
+      eventGapTimeoutMs: 120_000,
+      totalTimeoutMs: 300_000,
+    },
+    logging: {
+      dir: process.cwd(),
+      level: "info",
+      enableTranscript: true,
+      enableConsole: true,
+      enableColor: true,
+      rotateDaily: true,
+    },
+  };
+}
+
+function createOutbound() {
+  return {
+    sendMessage: vi.fn(async () => ({ messageId: "om_send" })),
+    replyMessage: vi.fn(async () => ({ messageId: "om_reply" })),
+    updateMessage: vi.fn(async () => ({ messageId: "om_update" })),
+  };
+}
+
+function createWhitelist(): ChatWhitelist {
+  return {
+    isBound() {
+      return false;
+    },
+    async bind() {},
+    async unbind() {
+      return false;
+    },
+    count() {
+      return 0;
+    },
+  };
+}
+
+function logger() {
+  return {
+    log() {},
+    logTranscript() {},
+  };
+}
+
+function extractInteractiveText(payload: { content: string } | undefined): string {
+  if (!payload) {
+    return "";
+  }
+  const parsed = JSON.parse(payload.content) as { header?: { title?: { content?: string } }; body?: { elements?: unknown[] } };
+  return `${parsed.header?.title?.content ?? ""} ${JSON.stringify(parsed.body?.elements ?? [])}`;
+}
+
+function getReplyPayloads(outbound: ReturnType<typeof createOutbound>): Array<{ content: string } | undefined> {
+  return (outbound.replyMessage.mock.calls as unknown[][]).map((call) => call[1] as { content: string } | undefined);
+}

--- a/test/formatter.test.ts
+++ b/test/formatter.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildCloseCommandCardPayload,
   buildLeaveCommandCardPayload,
+  buildModelCommandCardPayload,
+  buildNoticeCardPayload,
+  buildPermissionNoticeCardPayload,
   buildPostMarkdownPayload,
   buildPostPayload,
+  buildRenameCommandCardPayload,
   buildSessionListCardPayload,
   buildSessionTransitionCardPayload,
   buildStatusCommandCardPayload,
@@ -149,5 +154,102 @@ describe("buildPostPayload", () => {
     const content = JSON.parse(payload.content) as any;
     expect(content.header.title.content).toBe("无需解除绑定");
     expect(content.body.elements[0].columns[0].elements[0].content).toContain("尚未绑定");
+  });
+
+  it("renders a rename command card", () => {
+    const payload = buildRenameCommandCardPayload({
+      previousLabel: "帮我写个单测",
+      currentLabel: "代码审查",
+    });
+    const content = JSON.parse(payload.content) as any;
+    expect(content.header.title.content).toBe("已重命名会话");
+    expect(content.body.elements[0].columns[1].elements[0].content).toBe("~~帮我写个单测~~");
+    expect(content.body.elements[1].columns[1].elements[0].content).toBe("**代码审查**");
+  });
+
+  it("renders a close command card with next session", () => {
+    const payload = buildCloseCommandCardPayload({
+      closedLabel: "帮我写个单测",
+      nextLabel: "代码审查",
+      footer: "当前已切换到「代码审查」",
+    });
+    const content = JSON.parse(payload.content) as any;
+    expect(content.header.title.content).toBe("已关闭会话");
+    expect(content.body.elements[0].columns[1].elements[0].content).toBe("~~帮我写个单测~~");
+    expect(content.body.elements[1].columns[1].elements[0].content).toBe("**代码审查**");
+    expect(content.body.elements[3].columns[0].elements[0].content).toContain("代码审查");
+  });
+
+  it("renders a yellow notice card", () => {
+    const payload = buildNoticeCardPayload({
+      title: "提醒",
+      message: "会话列表已过期，请重新发送 `/sessions`",
+      template: "yellow",
+      iconToken: "maybe_outlined",
+    });
+    const content = JSON.parse(payload.content) as any;
+    expect(content.header.title.content).toBe("提醒");
+    expect(content.header.template).toBe("yellow");
+    expect(content.header.icon.token).toBe("maybe_outlined");
+    expect(content.body.elements[0].columns[0].elements[0].content).toContain("`/sessions`");
+  });
+
+  it("renders an orange abort notice card", () => {
+    const payload = buildNoticeCardPayload({
+      title: "任务已中止",
+      message: "当前任务已中止，可发送新消息继续对话。",
+      template: "orange",
+      iconToken: "stop-record_filled",
+    });
+    const content = JSON.parse(payload.content) as any;
+    expect(content.header.title.content).toBe("任务已中止");
+    expect(content.header.template).toBe("orange");
+    expect(content.body.elements[0].columns[0].elements[0].content).toContain("当前任务已中止");
+  });
+
+  it("renders a permission notice card with fake buttons", () => {
+    const payload = buildPermissionNoticeCardPayload({
+      command: "rm -rf dist/",
+      timeoutText: "120s 后自动拒绝",
+    });
+    const content = JSON.parse(payload.content) as any;
+    expect(content.header.title.content).toBe("权限请求");
+    expect(content.header.template).toBe("purple");
+    expect(content.body.elements[0].columns[0].elements[0].content).toBe("OpenCode 想执行：");
+    expect(content.body.elements[0].columns[0].elements[1].columns[0].elements[0].content).toContain("rm -rf dist/");
+    expect(content.body.elements[2].columns[0].elements[0].text.content).toContain("/allow once");
+    expect(content.body.elements[2].columns[1].elements[0].text.content).toContain("/allow always");
+    expect(content.body.elements[2].columns[2].elements[0].text.content).toContain("/deny");
+    expect(content.body.elements[3].content).toBe("120s 后自动拒绝");
+  });
+
+  it("renders a model command card", () => {
+    const payload = buildModelCommandCardPayload({
+      providers: [
+        {
+          title: "OpenAI 模型",
+          highlightStyle: "purple-50",
+          models: [
+            { label: "gpt-5.4-mini", current: true, default: true },
+            { label: "gpt-5.4" },
+          ],
+        },
+        {
+          title: "OpenCode 模型",
+          highlightStyle: "blue-50",
+          models: [
+            { label: "big-pickle" },
+          ],
+        },
+      ],
+      footer: "`/model use <provider/model>` 切换当前窗口模型\n当前仅展示每个提供方最近 5 个模型；发送 `/model <provider>` 查看更多。",
+    });
+    const content = JSON.parse(payload.content) as any;
+    expect(content.header.title.content).toBe("可用模型");
+    expect(content.header.template).toBe("indigo");
+    expect(content.body.elements[0].columns[0].elements[0].content).toBe("OpenAI 模型");
+    expect(content.body.elements[0].columns[0].elements[1].columns[0].background_style).toBe("purple-50");
+    expect(content.body.elements[0].columns[0].elements[1].columns[0].elements[0].content).toContain("gpt-5.4-mini");
+    expect(content.body.elements[4].content).toContain("最近 5 个模型");
   });
 });

--- a/test/mappings.test.ts
+++ b/test/mappings.test.ts
@@ -37,7 +37,7 @@ describe("MappingStore", () => {
     const store = new MappingStore(dir, "mappings.json", 2);
 
     await store.save({
-      a: { mode: "single", activeSessionId: "ses_a", sessions: [{ sessionId: "ses_a", label: "A", createdAt: 1, lastUsedAt: 1 }] },
+      a: { mode: "single", model: "openai/gpt-5.4", activeSessionId: "ses_a", sessions: [{ sessionId: "ses_a", label: "A", createdAt: 1, lastUsedAt: 1 }] },
       b: { mode: "single", activeSessionId: "ses_b", sessions: [{ sessionId: "ses_b", label: "B", createdAt: 3, lastUsedAt: 3 }] },
       c: { mode: "single", activeSessionId: "ses_c", sessions: [{ sessionId: "ses_c", label: "C", createdAt: 2, lastUsedAt: 2 }] },
     });

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -41,6 +41,21 @@ describe("routeIncomingText", () => {
     });
   });
 
+  it("rejects invalid built-in command arguments before passthrough", () => {
+    expect(routeIncomingText("/model use")).toEqual({
+      kind: "command",
+      command: { kind: "invalid", message: "用法：/model use <provider/model>" },
+    });
+    expect(routeIncomingText("/close abc")).toEqual({
+      kind: "command",
+      command: { kind: "invalid", message: "用法：/close [编号]" },
+    });
+    expect(routeIncomingText("/rename")).toEqual({
+      kind: "command",
+      command: { kind: "invalid", message: "用法：/rename <新名称>" },
+    });
+  });
+
   it("routes rename and close aliases", () => {
     expect(routeIncomingText("/rename 代码审查")).toEqual({
       kind: "command",

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -8,9 +8,55 @@ describe("routeIncomingText", () => {
       kind: "command",
       command: { kind: "status" },
     });
+    expect(routeIncomingText("/current")).toEqual({
+      kind: "command",
+      command: { kind: "status" },
+    });
     expect(routeIncomingText("/new")).toEqual({
       kind: "command",
       command: { kind: "new" },
+    });
+    expect(routeIncomingText("/model")).toEqual({
+      kind: "command",
+      command: { kind: "models" },
+    });
+  });
+
+  it("routes model subcommands", () => {
+    expect(routeIncomingText("/model openai")).toEqual({
+      kind: "command",
+      command: { kind: "models", provider: "openai" },
+    });
+    expect(routeIncomingText("/models opencode")).toEqual({
+      kind: "command",
+      command: { kind: "models", provider: "opencode" },
+    });
+    expect(routeIncomingText("/model use openai/gpt-5.4")).toEqual({
+      kind: "command",
+      command: { kind: "model-use", model: "openai/gpt-5.4" },
+    });
+    expect(routeIncomingText("/model reset")).toEqual({
+      kind: "command",
+      command: { kind: "model-reset" },
+    });
+  });
+
+  it("routes rename and close aliases", () => {
+    expect(routeIncomingText("/rename 代码审查")).toEqual({
+      kind: "command",
+      command: { kind: "rename", label: "代码审查" },
+    });
+    expect(routeIncomingText("/close")).toEqual({
+      kind: "command",
+      command: { kind: "close" },
+    });
+    expect(routeIncomingText("/close 2")).toEqual({
+      kind: "command",
+      command: { kind: "close", index: 2 },
+    });
+    expect(routeIncomingText("/delete 3")).toEqual({
+      kind: "command",
+      command: { kind: "close", index: 3 },
     });
   });
 

--- a/test/session-windows.test.ts
+++ b/test/session-windows.test.ts
@@ -9,6 +9,7 @@ import {
   removeSession,
   resolveSessionMode,
   setActiveSession,
+  updateWindowModel,
 } from "../src/runtime/session-windows.js";
 
 describe("session windows", () => {
@@ -21,6 +22,7 @@ describe("session windows", () => {
   it("keeps only one active session in single mode", () => {
     const record: SessionWindowRecord = {
       mode: "single",
+      model: "openai/gpt-5.4",
       activeSessionId: "ses_old",
       sessions: [
         { sessionId: "ses_old", label: "old", createdAt: 1, lastUsedAt: 1 },
@@ -31,6 +33,7 @@ describe("session windows", () => {
     const normalized = normalizeSessionWindowRecord(record, "single", 20);
     expect(normalized.sessions).toHaveLength(1);
     expect(normalized.activeSessionId).toBe("ses_old");
+    expect(normalized.model).toBe("openai/gpt-5.4");
   });
 
   it("adds and switches sessions in multi mode", () => {
@@ -56,6 +59,7 @@ describe("session windows", () => {
   it("removes stale sessions and promotes the next active item", () => {
     const record = removeSession({
       mode: "multi",
+      model: "openai/gpt-5.4-mini",
       activeSessionId: "ses_2",
       sessions: [
         { sessionId: "ses_2", label: "two", createdAt: 2, lastUsedAt: 2 },
@@ -65,5 +69,19 @@ describe("session windows", () => {
 
     expect(record.activeSessionId).toBe("ses_1");
     expect(record.sessions).toHaveLength(1);
+    expect(record.model).toBe("openai/gpt-5.4-mini");
+  });
+
+  it("updates the window model override", () => {
+    const record = updateWindowModel({
+      mode: "multi",
+      model: null,
+      activeSessionId: "ses_1",
+      sessions: [
+        { sessionId: "ses_1", label: "one", createdAt: 1, lastUsedAt: 1 },
+      ],
+    }, "openai/gpt-5.4", 5);
+
+    expect(record.model).toBe("openai/gpt-5.4");
   });
 });


### PR DESCRIPTION
## 变更内容
- 新增会话命令能力，支持 `/rename`、`/close`、`/model`、`/model use`、`/model reset`
- 为会话命令与模型命令补充卡片化回包，统一交互展示
- 扩展 session window 与 mappings 数据结构，支持窗口级模型配置
- 补充会话命令、模型切换、卡片展示相关测试

## 变更原因
- 让会话管理能力更完整，减少依赖底层命令或记忆式操作
- 统一命令回包样式，提升卡片交互的一致性和可读性
- 为后续会话级模型选择和管理打基础

## 影响
- 新分支当前基于 `codex/group-whitelist-binding`，因此本 PR 以该分支为 base
- 合并后用户可直接通过命令完成会话重命名、关闭和模型切换
- 命令反馈从纯文本扩展为卡片展示，不影响现有主流程消息处理

## 验证
- `npm test`
- `npm run typecheck`
- `npm run lint`