### PR TITLE
[codex] 完善运行时稳定性与日志配置

### DIFF
--- a/src/bridge/state.ts
+++ b/src/bridge/state.ts
@@ -1,5 +1,6 @@
 export type PendingQuestionInteraction = {
   kind: "question";
+  turnId: string;
   requestId: string;
   sessionId: string;
   questions: Array<{ header: string; question: string }>;

--- a/src/feishu/api.ts
+++ b/src/feishu/api.ts
@@ -4,6 +4,9 @@ const RETRY_MAX_ATTEMPTS = 3;
 const RETRY_BASE_DELAY_MS = 500;
 
 export class FeishuApiClient {
+  private cachedToken: { token: string; expiresAt: number } | null = null;
+  private tokenRequest: Promise<string> | null = null;
+
   constructor(private readonly appId: string, private readonly appSecret: string) {}
 
   async sendMessage(chatId: string, payload: FeishuPostPayload): Promise<{ messageId: string }> {
@@ -58,15 +61,36 @@ export class FeishuApiClient {
   }
 
   async getTenantToken(): Promise<string> {
+    if (this.cachedToken && Date.now() < this.cachedToken.expiresAt) {
+      return this.cachedToken.token;
+    }
+
+    if (this.tokenRequest) {
+      return this.tokenRequest;
+    }
+
+    this.tokenRequest = this.fetchTenantToken().finally(() => {
+      this.tokenRequest = null;
+    });
+    return this.tokenRequest;
+  }
+
+  private async fetchTenantToken(): Promise<string> {
     const response = await fetch("https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ app_id: this.appId, app_secret: this.appSecret }),
     });
-    const body = (await response.json()) as { code: number; msg?: string; tenant_access_token?: string };
+    const body = (await response.json()) as { code: number; msg?: string; tenant_access_token?: string; expire?: number };
     if (!response.ok || body.code !== 0 || !body.tenant_access_token) {
       throw new Error(`Feishu fetch token failed: ${body.msg ?? response.statusText}`);
     }
+
+    const expireSeconds = typeof body.expire === "number" && Number.isFinite(body.expire) ? body.expire : 7_200;
+    this.cachedToken = {
+      token: body.tenant_access_token,
+      expiresAt: Date.now() + Math.max(60, expireSeconds - 300) * 1_000,
+    };
     return body.tenant_access_token;
   }
 }

--- a/src/feishu/ws.ts
+++ b/src/feishu/ws.ts
@@ -172,9 +172,7 @@ export class FeishuWsClient {
           }, "warn");
           return;
         }
-      } else if (mentionMatched) {
-        await this.whitelist.bind(incoming.chatId, incoming.senderOpenId);
-      } else if (!isBound) {
+      } else if (!mentionMatched && !isBound) {
         this.logger.log("feishu/ws", "message skipped", {
           reason: hasAnyMention ? "group-mention-mismatch" : "not-whitelisted",
           chatId: incoming.chatId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ async function main(): Promise<void> {
   const config = await loadConfig();
   const outbound = new FeishuApiClient(config.feishu.appId, config.feishu.appSecret);
   await runStartupPreflight(config, outbound);
-  const logger = await createLogger(config.logging.dir);
+  const logger = await createLogger(config.logging.dir, config.logging);
   const whitelist = new WhitelistStore(config.whitelist.storePath, logger);
   await whitelist.load();
   const app = new BridgeApp(config, outbound, logger, whitelist);

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -8,6 +8,14 @@ export type Logger = {
   logTranscript: (type: TranscriptType, fields: Record<string, unknown>, content: string) => void;
 };
 
+export type LoggerOptions = {
+  level: "debug" | "info" | "warn" | "error";
+  enableTranscript: boolean;
+  enableConsole: boolean;
+  enableColor: boolean;
+  rotateDaily: boolean;
+};
+
 const TRANSCRIPT_LABELS: Record<TranscriptType, string> = {
   inbound: "入站",
   "outbound-process": "出站-过程",
@@ -16,22 +24,46 @@ const TRANSCRIPT_LABELS: Record<TranscriptType, string> = {
   "reasoning-raw": "OpenCode思考原文",
 };
 
-export async function createLogger(loggingDir: string): Promise<Logger> {
+const DEFAULT_LOGGER_OPTIONS: LoggerOptions = {
+  level: "info",
+  enableTranscript: true,
+  enableConsole: true,
+  enableColor: true,
+  rotateDaily: true,
+};
+
+const LEVEL_PRIORITY: Record<LoggerOptions["level"], number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+export async function createLogger(loggingDir: string, options: Partial<LoggerOptions> = {}): Promise<Logger> {
   await mkdir(loggingDir, { recursive: true });
-  const day = new Date().toISOString().slice(0, 10);
-  const bridgeLog = path.join(loggingDir, `bridge-${day}.log`);
-  const transcriptLog = path.join(loggingDir, `transcript-${day}.log`);
+  const resolvedOptions = {
+    ...DEFAULT_LOGGER_OPTIONS,
+    ...options,
+  };
 
   return {
-    log(scope, message, fields = {}) {
+    log(scope, message, fields = {}, level = "info") {
+      if (!shouldLog(level, resolvedOptions.level)) {
+        return;
+      }
       const line = `${timeStamp()} [${scope}] ${message} ${formatFields(fields)}`.trimEnd();
-      void appendFile(bridgeLog, `${line}\n`, "utf8");
-      console.log(line);
+      void appendFile(resolveLogPath(loggingDir, "bridge", resolvedOptions.rotateDaily), `${line}\n`, "utf8");
+      if (resolvedOptions.enableConsole) {
+        console.log(resolvedOptions.enableColor ? colorizeLine(line, level) : line);
+      }
     },
     logTranscript(type, fields, content) {
+      if (!resolvedOptions.enableTranscript) {
+        return;
+      }
       const header = `[${TRANSCRIPT_LABELS[type]}] ${formatFields(fields)}`.trimEnd();
       const block = `${header}\n内容: ${content}\n---\n`;
-      void appendFile(transcriptLog, block, "utf8");
+      void appendFile(resolveLogPath(loggingDir, "transcript", resolvedOptions.rotateDaily), block, "utf8");
     },
   };
 }
@@ -43,6 +75,30 @@ export function createTextPreview(text: string): string {
 
 function timeStamp(): string {
   return new Date().toTimeString().slice(0, 8);
+}
+
+function resolveLogPath(loggingDir: string, kind: "bridge" | "transcript", rotateDaily: boolean): string {
+  if (!rotateDaily) {
+    return path.join(loggingDir, `${kind}.log`);
+  }
+
+  const day = new Date().toISOString().slice(0, 10);
+  return path.join(loggingDir, `${kind}-${day}.log`);
+}
+
+function shouldLog(level: LoggerOptions["level"], configuredLevel: LoggerOptions["level"]): boolean {
+  return LEVEL_PRIORITY[level] >= LEVEL_PRIORITY[configuredLevel];
+}
+
+function colorizeLine(line: string, level: LoggerOptions["level"]): string {
+  switch (level) {
+    case "debug": return `\u001b[90m${line}\u001b[0m`;
+    case "warn": return `\u001b[33m${line}\u001b[0m`;
+    case "error": return `\u001b[31m${line}\u001b[0m`;
+    case "info":
+    default:
+      return line;
+  }
 }
 
 function formatFields(fields: Record<string, unknown>): string {

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -162,6 +162,7 @@ export class BridgeApp {
       ensureSession: async (source) => await this.ensureSession(source),
       maybeUpdateSessionLabel: async (turn) => await this.maybeUpdateSessionLabel(turn),
       clearPendingInteraction: (conversationKey, keepNonExpiring) => this.clearPendingInteraction(conversationKey, keepNonExpiring),
+      clearTurnOwnedPendingInteraction: (conversationKey, turnId) => this.clearTurnOwnedPendingInteraction(conversationKey, turnId),
       setPendingInteraction: (conversationKey, interaction) => this.setPendingInteraction(conversationKey, interaction),
       sendPayload: async (chatId, payload, options, delivery) => await this.sendPayload(chatId, payload, options, delivery),
     });
@@ -551,6 +552,20 @@ export class BridgeApp {
     }
 
     this.pendingInteractions.delete(conversationKey);
+  }
+
+  private clearTurnOwnedPendingInteraction(conversationKey: string, turnId: string): void {
+    const current = this.pendingInteractions.get(conversationKey);
+    if (!current) {
+      return;
+    }
+
+    if (
+      (current.kind === "permission" && current.turnId === turnId)
+      || (current.kind === "question" && current.turnId === turnId)
+    ) {
+      this.clearPendingInteraction(conversationKey, false);
+    }
   }
 
   private async handlePermissionTimeout(conversationKey: string, pending: PendingPermissionInteraction): Promise<void> {

--- a/src/runtime/turn-executor.ts
+++ b/src/runtime/turn-executor.ts
@@ -5,7 +5,7 @@ import { transitionTurn } from "../bridge/state-machine.js";
 import { TurnWatchdog } from "../bridge/watchdog.js";
 import type { BridgeTurn } from "../bridge/turn.js";
 import { buildPermissionRequestCardPayload, buildPostMarkdownPayload, type FeishuPostPayload } from "../feishu/formatter.js";
-import type { Logger, TranscriptType } from "../logging/logger.js";
+import { createTextPreview, type Logger, type TranscriptType } from "../logging/logger.js";
 import { type OpenCodeMessage, type OpenCodeSessionStatus } from "../opencode/client.js";
 import { getEventSessionId, type OpenCodeEvent } from "../opencode/events.js";
 import { type SessionWindowRecord } from "../store/mappings.js";
@@ -88,6 +88,7 @@ export type TurnExecutorContext = {
   ensureSession(source: Pick<BridgeTurn, "chatId" | "chatType" | "conversationKey" | "threadKey">): Promise<string>;
   maybeUpdateSessionLabel(turn: BridgeTurn & { sessionId: string }): Promise<void>;
   clearPendingInteraction(conversationKey: string, keepNonExpiring: boolean): void;
+  clearTurnOwnedPendingInteraction(conversationKey: string, turnId: string): void;
   setPendingInteraction(conversationKey: string, interaction: PendingInteraction): void;
   sendPayload(
     chatId: string,
@@ -115,6 +116,7 @@ export class TurnExecutor {
 
     let turn = transitionTurn(active, "running");
     queue.replaceActive(turn);
+    let hasProcessCard = false;
 
     try {
       const sessionId = turn.sessionId ?? await this.context.ensureSession(turn);
@@ -124,7 +126,9 @@ export class TurnExecutor {
 
       const card = await this.context.turnCardManager.createTurnCard(turn.chatId, turn.turnId, sessionId, turn.inboundMessageId);
       if (card) {
-        queue.replaceActive({ ...turn, processMessageId: card.messageId });
+        hasProcessCard = true;
+        turn = { ...turn, processMessageId: card.messageId };
+        queue.replaceActive(turn);
       }
 
       const reply = cleanAssistantReply(await this.executeTurn(conversationKey, turn as BridgeTurn & { sessionId: string }));
@@ -134,6 +138,9 @@ export class TurnExecutor {
       if (reply) {
         this.context.memory?.enqueueLearn(turn.senderOpenId, turn.plainText, reply);
       }
+      if (!card && reply) {
+        await this.sendTurnFallbackMarkdown(turn.chatId, reply);
+      }
       await this.context.turnCardManager.flushStreamUpdate(turn.turnId, reply, true);
       await this.context.turnCardManager.updateTurnCard(turn.turnId, { status: "已完成", update: `最终回复已生成（${reply.length} 字）`, target: "step" });
       queue.replaceActive(transitionTurn({ ...turn, sessionId }, "done"));
@@ -141,10 +148,13 @@ export class TurnExecutor {
     } catch (error) {
       const detail = cleanAssistantReply(error instanceof Error ? error.message : String(error));
       this.context.logger.log("bridge/queue", "run turn failed", { chatId: turn.chatId, conversationKey, turnId: turn.turnId, detail }, "error");
+      if (!hasProcessCard) {
+        await this.sendTurnFallbackMarkdown(turn.chatId, `处理失败：${escapeMarkdownText(detail)}`);
+      }
       await this.context.turnCardManager.updateTurnCard(turn.turnId, { status: detail.includes("超时") ? "已超时" : "处理失败", update: detail, target: "step" });
       queue.replaceActive(transitionTurn(turn, detail.includes("超时") ? "timeout" : "aborted"));
     } finally {
-      this.context.clearPendingInteraction(conversationKey, false);
+      this.context.clearTurnOwnedPendingInteraction(conversationKey, turn.turnId);
       this.context.turnCardManager.cleanup(turn.turnId);
     }
   }
@@ -404,6 +414,7 @@ export class TurnExecutor {
       if (!request) return;
       this.context.setPendingInteraction(turn.conversationKey, {
         kind: "question",
+        turnId: turn.turnId,
         requestId: request.id,
         sessionId: request.sessionId,
         questions: request.questions,
@@ -520,5 +531,14 @@ export class TurnExecutor {
   private async getAssistantMessageById(sessionId: string, messageId: string): Promise<OpenCodeMessage | null> {
     const messages = await this.context.opencode.getSessionMessages(sessionId, 200);
     return messages.find((message) => message.info.id === messageId && message.info.role === "assistant") ?? null;
+  }
+
+  private async sendTurnFallbackMarkdown(chatId: string, markdown: string): Promise<void> {
+    await this.context.sendPayload(chatId, buildPostMarkdownPayload(markdown), {
+      event: "fallback final message sent",
+      transcriptType: "outbound-final",
+      textPreview: createTextPreview(markdown),
+      len: markdown.length,
+    });
   }
 }

--- a/test/app-command-surface.test.ts
+++ b/test/app-command-surface.test.ts
@@ -529,6 +529,184 @@ describe("BridgeApp command surface", () => {
 
     expect(extractInteractiveText(getReplyPayloads(outbound)[0])).toContain("请先发送 `/abort`");
   });
+
+  it("falls back to a direct message when the process card cannot be created", async () => {
+    const outbound = createOutbound();
+    const app = new BridgeApp(baseConfig(), outbound, logger(), createWhitelist());
+    const appAny = app as unknown as {
+      turnExecutor: {
+        context: {
+          ensureSession: (source: Record<string, unknown>) => Promise<string>;
+          turnCardManager: {
+            createTurnCard: (chatId: string, turnId: string, sessionId: string, replyToMessageId: string) => Promise<null>;
+          };
+        };
+        executeTurn: (conversationKey: string, turn: Record<string, unknown>) => Promise<string>;
+      };
+      runTurn: (conversationKey: string) => Promise<void>;
+      queues: {
+        get(key: string): {
+          enqueue: (turn: Record<string, unknown>) => { accepted: boolean };
+        };
+      };
+    };
+    appAny.turnExecutor.context.ensureSession = vi.fn(async () => "ses_1");
+    appAny.turnExecutor.context.turnCardManager.createTurnCard = vi.fn(async () => null);
+    appAny.turnExecutor.executeTurn = vi.fn(async () => "最终回复");
+    appAny.queues.get("oc_p2p_1").enqueue({
+      turnId: "turn_1",
+      chatId: "oc_p2p_1",
+      conversationKey: "oc_p2p_1",
+      threadKey: "om_1",
+      senderOpenId: "ou_123",
+      inboundMessageId: "om_1",
+      plainText: "hello",
+      text: "hello",
+    });
+
+    await appAny.runTurn("oc_p2p_1");
+
+    expect(outbound.sendMessage).toHaveBeenCalledTimes(1);
+    expect(extractMarkdown(getSendPayloads(outbound)[0])).toContain("最终回复");
+  });
+
+  it("falls back to a direct error message when the process card cannot be created", async () => {
+    const outbound = createOutbound();
+    const app = new BridgeApp(baseConfig(), outbound, logger(), createWhitelist());
+    const appAny = app as unknown as {
+      turnExecutor: {
+        context: {
+          ensureSession: (source: Record<string, unknown>) => Promise<string>;
+          turnCardManager: {
+            createTurnCard: (chatId: string, turnId: string, sessionId: string, replyToMessageId: string) => Promise<null>;
+          };
+        };
+        executeTurn: (conversationKey: string, turn: Record<string, unknown>) => Promise<string>;
+      };
+      runTurn: (conversationKey: string) => Promise<void>;
+      queues: {
+        get(key: string): {
+          enqueue: (turn: Record<string, unknown>) => { accepted: boolean };
+        };
+      };
+    };
+    appAny.turnExecutor.context.ensureSession = vi.fn(async () => "ses_1");
+    appAny.turnExecutor.context.turnCardManager.createTurnCard = vi.fn(async () => null);
+    appAny.turnExecutor.executeTurn = vi.fn(async () => {
+      throw new Error("服务暂时不可用");
+    });
+    appAny.queues.get("oc_p2p_1").enqueue({
+      turnId: "turn_1",
+      chatId: "oc_p2p_1",
+      conversationKey: "oc_p2p_1",
+      threadKey: "om_1",
+      senderOpenId: "ou_123",
+      inboundMessageId: "om_1",
+      plainText: "hello",
+      text: "hello",
+    });
+
+    await appAny.runTurn("oc_p2p_1");
+
+    expect(outbound.sendMessage).toHaveBeenCalledTimes(1);
+    expect(extractMarkdown(getSendPayloads(outbound)[0])).toContain("处理失败：服务暂时不可用");
+  });
+
+  it("keeps session selection state after an unrelated turn finishes", async () => {
+    const outbound = createOutbound();
+    const app = new BridgeApp(baseConfig(), outbound, logger(), createWhitelist());
+    const appAny = app as unknown as {
+      turnExecutor: {
+        context: {
+          ensureSession: (source: Record<string, unknown>) => Promise<string>;
+          turnCardManager: {
+            createTurnCard: (chatId: string, turnId: string, sessionId: string, replyToMessageId: string) => Promise<null>;
+          };
+        };
+        executeTurn: (conversationKey: string, turn: Record<string, unknown>) => Promise<string>;
+      };
+      runTurn: (conversationKey: string) => Promise<void>;
+      queues: {
+        get(key: string): {
+          enqueue: (turn: Record<string, unknown>) => { accepted: boolean };
+        };
+      };
+      pendingInteractions: Map<string, PendingInteraction>;
+    };
+    appAny.turnExecutor.context.ensureSession = vi.fn(async () => "ses_1");
+    appAny.turnExecutor.context.turnCardManager.createTurnCard = vi.fn(async () => null);
+    appAny.turnExecutor.executeTurn = vi.fn(async () => "done");
+    appAny.pendingInteractions.set("oc_p2p_1", {
+      kind: "session-select",
+      expiresAt: Date.now() + 30_000,
+      options: [
+        { index: 1, sessionId: "ses_1", title: "会话1", current: true },
+      ],
+    });
+    appAny.queues.get("oc_p2p_1").enqueue({
+      turnId: "turn_1",
+      chatId: "oc_p2p_1",
+      conversationKey: "oc_p2p_1",
+      threadKey: "om_1",
+      senderOpenId: "ou_123",
+      inboundMessageId: "om_1",
+      plainText: "hello",
+      text: "hello",
+    });
+
+    await appAny.runTurn("oc_p2p_1");
+
+    expect(appAny.pendingInteractions.get("oc_p2p_1")).toEqual(expect.objectContaining({
+      kind: "session-select",
+    }));
+  });
+
+  it("clears question state owned by the finishing turn", async () => {
+    const outbound = createOutbound();
+    const app = new BridgeApp(baseConfig(), outbound, logger(), createWhitelist());
+    const appAny = app as unknown as {
+      turnExecutor: {
+        context: {
+          ensureSession: (source: Record<string, unknown>) => Promise<string>;
+          turnCardManager: {
+            createTurnCard: (chatId: string, turnId: string, sessionId: string, replyToMessageId: string) => Promise<null>;
+          };
+        };
+        executeTurn: (conversationKey: string, turn: Record<string, unknown>) => Promise<string>;
+      };
+      runTurn: (conversationKey: string) => Promise<void>;
+      queues: {
+        get(key: string): {
+          enqueue: (turn: Record<string, unknown>) => { accepted: boolean };
+        };
+      };
+      pendingInteractions: Map<string, PendingInteraction>;
+    };
+    appAny.turnExecutor.context.ensureSession = vi.fn(async () => "ses_1");
+    appAny.turnExecutor.context.turnCardManager.createTurnCard = vi.fn(async () => null);
+    appAny.turnExecutor.executeTurn = vi.fn(async () => "done");
+    appAny.pendingInteractions.set("oc_p2p_1", {
+      kind: "question",
+      turnId: "turn_1",
+      requestId: "q_1",
+      sessionId: "ses_1",
+      questions: [{ header: "问题", question: "请补充信息" }],
+    });
+    appAny.queues.get("oc_p2p_1").enqueue({
+      turnId: "turn_1",
+      chatId: "oc_p2p_1",
+      conversationKey: "oc_p2p_1",
+      threadKey: "om_1",
+      senderOpenId: "ou_123",
+      inboundMessageId: "om_1",
+      plainText: "hello",
+      text: "hello",
+    });
+
+    await appAny.runTurn("oc_p2p_1");
+
+    expect(appAny.pendingInteractions.has("oc_p2p_1")).toBe(false);
+  });
 });
 
 async function callHandleCommand(
@@ -735,4 +913,8 @@ function extractInteractiveHeader(payload: { content: string } | undefined): str
 
 function getReplyPayloads(outbound: ReturnType<typeof createOutbound>): Array<{ content: string } | undefined> {
   return (outbound.replyMessage.mock.calls as unknown[][]).map((call) => call[1] as { content: string } | undefined);
+}
+
+function getSendPayloads(outbound: ReturnType<typeof createOutbound>): Array<{ content: string } | undefined> {
+  return (outbound.sendMessage.mock.calls as unknown[][]).map((call) => call[1] as { content: string } | undefined);
 }

--- a/test/group-chat.test.ts
+++ b/test/group-chat.test.ts
@@ -576,6 +576,40 @@ describe("group chat support", () => {
     expect(whitelist.isBound("oc_group_bind_1", "ou_123")).toBe(true);
   });
 
+  it("keeps dispatching mention messages when best-effort binding fails", async () => {
+    const handler = vi.fn(async () => {});
+    const logger = { log: vi.fn() };
+    const whitelist = {
+      isBound() { return false; },
+      bind: vi.fn(async () => {
+        throw new Error("disk full");
+      }),
+      async unbind() { return false; },
+      count() { return 0; },
+    };
+    const client = new FeishuWsClient("app", "secret", makeOptions(), whitelist, handler, logger);
+
+    await (client as unknown as { handleEvent(payload: unknown): Promise<void> }).handleEvent({
+      message: {
+        chat_id: "oc_group_bind_fail_1",
+        chat_type: "group",
+        message_id: "om_bind_fail_1",
+        message_type: "text",
+        content: JSON.stringify({ text: '<at user_id="ou_bot">机器人</at> 帮我分析一下' }),
+        mentions: [{ id: { open_id: "ou_bot" }, name: "机器人" }],
+      },
+      sender: { sender_id: { open_id: "ou_123" } },
+    });
+
+    expect(whitelist.bind).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(logger.log).toHaveBeenCalledWith("store/whitelist", "bind failed", expect.objectContaining({
+      chatId: "oc_group_bind_fail_1",
+      senderOpenId: "ou_123",
+      detail: "disk full",
+    }), "warn");
+  });
+
   it("skips unbound non-mentioned group messages with not-whitelisted", async () => {
     const handler = vi.fn(async () => {});
     const logger = { log: vi.fn() };

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -2,11 +2,15 @@ import { mkdtemp, readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createLogger, createTextPreview } from "../src/logging/logger.js";
 
 describe("logger", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("creates previews", () => {
     expect(createTextPreview("a".repeat(120)).length).toBeLessThanOrEqual(80);
   });
@@ -77,5 +81,41 @@ describe("logger", () => {
     const day = new Date().toISOString().slice(0, 10);
     const content = await readFile(path.join(dir, `transcript-${day}.log`), "utf8");
     expect(content).toContain("reply");
+  });
+
+  it("honors level filtering and console output settings", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-logger-"));
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    const logger = await createLogger(dir, {
+      level: "warn",
+      enableConsole: false,
+      enableColor: false,
+    });
+
+    logger.log("scope", "info message", {}, "info");
+    logger.log("scope", "warn message", {}, "warn");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const day = new Date().toISOString().slice(0, 10);
+    const content = await readFile(path.join(dir, `bridge-${day}.log`), "utf8");
+    expect(content).not.toContain("info message");
+    expect(content).toContain("warn message");
+    expect(consoleLog).not.toHaveBeenCalled();
+  });
+
+  it("honors transcript and rotation settings", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-logger-"));
+    const logger = await createLogger(dir, {
+      enableTranscript: false,
+      rotateDaily: false,
+    });
+
+    logger.log("scope", "message", {});
+    logger.logTranscript("inbound", { chatId: "c" }, "hidden");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const bridgeContent = await readFile(path.join(dir, "bridge.log"), "utf8");
+    expect(bridgeContent).toContain("message");
+    await expect(readFile(path.join(dir, "transcript.log"), "utf8")).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## 变更内容
- 为飞书租户 token 增加缓存与并发请求复用，减少重复 token 请求
- 为日志增加 level、console、color、transcript 与按天滚动配置，并接入启动入口
- 在过程卡片创建失败时补充最终回复/错误的 direct message 回退
- 调整 pending question 清理逻辑，避免 unrelated pending 状态被完成的 turn 误清理
- 保留群聊 mention 后白名单绑定失败时继续分发的容错行为，并补充测试

## 变更原因

- 最近主线合并后运行时结构已经模块化，这批跟进需要落在新的 `TurnExecutor` 路径上
- 提升服务端运行稳定性、日志可配置性和卡片失败场景下的消息可达性

## 影响

- 运行时在卡片创建失败时仍能返回最终内容或错误提示
- 日志输出行为可通过配置控制，飞书 API token 请求更少
- 问题/会话选择等 pending 状态清理更精确

## 验证
- `npm test -- test/app-command-surface.test.ts test/group-chat.test.ts test/logger.test.ts test/feishu-api.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run lint`
