### PR TITLE
[codex] 修复本地日志轮转日期与兜底回复线程关联

### DIFF
--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -82,8 +82,15 @@ function resolveLogPath(loggingDir: string, kind: "bridge" | "transcript", rotat
     return path.join(loggingDir, `${kind}.log`);
   }
 
-  const day = new Date().toISOString().slice(0, 10);
+  const day = formatLocalDate(new Date());
   return path.join(loggingDir, `${kind}-${day}.log`);
+}
+
+function formatLocalDate(date: Date): string {
+  const year = String(date.getFullYear());
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
 function shouldLog(level: LoggerOptions["level"], configuredLevel: LoggerOptions["level"]): boolean {

--- a/src/runtime/turn-executor.ts
+++ b/src/runtime/turn-executor.ts
@@ -139,7 +139,7 @@ export class TurnExecutor {
         this.context.memory?.enqueueLearn(turn.senderOpenId, turn.plainText, reply);
       }
       if (!card && reply) {
-        await this.sendTurnFallbackMarkdown(turn.chatId, reply);
+        await this.sendTurnFallbackMarkdown(turn.chatId, reply, turn.inboundMessageId);
       }
       await this.context.turnCardManager.flushStreamUpdate(turn.turnId, reply, true);
       await this.context.turnCardManager.updateTurnCard(turn.turnId, { status: "已完成", update: `最终回复已生成（${reply.length} 字）`, target: "step" });
@@ -149,7 +149,7 @@ export class TurnExecutor {
       const detail = cleanAssistantReply(error instanceof Error ? error.message : String(error));
       this.context.logger.log("bridge/queue", "run turn failed", { chatId: turn.chatId, conversationKey, turnId: turn.turnId, detail }, "error");
       if (!hasProcessCard) {
-        await this.sendTurnFallbackMarkdown(turn.chatId, `处理失败：${escapeMarkdownText(detail)}`);
+        await this.sendTurnFallbackMarkdown(turn.chatId, `处理失败：${escapeMarkdownText(detail)}`, turn.inboundMessageId);
       }
       await this.context.turnCardManager.updateTurnCard(turn.turnId, { status: detail.includes("超时") ? "已超时" : "处理失败", update: detail, target: "step" });
       queue.replaceActive(transitionTurn(turn, detail.includes("超时") ? "timeout" : "aborted"));
@@ -533,12 +533,12 @@ export class TurnExecutor {
     return messages.find((message) => message.info.id === messageId && message.info.role === "assistant") ?? null;
   }
 
-  private async sendTurnFallbackMarkdown(chatId: string, markdown: string): Promise<void> {
+  private async sendTurnFallbackMarkdown(chatId: string, markdown: string, replyToMessageId: string): Promise<void> {
     await this.context.sendPayload(chatId, buildPostMarkdownPayload(markdown), {
       event: "fallback final message sent",
       transcriptType: "outbound-final",
       textPreview: createTextPreview(markdown),
       len: markdown.length,
-    });
+    }, { replyToMessageId });
   }
 }

--- a/test/app-command-surface.test.ts
+++ b/test/app-command-surface.test.ts
@@ -566,8 +566,10 @@ describe("BridgeApp command surface", () => {
 
     await appAny.runTurn("oc_p2p_1");
 
-    expect(outbound.sendMessage).toHaveBeenCalledTimes(1);
-    expect(extractMarkdown(getSendPayloads(outbound)[0])).toContain("最终回复");
+    expect(outbound.sendMessage).not.toHaveBeenCalled();
+    expect(outbound.replyMessage).toHaveBeenCalledTimes(1);
+    expect(outbound.replyMessage).toHaveBeenCalledWith("om_1", expect.any(Object));
+    expect(extractMarkdown(getReplyPayloads(outbound)[0])).toContain("最终回复");
   });
 
   it("falls back to a direct error message when the process card cannot be created", async () => {
@@ -608,8 +610,10 @@ describe("BridgeApp command surface", () => {
 
     await appAny.runTurn("oc_p2p_1");
 
-    expect(outbound.sendMessage).toHaveBeenCalledTimes(1);
-    expect(extractMarkdown(getSendPayloads(outbound)[0])).toContain("处理失败：服务暂时不可用");
+    expect(outbound.sendMessage).not.toHaveBeenCalled();
+    expect(outbound.replyMessage).toHaveBeenCalledTimes(1);
+    expect(outbound.replyMessage).toHaveBeenCalledWith("om_1", expect.any(Object));
+    expect(extractMarkdown(getReplyPayloads(outbound)[0])).toContain("处理失败：服务暂时不可用");
   });
 
   it("keeps session selection state after an unrelated turn finishes", async () => {
@@ -913,8 +917,4 @@ function extractInteractiveHeader(payload: { content: string } | undefined): str
 
 function getReplyPayloads(outbound: ReturnType<typeof createOutbound>): Array<{ content: string } | undefined> {
   return (outbound.replyMessage.mock.calls as unknown[][]).map((call) => call[1] as { content: string } | undefined);
-}
-
-function getSendPayloads(outbound: ReturnType<typeof createOutbound>): Array<{ content: string } | undefined> {
-  return (outbound.sendMessage.mock.calls as unknown[][]).map((call) => call[1] as { content: string } | undefined);
 }

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -9,6 +9,7 @@ import { createLogger, createTextPreview } from "../src/logging/logger.js";
 describe("logger", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("creates previews", () => {
@@ -117,5 +118,19 @@ describe("logger", () => {
     const bridgeContent = await readFile(path.join(dir, "bridge.log"), "utf8");
     expect(bridgeContent).toContain("message");
     await expect(readFile(path.join(dir, "transcript.log"), "utf8")).rejects.toThrow();
+  });
+
+  it("rotates daily logs using the local calendar day", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-logger-"));
+    vi.spyOn(Date.prototype, "getFullYear").mockReturnValue(2026);
+    vi.spyOn(Date.prototype, "getMonth").mockReturnValue(3);
+    vi.spyOn(Date.prototype, "getDate").mockReturnValue(12);
+    const logger = await createLogger(dir, { enableConsole: false });
+
+    logger.log("scope", "message", {});
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const content = await readFile(path.join(dir, "bridge-2026-04-12.log"), "utf8");
+    expect(content).toContain("message");
   });
 });


### PR DESCRIPTION
## 变更内容
- 修复日志按天轮转时使用 UTC 日期导致的本地日期偏差
- 修复过程卡片创建失败时，最终回复和失败提示未继续回复到原消息线程的问题
- 更新对应的运行时与日志测试

## 变更原因
- 本地日志文件名应按部署机器的本地自然日切分，避免跨时区时落到错误日期
- 兜底回复脱离原消息线程时，群内和会话上下文会变得不连贯，排查也更困难

## 影响
- 每日日志文件会按本地日期命名
- 过程卡片失败时，桥接的兜底回复会继续挂载在原消息线程下
- 不影响正常过程卡片路径，仅修正兜底行为

## 验证
- `npm test -- test/logger.test.ts test/app-command-surface.test.ts`
- `npm run typecheck`
- `npm run lint`