### PR TITLE
[codex] 更新 README 并补充 Apache 许可证

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025 Clukay_Fun
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,117 +1,121 @@
 # Feishu OpenCode Bridge
 
+[中文](README.zh-CN.md) | English
+
+[![CI](https://github.com/Clukay-Fun/feishu-opencode-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/Clukay-Fun/feishu-opencode-bridge/actions/workflows/ci.yml)
 [![Node.js](https://img.shields.io/badge/Node.js-20%2B-339933)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6)](https://www.typescriptlang.org/)
-[![Feishu](https://img.shields.io/badge/Feishu-Bridge-0F6FFF)](https://open.feishu.cn/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
-Feishu OpenCode Bridge is a Feishu-native runtime adapter for OpenCode.
+Turn Feishu chats into persistent, session-aware OpenCode workspaces.
 
-It turns Feishu chats into session-aware OpenCode workspaces, keeps process updates inside interactive cards, handles permission confirmation, and preserves a clear boundary between bridge-owned runtime control and passthrough OpenCode commands.
+Feishu OpenCode Bridge is a standalone TypeScript service that connects Feishu conversations to a local [OpenCode](https://opencode.ai) server. It manages sessions, renders streaming process cards, handles permission approval via interactive buttons, supports group collaboration, and maintains long-term user memory — all inside Feishu.
 
-## Why This Is Not A Normal Bot
+<!-- Screenshots: replace placeholders with actual images -->
+<!--
+<p align="center">
+  <img src="docs/assets/process-card.png" width="320" alt="Process card" />
+  <img src="docs/assets/permission-card.png" width="320" alt="Permission buttons" />
+  <img src="docs/assets/sessions-card.png" width="320" alt="Session list" />
+</p>
+-->
 
-This project is not trying to be a generic chat bot.
+## Key Features
 
-It is a bridge layer that gives OpenCode a stable runtime surface inside Feishu:
-
-- session-aware windows for `p2p`, `group`, and `topic_group`
-- bridge-owned runtime commands such as `/new`, `/status`, `/sessions`, `/switch`
-- process cards that update in place while a task is running
-- real permission buttons backed by Feishu card actions
-- group whitelist binding so collaboration can continue without repeated `@bot`
-
-## Features
-
-- Interactive Process Card with in-place updates for running turns
-- Bridge-owned command cards for session and group binding flows
-- True permission buttons with text-command fallback
-- Group whitelist binding with `/who` and `/leave`
-- `single` and `multi` session modes per window type
-- Optional long-term memory with fact extraction, SQLite/FTS5 storage, embedding-based retrieval, and Obsidian `profile.md` sync
-- Slash command passthrough to OpenCode for commands the bridge does not own
-- Startup preflight for Feishu auth, OpenCode health, providers, and callback config
-- JSON-backed stores for session mappings and group bindings
-- Markdown output rules documented in [docs/feishu-markdown.md](/Users/clukay/Program/feishu-opencode-bridge/docs/feishu-markdown.md)
+- **Session Windows** — Independent session binding for private chats, group chats, and topic groups, with `single` and `multi` session modes.
+- **Streaming Process Cards** — Real-time in-place card updates while OpenCode runs. Completed output is rendered as semantically split Markdown blocks for better readability.
+- **Permission Buttons** — Approve or deny OpenCode tool calls directly from Feishu card buttons. Supports allow-once, allow-always, and deny.
+- **Group Collaboration** — Mention `@bot` once to bind the whitelist. Subsequent messages work without mentioning. Manage with `/who` and `/leave`.
+- **Long-term Memory** — Automatically extracts user facts, stores embeddings in SQLite, recalls relevant context across sessions, and can sync an Obsidian `profile.md`.
+- **Fault Tolerance** — SSE reconnection with exponential backoff, Feishu API retry with token caching, rate limiting, and graceful process card fallback.
+- **Command Passthrough** — Commands the bridge does not own continue to flow through to OpenCode.
+- **Operational Guardrails** — Startup preflight checks Feishu auth, OpenCode health, providers, storage, and callback configuration before serving traffic.
 
 ## Architecture
 
 ```mermaid
 flowchart LR
-    A["Feishu WebSocket Events"] --> B["Bridge Runtime"]
-    B --> C["OpenCode Server API"]
-    C --> D["OpenCode Event Stream"]
+    A[Feishu WebSocket] --> B[Bridge Runtime]
+    B --> C[OpenCode Server]
+    C --> D[SSE Event Stream]
     D --> B
-    B --> E["Feishu Process / Command / Notice Cards"]
-    F["Feishu Card Action Callback"] --> B
-    G["Whitelist + Session Mapping Stores"] --> B
+    B --> E[Feishu Cards]
+    F[Card Action Callback] --> B
+    B --> G[SQLite Memory]
+    B --> H[JSON Stores]
 ```
-
-## Demo Flow
-
-The fixed public demo script lives in [docs/demo-script.md](/Users/clukay/Program/feishu-opencode-bridge/docs/demo-script.md).
-
-It covers:
-
-1. Private chat developer assistant flow
-2. Group chat binding and no-mention continuation
-3. Permission button flow
-4. `lark-cli`-driven Feishu workflow actions
-
-## Output Rules
-
-- Markdown rules: [docs/feishu-markdown.md](/Users/clukay/Program/feishu-opencode-bridge/docs/feishu-markdown.md)
-- `Plain Post` is only for passthrough text output, ultra-short confirmations, and card fallback
-- Bridge-owned commands, structured lists, and system notices should use cards instead
-
-## Requirements
-
-- Node.js 20+
-- A Feishu app with bot capability
-- A running OpenCode server
-- Public HTTPS callback if you want real permission buttons
 
 ## Quick Start
 
-Install dependencies:
+### Prerequisites
+
+- Node.js 20+
+- A Feishu custom app with bot capability ([create one here](https://open.feishu.cn/app))
+- A running OpenCode server (`opencode serve`)
+- (Optional) Public HTTPS endpoint for permission button callbacks
+
+### Setup
 
 ```bash
+git clone https://github.com/Clukay-Fun/feishu-opencode-bridge.git
+cd feishu-opencode-bridge
 npm install
+cp config.example.json config.json
+# Edit config.json — fill in feishu.appId, feishu.appSecret, and opencode.baseUrl
 ```
 
-Start OpenCode first:
+### Run
 
 ```bash
-opencode serve
+opencode serve          # Start OpenCode first
+npm run dev             # Then start the bridge
 ```
 
-Then start the bridge:
+The bridge runs a startup preflight that checks Feishu auth, OpenCode connectivity, storage directories, and callback config. If anything fails, it exits immediately with a clear error.
 
-```bash
-npm run dev
-```
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/new` | Create a new session |
+| `/status` | Show current session and system state |
+| `/abort` | Abort the running task |
+| `/sessions` | List all sessions |
+| `/switch <n>` | Switch to session by index |
+| `/model` | Show the current model and active override |
+| `/model <provider>` | Show models under a provider |
+| `/who` | Show group binding status |
+| `/leave` | Unbind from group whitelist |
+| `/close` | Close the current session |
+| `/close all` | Close every session in the current window |
+| `/close <start-end>` | Close a session range |
+| `/delete` | Delete the current session |
+| `/delete all confirm` | Delete all sessions in the current window |
+| `/delete <index> confirm` | Delete one session by index |
+| `/delete <start-end> confirm` | Delete a session range |
+| `/allow once` | Allow the current permission request |
+| `/allow always` | Always allow this permission |
+| `/deny` | Deny the permission request |
+
+Any other `/` command is passed through to OpenCode (e.g. `/model use ...`, `/model reset`, `/review`, `/init`).
 
 ## Configuration
 
-Use [config.example.json](/Users/clukay/Program/feishu-opencode-bridge/config.example.json) as the baseline.
+See [`config.example.json`](config.example.json) for the full reference.
 
-Important sections:
+| Section | What it controls |
+|---------|-----------------|
+| `feishu` | App credentials, bot behavior, card action security |
+| `opencode` | OpenCode server URL and target worktree |
+| `server` | HTTP listen address and public callback URL |
+| `bridge` | Queue concurrency, session mode, timeouts |
+| `storage` | JSON store and SQLite paths |
+| `logging` | Log level, console/transcript toggles, daily rotation |
+| `memory` | Memory extraction, embedding, recall, and optional Obsidian sync |
 
-- `feishu`
-  bot identity, behavior flags, and card action security settings
-- `opencode`
-  OpenCode base URL and target worktree
-- `server`
-  local HTTP listen address and public callback base URL
-- `storage`
-  JSON persistence location
-- `bridge`
-  queueing, session mode, and timeout behavior
-- `memory`
-  optional long-term memory storage and retrieval settings
+### Permission Button Callback
 
-### Button Callback Config
-
-To enable real permission buttons:
+To enable interactive permission buttons, expose the bridge HTTP server behind HTTPS and configure:
 
 ```json
 {
@@ -125,50 +129,13 @@ To enable real permission buttons:
       "enabled": true,
       "path": "/webhook/card",
       "verificationToken": "your-token",
-      "encryptKey": ""
+      "encryptKey": "your-encrypt-key"
     }
   }
 }
 ```
 
 If Feishu event encryption is enabled, set `encryptKey` as well.
-
-## Commands
-
-Bridge-owned commands:
-
-- `/new`
-- `/status`
-- `/abort`
-- `/model`
-- `/model <provider>`
-- `/sessions`
-- `/sessions all`
-- `/sessions <index>`
-- `/switch <index>`
-- `/close`
-- `/close all`
-- `/close <start-end>`
-- `/delete`
-- `/delete all confirm`
-- `/delete <index> confirm`
-- `/delete <start-end> confirm`
-- `/who`
-- `/leave`
-- `/allow once`
-- `/allow always`
-- `/deny`
-
-Any other slash command is forwarded to OpenCode.
-
-That means OpenCode-native commands such as:
-
-- `/model use ...`
-- `/model reset`
-- `/review`
-- `/init`
-
-can continue to work through passthrough, as long as your OpenCode runtime supports them.
 
 ## Startup Preflight
 
@@ -182,61 +149,48 @@ On startup the bridge checks:
 - card callback config is complete when button mode is enabled
 
 If any of these checks fail, the bridge exits early instead of half-starting.
-
 ## Deployment
 
-Single-host deployment guidance lives in [docs/deploy.md](/Users/clukay/Program/feishu-opencode-bridge/docs/deploy.md).
+See [docs/deploy.md](docs/deploy.md) for single-host deployment with Caddy.
 
-Included assets:
-
-- [ops/Caddyfile](/Users/clukay/Program/feishu-opencode-bridge/ops/Caddyfile)
-- [.env.example](/Users/clukay/Program/feishu-opencode-bridge/.env.example)
-
-Health check endpoint:
-
-```text
-GET /healthz
+```bash
+npm run build
+node dist/index.js
 ```
 
-Card action callback default path:
+Docker:
 
-```text
-/webhook/card
+```bash
+docker build -t feishu-opencode-bridge .
+docker run -v ./config.json:/app/config.json feishu-opencode-bridge
 ```
+
+Health check: `GET /healthz`
 
 ## Development
 
-Useful commands:
-
 ```bash
-npm run typecheck
-npm test
-npm run lint
-npm run dev
-npm run dev:once
+npm run typecheck       # Type check
+npm run lint            # Lint
+npm test                # Run all tests
+npm run dev             # Start with watch mode
 ```
 
 ## Project Layout
 
-- `src/bridge/`
-  queueing, routing, pending interaction state, watchdog
-- `src/config/`
-  config schema and loader
-- `src/feishu/`
-  API client, formatter, WebSocket ingress
-- `src/http/`
-  callback server and health endpoint
-- `src/opencode/`
-  OpenCode HTTP client and event stream
-- `src/runtime/`
-  app orchestrator, command handler, turn executor,
-  permission manager, turn card manager, helpers, preflight
-- `src/memory/`
-  long-term memory storage, extraction, retrieval, Obsidian sync
-- `src/store/`
-  JSON-backed stores
+```
+src/
+  bridge/       Queue, routing, pending interaction state
+  config/       Config schema (Zod) and loader
+  feishu/       Feishu API client, card formatter, WebSocket ingress
+  http/         Callback server and health endpoint
+  logging/      Structured logger with daily rotation
+  memory/       Memory extraction, embedding, SQLite storage, Obsidian sync
+  opencode/     OpenCode HTTP client and SSE event stream
+  runtime/      Bridge orchestration, commands, turn execution, permission manager
+  store/        JSON-backed session and whitelist stores
+```
 
-## Notes
+## License
 
-- This repo currently targets a public demo / submission build, not a full team-production platform
-- Linux x64 validation remains a release gate, especially if any native dependency is introduced later
+[Apache License 2.0](LICENSE)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,115 +1,122 @@
 # Feishu OpenCode Bridge
 
+中文 | [English](README.md)
+
+[![CI](https://github.com/Clukay-Fun/feishu-opencode-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/Clukay-Fun/feishu-opencode-bridge/actions/workflows/ci.yml)
 [![Node.js](https://img.shields.io/badge/Node.js-20%2B-339933)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6)](https://www.typescriptlang.org/)
-[![Feishu](https://img.shields.io/badge/Feishu-Bridge-0F6FFF)](https://open.feishu.cn/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
-Feishu OpenCode Bridge 是一个把 OpenCode 运行时产品化到飞书里的桥接层。
+把飞书聊天变成持久化的 OpenCode 工作台。
 
-它把飞书聊天窗口变成有会话、有过程卡片、有权限确认、有群聊协作边界的 OpenCode 入口，而不是一个普通的聊天机器人。
+Feishu OpenCode Bridge 是一个独立的 TypeScript 服务，将飞书会话连接到本地 [OpenCode](https://opencode.ai) 服务器。它管理会话窗口、渲染流式过程卡、通过交互按钮处理权限审批、支持群聊协作，并维护跨会话的长期用户记忆 — 一切都在飞书内完成。
 
-## 为什么它不是普通机器人
+<!-- 截图：替换为实际图片 -->
+<!--
+<p align="center">
+  <img src="docs/assets/process-card.png" width="320" alt="过程卡" />
+  <img src="docs/assets/permission-card.png" width="320" alt="权限按钮" />
+  <img src="docs/assets/sessions-card.png" width="320" alt="会话列表" />
+</p>
+-->
 
-这个项目的目标不是“在飞书里接一个 LLM 问答机器人”。
+## 核心能力
 
-它更像一个 Feishu-native 的 OpenCode runtime adapter：
+- **会话窗口** — 私聊、群聊、话题群各自独立的 session 绑定，支持 `single` 和 `multi` 两种会话模式。
+- **流式过程卡** — OpenCode 执行期间实时更新飞书卡片。完成后按语义分块渲染 Markdown，提升长文本可读性。
+- **权限按钮** — 在飞书卡片内直接审批 OpenCode 的工具调用请求，支持本次允许、始终允许和拒绝。
+- **群聊协作** — @bot 一次自动绑定白名单，后续无需 @ 即可对话。通过 `/who` 和 `/leave` 管理绑定。
+- **长期记忆** — 自动提取用户事实，embedding 存入 SQLite，跨会话语义召回相关上下文，并可同步到 Obsidian `profile.md`。
+- **容错机制** — SSE 指数退避重连、飞书 API 自动重试与 token 缓存、请求限流、过程卡降级兜底。
+- **命令透传** — 未被 bridge 接管的命令会继续透传给 OpenCode。
+- **运行时护栏** — 启动前会预检飞书鉴权、OpenCode 健康、provider、存储和回调配置，避免半启动状态。
 
-- 在 `p2p`、`group`、`topic_group` 里维护窗口级 session
-- 把 `/new`、`/status`、`/sessions`、`/switch` 这类运行时控制留在 bridge 侧
-- 用 Process Card 持续更新任务处理过程
-- 用真实权限按钮处理危险操作确认
-- 用群级白名单绑定保证协作流畅，而不是每句都重复 `@bot`
-
-## 功能特性
-
-- Process Card 持续原位更新任务过程
-- Command Card 承载会话管理和群聊绑定结果
-- 真按钮权限流，并保留文本命令 fallback
-- 群聊白名单绑定，支持 `/who` 与 `/leave`
-- 按窗口类型配置 `single` / `multi` 会话模式
-- 支持可选的长期记忆召回、embedding 检索，以及 Obsidian 用户画像同步
-- 未被 bridge 接管的 slash 命令透传给 OpenCode
-- 启动前 preflight，提前检查鉴权、OpenCode 健康、provider、回调配置
-- 基于 JSON 的会话映射和群聊绑定持久化
-- 飞书输出规范集中维护在 [docs/feishu-markdown.md](/Users/clukay/Program/feishu-opencode-bridge/docs/feishu-markdown.md)
-
-## 架构图
+## 架构
 
 ```mermaid
 flowchart LR
-    A["飞书 WebSocket 事件"] --> B["Bridge Runtime"]
-    B --> C["OpenCode Server API"]
-    C --> D["OpenCode Event Stream"]
+    A[飞书 WebSocket] --> B[Bridge 运行时]
+    B --> C[OpenCode Server]
+    C --> D[SSE 事件流]
     D --> B
-    B --> E["飞书 Process / Command / Notice Cards"]
-    F["飞书卡片 Action 回调"] --> B
-    G["白名单与 Session 映射存储"] --> B
+    B --> E[飞书卡片]
+    F[卡片回调] --> B
+    B --> G[SQLite 记忆]
+    B --> H[JSON 存储]
 ```
-
-## 演示脚本
-
-固定演示脚本见 [docs/demo-script.md](/Users/clukay/Program/feishu-opencode-bridge/docs/demo-script.md)。
-
-包含四条固定链路：
-
-1. 私聊开发助手
-2. 群聊协作
-3. 权限按钮流
-4. `lark-cli` 联动
-
-## 输出规范
-
-- Markdown 规则： [docs/feishu-markdown.md](/Users/clukay/Program/feishu-opencode-bridge/docs/feishu-markdown.md)
-- `Plain Post` 只用于 passthrough 文本输出、极短确认语和卡片降级兜底
-- bridge 自有命令、结构化列表、系统提示优先用卡片
-
-## 环境要求
-
-- Node.js 20+
-- 已开启机器人能力的飞书应用
-- 正在运行的 OpenCode 服务
-- 若要启用真按钮权限流，需要一个公开 HTTPS 回调地址
 
 ## 快速开始
 
-安装依赖：
+### 前置条件
+
+- Node.js 20+
+- 一个飞书自建应用，需开启机器人能力（[创建应用](https://open.feishu.cn/app)）
+- 一个运行中的 OpenCode 服务（`opencode serve`）
+- （可选）公网 HTTPS 端点，用于权限按钮回调
+
+### 安装
 
 ```bash
+git clone https://github.com/Clukay-Fun/feishu-opencode-bridge.git
+cd feishu-opencode-bridge
 npm install
+cp config.example.json config.json
+# 编辑 config.json，填入 feishu.appId、feishu.appSecret 和 opencode.baseUrl
 ```
 
-先启动 OpenCode：
+### 启动
 
 ```bash
-opencode serve
+opencode serve          # 先启动 OpenCode
+npm run dev             # 再启动 bridge
 ```
 
-再启动 bridge：
+启动时会自动执行预检：检查飞书认证、OpenCode 连接、存储目录和回调配置。任一项失败会立即退出并给出明确的错误提示。
 
-```bash
-npm run dev
-```
+## 命令
+
+| 命令 | 说明 |
+|------|------|
+| `/new` | 新建会话 |
+| `/status` | 查看当前会话和系统状态 |
+| `/abort` | 中止当前任务 |
+| `/model` | 查看当前模型和活动覆盖 |
+| `/model <provider>` | 查看指定 provider 下的模型 |
+| `/sessions` | 当前窗口的会话列表 |
+| `/sessions all` | 查看所有窗口的会话 |
+| `/switch <n>` | 按编号切换会话 |
+| `/who` | 查看群聊绑定状态 |
+| `/leave` | 解除群聊绑定 |
+| `/close` | 关闭当前会话 |
+| `/close all` | 关闭当前窗口全部会话 |
+| `/close <start-end>` | 按范围关闭会话 |
+| `/delete` | 删除当前会话 |
+| `/delete all confirm` | 删除当前窗口全部会话 |
+| `/delete <index> confirm` | 按编号删除会话 |
+| `/delete <start-end> confirm` | 按范围删除会话 |
+| `/allow once` | 本次允许权限请求 |
+| `/allow always` | 始终允许此权限 |
+| `/deny` | 拒绝权限请求 |
+
+其他 `/` 命令透传给 OpenCode（如 `/model use ...`、`/model reset`、`/review`、`/init`）。
 
 ## 配置
 
-以 [config.example.json](/Users/clukay/Program/feishu-opencode-bridge/config.example.json) 为基线创建 `config.json`。
+完整配置参考 [`config.example.json`](config.example.json)。
 
-重点配置块：
+| 配置段 | 控制内容 |
+|--------|---------|
+| `feishu` | 应用凭证、机器人行为、卡片回调安全设置 |
+| `opencode` | OpenCode 服务地址和目标工作目录 |
+| `server` | HTTP 监听地址和公网回调 URL |
+| `bridge` | 队列并发、会话模式、超时策略 |
+| `storage` | JSON 存储和 SQLite 路径 |
+| `logging` | 日志级别、控制台/转录开关、按日轮转 |
+| `memory` | 记忆提取、embedding、召回和可选的 Obsidian 同步设置 |
 
-- `feishu`
-  飞书应用、行为开关、卡片 action 安全参数
-- `opencode`
-  OpenCode 地址与目标工作目录
-- `server`
-  本地 HTTP 监听地址与公网回调 base URL
-- `storage`
-  JSON 持久化目录
-- `bridge`
-  队列、会话模式、超时参数
-- `memory`
-  可选的长期记忆存储与召回配置
+### 权限按钮回调
 
-### 真按钮权限流配置
+要启用交互式权限按钮，需将 bridge HTTP 服务暴露在 HTTPS 之后并配置：
 
 ```json
 {
@@ -123,42 +130,15 @@ npm run dev
       "enabled": true,
       "path": "/webhook/card",
       "verificationToken": "your-token",
-      "encryptKey": ""
+      "encryptKey": "your-encrypt-key"
     }
   }
 }
 ```
 
-如果飞书开启了加密推送，需要同时配置 `encryptKey`。
+如果飞书开启了事件加密推送，也需要同时配置 `encryptKey`。
 
-## 支持的命令
-
-bridge 自己接管的命令：
-
-- `/new`
-- `/status`
-- `/abort`
-- `/models`
-- `/sessions`
-- `/sessions <编号>`
-- `/switch <编号>`
-- `/who`
-- `/leave`
-- `/allow once`
-- `/allow always`
-- `/deny`
-
-其他 slash 命令会透传给 OpenCode。
-
-这意味着像下面这类 OpenCode 原生命令：
-
-- `/model use ...`
-- `/review`
-- `/init`
-
-只要你的 OpenCode runtime 支持，仍然可以通过 passthrough 工作。
-
-## 启动前 Preflight
+## 启动前预检
 
 bridge 启动时会检查：
 
@@ -169,57 +149,48 @@ bridge 启动时会检查：
 - provider 列表可访问
 - 开启按钮模式时，卡片回调配置完整
 
-只要其中一项失败，bridge 就会直接退出，不会进入半启动状态。
-
 ## 部署
 
-单机部署说明见 [docs/deploy.md](/Users/clukay/Program/feishu-opencode-bridge/docs/deploy.md)。
-
-仓库内已提供：
-
-- [ops/Caddyfile](/Users/clukay/Program/feishu-opencode-bridge/ops/Caddyfile)
-- [.env.example](/Users/clukay/Program/feishu-opencode-bridge/.env.example)
-
-健康检查：
-
-```text
-GET /healthz
-```
-
-卡片 action 默认回调路径：
-
-```text
-/webhook/card
-```
-
-## 开发命令
+参见 [docs/deploy.md](docs/deploy.md) 了解基于 Caddy 的单机部署方案。
 
 ```bash
-npm run typecheck
-npm test
-npm run lint
-npm run dev
-npm run dev:once
+npm run build
+node dist/index.js
 ```
 
-## 目录结构
+Docker：
 
-- `src/bridge/`
-  队列、路由、pending interaction、watchdog
-- `src/config/`
-  配置 schema 与 loader
-- `src/feishu/`
-  API、formatter、WebSocket 入站
-- `src/http/`
-  callback server 与健康检查
-- `src/opencode/`
-  OpenCode HTTP client 与 event stream
-- `src/runtime/`
-  bridge 编排与启动前 preflight
-- `src/store/`
-  JSON 持久化存储
+```bash
+docker build -t feishu-opencode-bridge .
+docker run -v ./config.json:/app/config.json feishu-opencode-bridge
+```
 
-## 当前定位
+健康检查：`GET /healthz`
 
-- 当前目标是“可公开演示、可提交”的版本，不是团队生产版
-- 若后续重新引入任何原生依赖，Linux x64 真机验证仍然是发布前门禁
+## 开发
+
+```bash
+npm run typecheck       # 类型检查
+npm run lint            # 代码检查
+npm test                # 运行全部测试
+npm run dev             # 监听模式启动
+```
+
+## 项目结构
+
+```
+src/
+  bridge/       队列、路由、待确认交互状态
+  config/       配置 schema（Zod）和加载器
+  feishu/       飞书 API 客户端、卡片格式化、WebSocket 接入
+  http/         回调服务和健康检查端点
+  logging/      结构化日志，支持按日轮转
+  memory/       记忆提取、embedding、SQLite 存储
+  opencode/     OpenCode HTTP 客户端和 SSE 事件流
+  runtime/      Bridge 编排、turn 执行、权限管理
+  store/        JSON 持久化的会话和白名单存储
+```
+
+## 许可证
+
+[Apache License 2.0](LICENSE)


### PR DESCRIPTION
## 变更内容
- 重写中英文 README 首页结构，统一为更完整的项目介绍与使用说明
- 补充 CI 与许可证徽章，加入 Apache 2.0 许可证文件
- 合并主线已有的命令面、长期记忆和启动预检说明，避免文档信息回退

## 变更原因
- 现有 README 信息分散且中英文风格不一致，不利于项目对外展示
- 仓库缺少明确的许可证文件，影响开源信息完整性
- README 在同步到最新主线时出现冲突，需要整理成一版稳定且不丢信息的内容

## 影响
- 仓库首页会展示更完整的功能、命令、配置和部署说明
- 项目对外许可证信息明确为 Apache 2.0
- 不涉及运行时代码和测试行为变更

## 验证
- 人工检查 README 冲突已解决
- 人工检查中英文 README 与 LICENSE 已提交完整