### PR TITLE
[codex] 完善知识入库会话排队与线程回复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ logs/
 data/
 config.json
 mappings.json
+active-knowledge-ingests.json
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The project follows Semantic Versioning.
 
+## 0.1.10 - 2026-04-14
+
+### Added
+- Added persisted active knowledge-ingest session state so in-flight ingest sessions can be restored and tracked separately from normal pending interactions.
+
+### Changed
+- Updated knowledge-ingest flow to use session-level queue summaries, queued item processing, and explicit session idle configuration.
+- Updated Feishu reply delivery so ingest and permission replies can opt into threaded replies when needed.
+
 ## 0.1.9 - 2026-04-14
 
 ### Fixed

--- a/config.example.json
+++ b/config.example.json
@@ -120,6 +120,7 @@
     "ingest": {
       "allowedExtensions": [".pdf", ".docx", ".txt", ".md"],
       "maxFileSizeMb": 20,
+      "sessionIdleMs": 1800000,
       "concurrency": 3,
       "maxExtractChunks": 30,
       "maxExtractQas": 500

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feishu-opencode-bridge",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feishu-opencode-bridge",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.42.0",
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feishu-opencode-bridge",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/bridge/state.ts
+++ b/src/bridge/state.ts
@@ -45,11 +45,16 @@ export type PendingSessionDeleteConfirmationInteraction = {
 export type PendingKnowledgeIngestInteraction = {
   kind: "knowledge-ingest-await-file";
   chatId: string;
+  chatType: string;
   conversationKey: string;
   requesterOpenId: string;
   replyToMessageId: string;
+  rootMessageId: string;
+  anchorMessageId: string;
+  deliveryMode: "group_thread" | "p2p_reply";
   ingestSessionId?: string | undefined;
   previousActiveSessionId?: string | null | undefined;
+  expiresAt: number;
 };
 
 export type PendingFileInstructionInteraction = {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -170,6 +170,7 @@ export async function loadConfig(configPath?: string): Promise<AppConfig> {
         allowedExtensions: parsed.knowledgeBase.ingest.allowedExtensions.map((value) => value.trim().toLowerCase()),
         maxFileSizeMb: parsed.knowledgeBase.ingest.maxFileSizeMb,
         pendingTtlMs: parsed.knowledgeBase.ingest.pendingTtlMs,
+        sessionIdleMs: parsed.knowledgeBase.ingest.sessionIdleMs,
         concurrency: parsed.knowledgeBase.ingest.concurrency,
         maxExtractChunks: parsed.knowledgeBase.ingest.maxExtractChunks,
         maxExtractQas: parsed.knowledgeBase.ingest.maxExtractQas,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -44,6 +44,7 @@ const KnowledgeBaseIngestSchema = z.object({
   allowedExtensions: z.array(z.string().min(1)).default([".pdf", ".docx", ".txt"]),
   maxFileSizeMb: z.number().positive().default(20),
   pendingTtlMs: z.number().int().positive().default(600_000),
+  sessionIdleMs: z.number().int().positive().default(1_800_000),
   concurrency: z.number().int().positive().max(10).default(3),
   maxExtractChunks: z.number().int().positive().default(30),
   maxExtractQas: z.number().int().positive().default(500),
@@ -362,6 +363,7 @@ export type AppConfig = {
       allowedExtensions: string[];
       maxFileSizeMb: number;
       pendingTtlMs: number;
+      sessionIdleMs: number;
       concurrency: number;
       maxExtractChunks: number;
       maxExtractQas: number;

--- a/src/feishu/api.ts
+++ b/src/feishu/api.ts
@@ -26,7 +26,7 @@ export class FeishuApiClient {
     return { messageId: body.data.message_id };
   }
 
-  async replyMessage(messageId: string, payload: FeishuPostPayload): Promise<{ messageId: string }> {
+  async replyMessage(messageId: string, payload: FeishuPostPayload, options?: { replyInThread?: boolean }): Promise<{ messageId: string }> {
     const token = await this.getTenantToken();
     const response = await withRetry(() => fetch(`https://open.feishu.cn/open-apis/im/v1/messages/${messageId}/reply`, {
       method: "POST",
@@ -34,7 +34,7 @@ export class FeishuApiClient {
         Authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(payload),
+      body: JSON.stringify(options?.replyInThread ? { ...payload, reply_in_thread: true } : payload),
     }));
     const body = (await response.json()) as { code: number; msg?: string; data?: { message_id?: string } };
     if (!response.ok || body.code !== 0 || !body.data?.message_id) {

--- a/src/feishu/formatter.ts
+++ b/src/feishu/formatter.ts
@@ -1,6 +1,6 @@
 import type { QueueNotice } from "../bridge/turn.js";
 import type { KnowledgeIngestResult, KnowledgeQueryResult } from "../knowledge/index.js";
-import { column, columnSet, markdown, standardIcon } from "./card-builder.js";
+import { column, columnSet, markdown, standardIcon, type IconDef } from "./card-builder.js";
 
 export type FeishuPostPayload = {
   msg_type: "post" | "interactive";
@@ -99,6 +99,17 @@ export type KnowledgeQueryEmptyCardView = {
 export type KnowledgeIngestProgressCardView = {
   sourceLabel: string;
   steps: ReadonlyArray<ToolUpdateView>;
+};
+
+export type KnowledgeIngestSessionSummaryView = {
+  completedCount: number;
+  failedCount: number;
+  queuedCount: number;
+  currentLabel?: string | undefined;
+  totalExtractedCount: number;
+  totalDedupedCount: number;
+  elapsedMs?: number | undefined;
+  bitableUrl?: string | undefined;
 };
 
 export type PermissionActionButton = {
@@ -365,12 +376,56 @@ export function buildKnowledgeQueryEmptyPayload(question: string): FeishuPostPay
 }
 
 export function buildKnowledgeIngestReadyPayload(): FeishuPostPayload {
+  return buildKnowledgeIngestSessionPayload({
+    completedCount: 0,
+    failedCount: 0,
+    queuedCount: 0,
+    totalExtractedCount: 0,
+    totalDedupedCount: 0,
+  });
+}
+
+export function buildKnowledgeIngestSessionPayload(view: KnowledgeIngestSessionSummaryView): FeishuPostPayload {
+  const bodyParts = [
+    `**已完成**\n${view.completedCount} 个素材`,
+    `**处理中**\n${view.currentLabel ? escapeText(view.currentLabel) : "无"}`,
+    `**排队中**\n${view.queuedCount} 个素材`,
+    `**总入库**\n${view.totalExtractedCount} 条问答`,
+  ];
+  if (view.failedCount > 0) {
+    bodyParts.push(`**失败**\n${view.failedCount} 个素材`);
+  }
   return buildInteractivePayload({
-    title: "知识入库",
+    title: "知识入库会话",
     template: "blue",
     iconToken: "upload_outlined",
     bodyElements: [
-      buildNoticeBodyBlock("已进入知识入库模式。请上传 PDF / DOCX / TXT / MD 文件，或直接发送网页 URL；我会连续提取问答并写入知识库。发送 `/kb-ingest-end` 可退出。", "upload_outlined", "blue", { showIcon: false }),
+      buildNoticeBodyBlock(bodyParts.join("\n\n"), "upload_outlined", "blue", { showIcon: false }),
+      buildDivider(),
+      buildFooterTipBlock("发送文件或网页链接继续入库；发送 `/kb-ingest-end` 结束。", "info_outlined", "grey", "notation"),
+    ],
+  });
+}
+
+export function buildKnowledgeIngestSessionFinalPayload(view: KnowledgeIngestSessionSummaryView): FeishuPostPayload {
+  const bodyParts = [
+    `**本次共处理**\n${view.completedCount + view.failedCount} 个素材`,
+    `**总入库**\n${view.totalExtractedCount} 条问答`,
+    `**去重合并**\n${view.totalDedupedCount} 条`,
+    `**失败**\n${view.failedCount} 个素材`,
+    `**耗时**\n${formatDurationMs(view.elapsedMs ?? 0)}`,
+  ];
+  if (view.bitableUrl) {
+    bodyParts.push(`[查看多维表格](${escapeText(view.bitableUrl)})`);
+  }
+  return buildInteractivePayload({
+    title: "知识入库完成",
+    template: view.failedCount > 0 ? "yellow" : "green",
+    iconToken: view.failedCount > 0 ? "maybe_outlined" : "book_outlined",
+    bodyElements: [
+      buildNoticeBodyBlock(bodyParts.join("\n\n"), "book_outlined", "green", { showIcon: false }),
+      buildDivider(),
+      buildFooterTipBlock("以上内容仅供参考，不构成法律意见。", "warning_outlined", "orange", "notation"),
     ],
   });
 }
@@ -413,14 +468,27 @@ export function buildKnowledgeIngestPayload(view: KnowledgeIngestResult): Feishu
 }
 
 export function buildKnowledgeIngestProcessingPayload(view: KnowledgeIngestProgressCardView): FeishuPostPayload {
+  const currentStep = view.steps.find((step) => step.status === "running")
+    ?? view.steps.find((step) => step.status === "error")
+    ?? view.steps.find((step) => step.status === "pending")
+    ?? view.steps[view.steps.length - 1];
+  const completedCount = view.steps.filter((step) => step.status === "completed").length;
+  const totalCount = Math.max(1, view.steps.length);
+  const currentText = currentStep
+    ? `**当前步骤**\n${escapeText(currentStep.label)}：${escapeText(currentStep.detail)}`
+    : "**当前步骤**\n准备开始";
   return buildInteractivePayload({
     title: "知识入库处理中",
     template: "blue",
     iconToken: "upload_outlined",
     bodyElements: [
-      buildNoticeBodyBlock(`**当前对象**\n${escapeText(view.sourceLabel)}`, "upload_outlined", "blue", { showIcon: false }),
+      buildNoticeBodyBlock([
+        `**当前对象**\n${escapeText(view.sourceLabel)}`,
+        `**整体进度**\n${completedCount}/${totalCount} 步完成`,
+        currentText,
+      ].join("\n\n"), "upload_outlined", "blue", { showIcon: false }),
       buildDivider(),
-      buildToolBlock(buildToolElements(view.steps)),
+      buildKnowledgeIngestStepBlock(view.steps),
       buildDivider(),
       buildFooterTipBlock("以上内容仅供参考，不构成法律意见。", "warning_outlined", "orange", "notation"),
     ],
@@ -651,6 +719,22 @@ function buildToolElements(lines: ReadonlyArray<ToolUpdateView>): Array<Record<s
   }));
 }
 
+function buildKnowledgeIngestStepBlock(steps: ReadonlyArray<ToolUpdateView>): Record<string, unknown> {
+  return {
+    ...columnSet([
+      {
+        ...column(steps.map((step, index) => markdown(formatKnowledgeIngestStep(step, index), {
+          icon: mapKnowledgeIngestStepIcon(step.status),
+        })), { bg: "grey-50", weight: 1 }),
+        padding: "12px 12px 12px 12px",
+        vertical_spacing: "8px",
+      },
+    ]),
+    flex_mode: "stretch",
+    horizontal_spacing: "12px",
+  };
+}
+
 function buildStatusCurrentSessionBlock(session: StatusCommandCardView["currentSession"]): Record<string, unknown> {
   return columnSet([
     column([
@@ -835,6 +919,50 @@ function mapToolIcon(status: ToolUpdateView["status"]): Record<string, string> {
       return standardIcon("loading_outlined", "blue") as Record<string, string>;
     default:
       return standardIcon("info_outlined", "grey") as Record<string, string>;
+  }
+}
+
+function formatKnowledgeIngestStep(step: ToolUpdateView, index: number): string {
+  return `**${index + 1}. ${escapeText(step.label)}**\n${formatKnowledgeIngestStepStatus(step.status)} · ${escapeText(step.detail)}`;
+}
+
+function formatKnowledgeIngestStepStatus(status: ToolUpdateView["status"]): string {
+  switch (status) {
+    case "completed":
+      return "已完成";
+    case "running":
+      return "进行中";
+    case "error":
+      return "失败";
+    case "pending":
+      return "等待中";
+    default:
+      return "未知状态";
+  }
+}
+
+function formatDurationMs(durationMs: number): string {
+  const seconds = Math.max(1, Math.round(durationMs / 1000));
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return remainingSeconds > 0 ? `${minutes} 分 ${remainingSeconds} 秒` : `${minutes} 分`;
+}
+
+function mapKnowledgeIngestStepIcon(status: ToolUpdateView["status"]): IconDef {
+  switch (status) {
+    case "completed":
+      return { token: "yes_outlined", color: "green" };
+    case "running":
+      return { token: "loading_outlined", color: "blue" };
+    case "error":
+      return { token: "more-close_outlined", color: "red" };
+    case "pending":
+      return { token: "time_outlined", color: "grey" };
+    default:
+      return { token: "info_outlined", color: "grey" };
   }
 }
 

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -1,10 +1,12 @@
 import { QueueRegistry } from "../bridge/queue.js";
-import { type PendingInteraction, type PendingPermissionInteraction } from "../bridge/state.js";
+import { type PendingInteraction, type PendingKnowledgeIngestInteraction, type PendingPermissionInteraction } from "../bridge/state.js";
 import { routeIncomingText, type RoutedText } from "../bridge/router.js";
 import type { BridgeTurn } from "../bridge/turn.js";
 import {
   buildKnowledgeIngestProcessingPayload,
   buildKnowledgeIngestPayload,
+  buildKnowledgeIngestSessionFinalPayload,
+  buildKnowledgeIngestSessionPayload,
   buildKnowledgeQueryEmptyPayload,
   buildKnowledgeQueryPayload,
   buildNoticeCardPayload,
@@ -19,6 +21,7 @@ import { detectKnowledgeWebIngest, detectLegalQuestion } from "../knowledge/dete
 import {
   KnowledgeBaseService,
   type KnowledgeBasePort,
+  type KnowledgeIngestResult,
   type KnowledgeIngestProgressStep,
   type KnowledgeIngestProgressUpdate,
 } from "../knowledge/index.js";
@@ -31,6 +34,7 @@ import {
 } from "../opencode/client.js";
 import { getEventSessionId, OpenCodeEventStream, type OpenCodeEvent } from "../opencode/events.js";
 import { MappingStore, type MappingRecord, type SessionBindingRecord, type SessionWindowRecord } from "../store/mappings.js";
+import { ActiveKnowledgeIngestStore, type ActiveKnowledgeIngestRecordMap } from "../store/active-ingests.js";
 import type { WhitelistStore } from "../store/whitelist.js";
 import type { AppConfig } from "../config/schema.js";
 import {
@@ -91,7 +95,7 @@ export type IncomingChatMessage = IncomingTextMessage | IncomingFileMessage;
 
 type OutboundPort = {
   sendMessage(chatId: string, payload: FeishuPostPayload): Promise<{ messageId: string }>;
-  replyMessage(messageId: string, payload: FeishuPostPayload): Promise<{ messageId: string }>;
+  replyMessage(messageId: string, payload: FeishuPostPayload, options?: { replyInThread?: boolean }): Promise<{ messageId: string }>;
   updateMessage(messageId: string, payload: FeishuPostPayload): Promise<{ messageId: string }>;
 };
 
@@ -141,9 +145,48 @@ export type PermissionCardActionValue = {
   nonce: string;
 };
 
+type KnowledgeIngestQueueItem = {
+  conversationKey: string;
+  chatId: string;
+  requesterOpenId: string;
+  processingMessageId: string;
+  progressState: KnowledgeIngestProgressState;
+} & (
+  | {
+    kind: "file";
+    messageId: string;
+    fileKey: string;
+    fileName: string;
+    size?: number | undefined;
+  }
+  | {
+    kind: "web";
+    messageId: string;
+    url: string;
+    instruction: string;
+  }
+);
+
+type KnowledgeIngestQueueState = {
+  active: boolean;
+  closing: boolean;
+  currentLabel?: string | undefined;
+  pending: KnowledgeIngestQueueItem[];
+};
+
+type KnowledgeIngestSessionStats = {
+  startedAt: number;
+  completedCount: number;
+  failedCount: number;
+  totalExtractedCount: number;
+  totalDedupedCount: number;
+  bitableUrl?: string | undefined;
+};
+
 export class BridgeApp {
   private readonly queues: QueueRegistry;
   private readonly mappings: MappingStore;
+  private readonly activeKnowledgeIngests: ActiveKnowledgeIngestStore;
   private readonly opencode: OpenCodePort;
   private readonly eventStream: OpenCodeEventStreamPort;
   private readonly permissionManager: PermissionManager;
@@ -151,8 +194,12 @@ export class BridgeApp {
   private readonly turnExecutor: TurnExecutor;
   private readonly rateLimiter = new SlidingWindowRateLimiter(20, 60_000);
   private sessionMap: MappingRecord = {};
+  private activeKnowledgeIngestMap: ActiveKnowledgeIngestRecordMap = {};
   private readonly runningChats = new Map<string, Promise<void>>();
   private readonly runningKnowledgeIngests = new Map<string, { requesterOpenId: string }>();
+  private readonly knowledgeIngestQueues = new Map<string, KnowledgeIngestQueueState>();
+  private readonly knowledgeIngestSessionStats = new Map<string, KnowledgeIngestSessionStats>();
+  private readonly knowledgeIngestInteractions = new Map<string, PendingKnowledgeIngestInteraction>();
   private readonly pendingInteractions = new Map<string, PendingInteraction>();
   private readonly pendingInteractionTimers = new Map<string, NodeJS.Timeout>();
   private readonly sessionStatuses = new Map<string, OpenCodeSessionStatus>();
@@ -169,6 +216,7 @@ export class BridgeApp {
   ) {
     this.queues = new QueueRegistry(config.bridge.queueLimit, logger);
     this.mappings = new MappingStore(config.storage.dataDir, config.storage.mappingsFile, 200, logger);
+    this.activeKnowledgeIngests = new ActiveKnowledgeIngestStore(config.storage.dataDir);
     this.opencode = deps?.opencode ?? new OpenCodeClient(config.opencode.baseUrl);
     this.eventStream = deps?.eventStream ?? new OpenCodeEventStream(config.opencode.baseUrl, logger);
     this.memory = deps && "memory" in deps
@@ -230,12 +278,14 @@ export class BridgeApp {
 
   async start(): Promise<void> {
     this.sessionMap = await this.mappings.load();
+    this.activeKnowledgeIngestMap = await this.activeKnowledgeIngests.load();
     const health = await this.opencode.health();
     const project = await this.opencode.getCurrentProject();
     if (project.worktree !== this.config.opencode.directory) {
       throw new Error(`opencode serve 当前在 ${project.worktree}，bridge 配置的是 ${this.config.opencode.directory}，请在正确目录重启 opencode serve`);
     }
     await this.syncStoredSessionLabels();
+    await this.interruptPersistedKnowledgeIngests();
     await this.memory?.start();
     if (this.knowledge) {
       try {
@@ -315,26 +365,37 @@ export class BridgeApp {
     const routed = message.messageType === "file"
       ? null
       : routeIncomingText(message.plainText);
+    const activeKnowledgeIngest = this.findKnowledgeIngestInteraction(message);
+    if (activeKnowledgeIngest) {
+      if (routed?.kind === "command" && routed.command.kind === "knowledge-ingest-end") {
+        await this.endKnowledgeIngestInteraction(message, activeKnowledgeIngest);
+        return;
+      }
+
+      const consumed = await this.handlePendingInteraction(message, activeKnowledgeIngest);
+      if (consumed) return;
+    }
+
     if (routed?.kind === "command") {
+      const backgroundKnowledgeIngest = this.getKnowledgeIngestInteraction(message.conversationKey);
+      if (
+        routed.command.kind === "knowledge-ingest-end"
+        && backgroundKnowledgeIngest?.kind === "knowledge-ingest-await-file"
+      ) {
+        await this.endKnowledgeIngestInteraction(message, backgroundKnowledgeIngest, { replyToMessageId: message.messageId });
+        return;
+      }
       await this.handleCommand(message, routed);
       return;
     }
 
-    const runningKnowledgeIngest = this.runningKnowledgeIngests.get(message.conversationKey);
     const pending = this.pendingInteractions.get(message.conversationKey);
-    const backgroundIngestAllowsNormalText = runningKnowledgeIngest
-      && pending?.kind === "knowledge-ingest-await-file"
-      && message.messageType !== "file"
-      && !detectKnowledgeWebIngest(message.plainText, { requireIngestIntent: false }).matched;
-    if (runningKnowledgeIngest && !backgroundIngestAllowsNormalText) {
-      await this.sendKnowledgeIngestBusyNotice(message);
-      return;
-    }
-    if (backgroundIngestAllowsNormalText && pending?.kind === "knowledge-ingest-await-file") {
-      await this.restorePreviousSessionForBackgroundIngest(message.conversationKey, message.chatType, pending);
+    const backgroundKnowledgeIngest = this.getKnowledgeIngestInteraction(message.conversationKey);
+    if (backgroundKnowledgeIngest) {
+      await this.restoreOrCreateNormalSessionForBackgroundIngest(message, backgroundKnowledgeIngest);
     }
 
-    if (pending && !backgroundIngestAllowsNormalText) {
+    if (pending) {
       const consumed = await this.handlePendingInteraction(message, pending);
       if (consumed) return;
     }
@@ -520,6 +581,8 @@ export class BridgeApp {
       sendMarkdown: async (chatId, markdown, replyToMessageId) => await this.sendMarkdown(chatId, markdown, replyToMessageId),
       setPendingInteraction: (conversationKey, interaction) => this.setPendingInteraction(conversationKey, interaction),
       clearPendingInteraction: (conversationKey, keepNonExpiring) => this.clearPendingInteraction(conversationKey, keepNonExpiring),
+      getKnowledgeIngestInteraction: (conversationKey) => this.getKnowledgeIngestInteraction(conversationKey),
+      clearKnowledgeIngestPending: async (conversationKey, chatType) => await this.clearKnowledgeIngestPending(conversationKey, chatType),
       listOpenCodeSessionsById: async () => await this.listOpenCodeSessionsById(),
       saveSessionWindow: async (conversationKey, window) => await this.saveSessionWindow(conversationKey, window),
       getSessionMessageCount: async (sessionId) => await this.getSessionMessageCount(sessionId),
@@ -569,128 +632,7 @@ export class BridgeApp {
     }
 
     if (pending.kind === "knowledge-ingest-await-file") {
-      if (message.senderOpenId !== pending.requesterOpenId) {
-        await this.sendMarkdown(message.chatId, "当前入库任务仅允许发起人继续上传文件。", message.messageId);
-        return true;
-      }
-      if (!this.knowledge) {
-        await this.sendMarkdown(message.chatId, "当前未启用法律知识库，请联系部署者补充 knowledgeBase 配置。", message.messageId);
-        return true;
-      }
-      if (message.messageType !== "file") {
-        const webIngest = detectKnowledgeWebIngest(message.plainText, { requireIngestIntent: false });
-        if (!webIngest.matched || !webIngest.url || !this.knowledge.ingestWebPage) {
-          await this.sendMarkdown(message.chatId, "请继续上传 PDF / DOCX / TXT / MD 文件，或直接发送网页 URL / 带 URL 的入库请求；发送 `/kb-ingest-end` 退出。", message.messageId);
-          return true;
-        }
-        this.setRunningKnowledgeIngest(message.conversationKey, pending.requesterOpenId);
-        const progressState = createKnowledgeIngestProgressState(webIngest.url);
-        const processing = await this.sendPayload(
-          message.chatId,
-          buildKnowledgeIngestProcessingPayload(progressState),
-          {
-            event: "knowledge web ingest processing sent",
-            transcriptType: "outbound-final",
-            textPreview: webIngest.url,
-            len: webIngest.url.length,
-          },
-          { replyToMessageId: message.messageId },
-        );
-        try {
-          const result = await this.knowledge.ingestWebPage({
-            url: webIngest.url,
-            instruction: message.plainText,
-            messageId: message.messageId,
-          }, {
-            onProgress: async (update) => await this.updateKnowledgeIngestProgress(message.chatId, processing.messageId, progressState, update),
-          });
-          this.maybeRefreshKnowledgeIngestPending(message.conversationKey, pending, message.messageId);
-          await this.updatePayload(
-            message.chatId,
-            processing.messageId,
-            buildKnowledgeIngestPayload(result),
-            {
-              event: "knowledge web ingest updated",
-              transcriptType: "outbound-final",
-              textPreview: result.sourceFile,
-              len: result.sourceFile.length,
-            },
-          );
-        } catch (error) {
-          const detail = error instanceof Error ? error.message : String(error);
-          await this.updatePayload(message.chatId, processing.messageId, buildNoticeCardPayload({
-            title: "网页入库失败",
-            template: "red",
-            iconToken: "error_filled",
-            message: detail,
-            messageIconToken: "error_filled",
-            messageIconColor: "red",
-            showMessageIcon: false,
-          }), {
-            event: "knowledge web ingest failed",
-            transcriptType: "outbound-final",
-            textPreview: detail,
-            len: detail.length,
-          });
-        } finally {
-          this.clearRunningKnowledgeIngest(message.conversationKey);
-        }
-        return true;
-      }
-      this.setRunningKnowledgeIngest(message.conversationKey, pending.requesterOpenId);
-      const progressState = createKnowledgeIngestProgressState(message.file.fileName);
-      const processing = await this.sendPayload(
-        message.chatId,
-        buildKnowledgeIngestProcessingPayload(progressState),
-        {
-          event: "knowledge ingest processing sent",
-          transcriptType: "outbound-final",
-          textPreview: message.file.fileName,
-          len: message.file.fileName.length,
-        },
-        { replyToMessageId: message.messageId },
-      );
-      try {
-        const result = await this.knowledge.ingestFile({
-          messageId: message.messageId,
-          fileKey: message.file.fileKey,
-          fileName: message.file.fileName,
-          size: message.file.size,
-        }, {
-          onProgress: async (update) => await this.updateKnowledgeIngestProgress(message.chatId, processing.messageId, progressState, update),
-        });
-        this.maybeRefreshKnowledgeIngestPending(message.conversationKey, pending, message.messageId);
-        await this.updatePayload(
-          message.chatId,
-          processing.messageId,
-          buildKnowledgeIngestPayload(result),
-          {
-            event: "knowledge ingest updated",
-            transcriptType: "outbound-final",
-            textPreview: result.sourceFile,
-            len: result.sourceFile.length,
-          },
-        );
-      } catch (error) {
-        const detail = error instanceof Error ? error.message : String(error);
-        await this.updatePayload(message.chatId, processing.messageId, buildNoticeCardPayload({
-          title: "知识入库失败",
-          template: "red",
-          iconToken: "error_filled",
-          message: detail,
-          messageIconToken: "error_filled",
-          messageIconColor: "red",
-          showMessageIcon: false,
-        }), {
-          event: "knowledge ingest failed",
-          transcriptType: "outbound-final",
-          textPreview: detail,
-          len: detail.length,
-        });
-      } finally {
-        this.clearRunningKnowledgeIngest(message.conversationKey);
-      }
-      return true;
+      return await this.enqueueKnowledgeIngestInput(message, pending);
     }
 
     if (pending.kind === "file-await-instruction") {
@@ -766,6 +708,262 @@ export class BridgeApp {
     }
 
     return false;
+  }
+
+  private async enqueueKnowledgeIngestInput(message: IncomingChatMessage, pending: PendingKnowledgeIngestInteraction): Promise<boolean> {
+    if (message.senderOpenId !== pending.requesterOpenId) {
+      await this.sendKnowledgeIngestMarkdown(pending, "当前入库任务仅允许发起人继续上传文件。");
+      return true;
+    }
+    if (!this.knowledge) {
+      await this.sendKnowledgeIngestMarkdown(pending, "当前未启用法律知识库，请联系部署者补充 knowledgeBase 配置。");
+      return true;
+    }
+
+    let sourceLabel: string;
+    let itemInput:
+      | Omit<Extract<KnowledgeIngestQueueItem, { kind: "file" }>, "processingMessageId" | "progressState">
+      | Omit<Extract<KnowledgeIngestQueueItem, { kind: "web" }>, "processingMessageId" | "progressState">;
+    if (message.messageType === "file") {
+      sourceLabel = message.file.fileName;
+      itemInput = {
+        kind: "file",
+        conversationKey: pending.conversationKey,
+        chatId: message.chatId,
+        requesterOpenId: pending.requesterOpenId,
+        messageId: message.messageId,
+        fileKey: message.file.fileKey,
+        fileName: message.file.fileName,
+        size: message.file.size,
+      };
+    } else {
+      const webIngest = detectKnowledgeWebIngest(message.plainText, { requireIngestIntent: false });
+      if (!webIngest.matched || !webIngest.url || !this.knowledge.ingestWebPage) {
+        await this.sendKnowledgeIngestMarkdown(pending, "请继续上传 PDF / DOCX / TXT / MD 文件，或直接发送网页 URL / 带 URL 的入库请求；发送 `/kb-ingest-end` 退出。");
+        return true;
+      }
+      sourceLabel = webIngest.url;
+      itemInput = {
+        kind: "web",
+        conversationKey: pending.conversationKey,
+        chatId: message.chatId,
+        requesterOpenId: pending.requesterOpenId,
+        messageId: message.messageId,
+        url: webIngest.url,
+        instruction: message.plainText,
+      };
+    }
+
+    const queue = this.getKnowledgeIngestQueue(pending.conversationKey);
+    if (queue.closing) {
+      await this.sendKnowledgeIngestMarkdown(pending, "已收到结束指令，当前队列处理完成后会自动结束。");
+      return true;
+    }
+    const queuedCount = queue.pending.length + (queue.active ? 1 : 0);
+    if (queuedCount >= this.config.bridge.queueLimit) {
+      await this.sendKnowledgeIngestMarkdown(pending, "已达上限，请等待当前文件处理完成。");
+      return true;
+    }
+
+    const progressState = createKnowledgeIngestProgressState(sourceLabel);
+    const processing = await this.sendPayload(message.chatId, buildKnowledgeIngestProcessingPayload(progressState), {
+      event: itemInput.kind === "web" ? "knowledge web ingest queued" : "knowledge ingest queued",
+      transcriptType: "outbound-final",
+      textPreview: sourceLabel,
+      len: sourceLabel.length,
+    }, this.getKnowledgeIngestDelivery(pending));
+    queue.pending.push({
+      ...itemInput,
+      processingMessageId: processing.messageId,
+      progressState,
+    });
+    this.refreshKnowledgeIngestPending(pending.conversationKey, pending);
+    await this.updateKnowledgeIngestSessionSummary(pending.conversationKey);
+    void this.processKnowledgeIngestQueue(pending.conversationKey);
+    return true;
+  }
+
+  private async processKnowledgeIngestQueue(conversationKey: string): Promise<void> {
+    const queue = this.knowledgeIngestQueues.get(conversationKey);
+    if (!queue || queue.active) {
+      return;
+    }
+    queue.active = true;
+    try {
+      let item = queue.pending.shift();
+      while (item) {
+        const currentItem = item;
+        const pending = this.getKnowledgeIngestInteraction(conversationKey);
+        if (!pending || !this.knowledge) {
+          break;
+        }
+        queue.currentLabel = getKnowledgeIngestQueueItemLabel(currentItem);
+        await this.updateKnowledgeIngestSessionSummary(conversationKey);
+        this.setRunningKnowledgeIngest(conversationKey, currentItem.requesterOpenId);
+        try {
+          if (currentItem.kind === "web") {
+            const result = await this.knowledge.ingestWebPage!({
+              url: currentItem.url,
+              instruction: currentItem.instruction,
+              messageId: currentItem.messageId,
+            }, {
+              onProgress: async (update) => await this.updateKnowledgeIngestProgress(currentItem.chatId, currentItem.processingMessageId, currentItem.progressState, update),
+            });
+            this.refreshKnowledgeIngestPending(conversationKey, pending);
+            await this.updatePayload(currentItem.chatId, currentItem.processingMessageId, buildKnowledgeIngestPayload(result), {
+              event: "knowledge web ingest updated",
+              transcriptType: "outbound-final",
+              textPreview: result.sourceFile,
+              len: result.sourceFile.length,
+            });
+            this.recordKnowledgeIngestResult(conversationKey, result);
+          } else {
+            const result = await this.knowledge.ingestFile({
+              messageId: currentItem.messageId,
+              fileKey: currentItem.fileKey,
+              fileName: currentItem.fileName,
+              size: currentItem.size,
+            }, {
+              onProgress: async (update) => await this.updateKnowledgeIngestProgress(currentItem.chatId, currentItem.processingMessageId, currentItem.progressState, update),
+            });
+            this.refreshKnowledgeIngestPending(conversationKey, pending);
+            await this.updatePayload(currentItem.chatId, currentItem.processingMessageId, buildKnowledgeIngestPayload(result), {
+              event: "knowledge ingest updated",
+              transcriptType: "outbound-final",
+              textPreview: result.sourceFile,
+              len: result.sourceFile.length,
+            });
+            this.recordKnowledgeIngestResult(conversationKey, result);
+          }
+        } catch (error) {
+          this.recordKnowledgeIngestFailure(conversationKey);
+          const detail = error instanceof Error ? error.message : String(error);
+          await this.updatePayload(currentItem.chatId, currentItem.processingMessageId, buildNoticeCardPayload({
+            title: currentItem.kind === "web" ? "网页入库失败" : "知识入库失败",
+            template: "red",
+            iconToken: "error_filled",
+            message: detail,
+            messageIconToken: "error_filled",
+            messageIconColor: "red",
+            showMessageIcon: false,
+          }), {
+            event: currentItem.kind === "web" ? "knowledge web ingest failed" : "knowledge ingest failed",
+            transcriptType: "outbound-final",
+            textPreview: detail,
+            len: detail.length,
+          });
+        } finally {
+          this.clearRunningKnowledgeIngest(conversationKey);
+        }
+        queue.currentLabel = undefined;
+        await this.updateKnowledgeIngestSessionSummary(conversationKey);
+        item = queue.pending.shift();
+      }
+    } finally {
+      queue.active = false;
+      queue.currentLabel = undefined;
+      let shouldUpdateSummary = true;
+      if (queue.pending.length === 0) {
+        if (queue.closing) {
+          shouldUpdateSummary = false;
+          const pending = this.getKnowledgeIngestInteraction(conversationKey);
+          if (pending) {
+            await this.sendKnowledgeIngestFinalSummary(pending);
+            await this.clearKnowledgeIngestPending(conversationKey, pending.chatType);
+          } else {
+            this.knowledgeIngestQueues.delete(conversationKey);
+          }
+        } else {
+          this.knowledgeIngestQueues.delete(conversationKey);
+          shouldUpdateSummary = false;
+        }
+      }
+      if (shouldUpdateSummary) {
+        await this.updateKnowledgeIngestSessionSummary(conversationKey);
+      }
+    }
+  }
+
+  private getKnowledgeIngestQueue(conversationKey: string): KnowledgeIngestQueueState {
+    const existing = this.knowledgeIngestQueues.get(conversationKey);
+    if (existing) {
+      return existing;
+    }
+    const queue: KnowledgeIngestQueueState = { active: false, closing: false, pending: [] };
+    this.knowledgeIngestQueues.set(conversationKey, queue);
+    return queue;
+  }
+
+  private getKnowledgeIngestSessionStats(conversationKey: string): KnowledgeIngestSessionStats {
+    const existing = this.knowledgeIngestSessionStats.get(conversationKey);
+    if (existing) {
+      return existing;
+    }
+    const stats: KnowledgeIngestSessionStats = {
+      startedAt: Date.now(),
+      completedCount: 0,
+      failedCount: 0,
+      totalExtractedCount: 0,
+      totalDedupedCount: 0,
+    };
+    this.knowledgeIngestSessionStats.set(conversationKey, stats);
+    return stats;
+  }
+
+  private recordKnowledgeIngestResult(conversationKey: string, result: KnowledgeIngestResult): void {
+    const stats = this.getKnowledgeIngestSessionStats(conversationKey);
+    const rawExtractedCount = result.rawExtractedCount ?? result.extractedCount;
+    stats.completedCount += 1;
+    stats.totalExtractedCount += result.extractedCount;
+    stats.totalDedupedCount += result.dedupedCount ?? Math.max(0, rawExtractedCount - result.extractedCount);
+    stats.bitableUrl = result.bitableUrl ?? stats.bitableUrl;
+  }
+
+  private recordKnowledgeIngestFailure(conversationKey: string): void {
+    const stats = this.getKnowledgeIngestSessionStats(conversationKey);
+    stats.failedCount += 1;
+  }
+
+  private async updateKnowledgeIngestSessionSummary(conversationKey: string): Promise<void> {
+    const pending = this.getKnowledgeIngestInteraction(conversationKey);
+    if (!pending) {
+      return;
+    }
+    const stats = this.getKnowledgeIngestSessionStats(conversationKey);
+    const queue = this.knowledgeIngestQueues.get(conversationKey);
+    await this.updatePayload(pending.chatId, pending.anchorMessageId, buildKnowledgeIngestSessionPayload({
+      completedCount: stats.completedCount,
+      failedCount: stats.failedCount,
+      queuedCount: queue?.pending.length ?? 0,
+      currentLabel: queue?.currentLabel,
+      totalExtractedCount: stats.totalExtractedCount,
+      totalDedupedCount: stats.totalDedupedCount,
+      elapsedMs: Date.now() - stats.startedAt,
+      bitableUrl: stats.bitableUrl,
+    }), {
+      event: "knowledge ingest session summary updated",
+      transcriptType: "outbound-final",
+      textPreview: "知识入库会话汇总",
+      len: 10,
+    });
+  }
+
+  private async sendKnowledgeIngestFinalSummary(pending: PendingKnowledgeIngestInteraction): Promise<void> {
+    const stats = this.getKnowledgeIngestSessionStats(pending.conversationKey);
+    await this.sendPayload(pending.chatId, buildKnowledgeIngestSessionFinalPayload({
+      completedCount: stats.completedCount,
+      failedCount: stats.failedCount,
+      queuedCount: 0,
+      totalExtractedCount: stats.totalExtractedCount,
+      totalDedupedCount: stats.totalDedupedCount,
+      elapsedMs: Date.now() - stats.startedAt,
+      bitableUrl: stats.bitableUrl,
+    }), {
+      event: "knowledge ingest session final summary sent",
+      transcriptType: "outbound-final",
+      textPreview: "知识入库完成汇总",
+      len: 10,
+    }, this.getKnowledgeIngestDelivery(pending));
   }
 
   private async ensureSession(source: Pick<BridgeTurn, "chatId" | "chatType" | "conversationKey" | "threadKey">): Promise<string> {
@@ -859,6 +1057,151 @@ export class BridgeApp {
     }
   }
 
+  private async interruptPersistedKnowledgeIngests(): Promise<void> {
+    const records = Object.values(this.activeKnowledgeIngestMap);
+    if (records.length === 0) {
+      return;
+    }
+
+    for (const record of records) {
+      await this.restorePreviousSessionForBackgroundIngest(record.conversationKey, record.chatType, record).catch((error) => {
+        this.logger.log("knowledge/ingest", "failed to restore interrupted ingest session", {
+          conversationKey: record.conversationKey,
+          detail: error instanceof Error ? error.message : String(error),
+        }, "warn");
+      });
+      await this.sendPayload(record.chatId, buildNoticeCardPayload({
+        title: "入库任务已中断",
+        template: "yellow",
+        iconToken: "maybe_outlined",
+        message: "入库任务因服务重启中断，请重新发送 `/kb-ingest-start`。",
+        messageIconToken: "maybe_outlined",
+        messageIconColor: "yellow",
+        showMessageIcon: false,
+      }), {
+        event: "knowledge ingest interrupted",
+        transcriptType: "outbound-final",
+        textPreview: "入库任务因服务重启中断",
+        len: 12,
+      }, {
+        replyToMessageId: record.anchorMessageId,
+        replyInThread: record.deliveryMode === "group_thread",
+      }).catch((error) => {
+        this.logger.log("knowledge/ingest", "failed to notify interrupted ingest", {
+          conversationKey: record.conversationKey,
+          detail: error instanceof Error ? error.message : String(error),
+        }, "warn");
+      });
+    }
+
+    this.activeKnowledgeIngestMap = {};
+    await this.activeKnowledgeIngests.saveRecords(this.activeKnowledgeIngestMap);
+  }
+
+  private findKnowledgeIngestInteraction(message: IncomingChatMessage): PendingKnowledgeIngestInteraction | null {
+    const direct = this.getKnowledgeIngestInteraction(message.conversationKey);
+    if (direct && this.isMessageInKnowledgeIngestChain(message, direct)) {
+      return direct;
+    }
+
+    for (const pending of this.knowledgeIngestInteractions.values()) {
+      if (pending.conversationKey === message.conversationKey) {
+        continue;
+      }
+      if (this.isMessageInKnowledgeIngestChain(message, pending)) {
+        return pending;
+      }
+    }
+
+    return null;
+  }
+
+  private isMessageInKnowledgeIngestChain(message: IncomingChatMessage, pending: PendingKnowledgeIngestInteraction): boolean {
+    if (message.chatId !== pending.chatId) {
+      return false;
+    }
+    if (message.chatType === "p2p") {
+      return message.rootId === pending.anchorMessageId
+        || message.parentId === pending.anchorMessageId
+        || message.rootId === pending.rootMessageId
+        || message.parentId === pending.rootMessageId;
+    }
+    const candidates = new Set([
+      message.rootId,
+      message.parentId,
+      message.threadKey,
+    ].filter((value): value is string => Boolean(value)));
+    return message.conversationKey === pending.conversationKey
+      || candidates.has(pending.anchorMessageId)
+      || candidates.has(pending.rootMessageId);
+  }
+
+  private async endKnowledgeIngestInteraction(
+    message: Pick<IncomingChatMessage, "messageId" | "senderOpenId">,
+    pending: PendingKnowledgeIngestInteraction,
+    delivery?: { replyToMessageId: string },
+  ): Promise<void> {
+    if (pending.requesterOpenId !== message.senderOpenId) {
+      await this.sendPayload(pending.chatId, buildNoticeCardPayload({
+        title: "无法结束入库模式",
+        template: "yellow",
+        iconToken: "maybe_outlined",
+        message: "当前入库模式仅允许发起人结束。",
+        messageIconToken: "maybe_outlined",
+        messageIconColor: "yellow",
+        showMessageIcon: false,
+      }), {
+        event: "knowledge ingest end rejected",
+        transcriptType: "outbound-final",
+        textPreview: "当前入库模式仅允许发起人结束。",
+        len: 16,
+      }, delivery ?? this.getKnowledgeIngestDelivery(pending));
+      return;
+    }
+    const queue = this.knowledgeIngestQueues.get(pending.conversationKey);
+    let endedImmediately = true;
+    if (queue && (queue.active || queue.pending.length > 0)) {
+      endedImmediately = false;
+      queue.closing = true;
+      await this.sendKnowledgeIngestMarkdown(pending, "已收到结束指令，将处理完当前队列后结束。");
+      await this.updateKnowledgeIngestSessionSummary(pending.conversationKey);
+    } else {
+      await this.sendKnowledgeIngestFinalSummary(pending);
+      await this.clearKnowledgeIngestPending(pending.conversationKey, pending.chatType);
+    }
+    if (!delivery || !endedImmediately) {
+      return;
+    }
+    await this.sendPayload(pending.chatId, buildNoticeCardPayload({
+      title: "已退出知识入库模式",
+      template: "green",
+      iconToken: "yes_filled",
+      message: "后续文件消息将不再自动入库；如需继续入库，请发送 `/kb-ingest-start`。",
+      messageIconToken: "yes_filled",
+      messageIconColor: "green",
+      showMessageIcon: false,
+    }), {
+      event: "knowledge ingest ended",
+      transcriptType: "outbound-final",
+      textPreview: "已退出知识入库模式",
+      len: 9,
+    }, delivery);
+  }
+
+  async clearKnowledgeIngestPending(conversationKey: string, chatType: string): Promise<boolean> {
+    const pending = this.getKnowledgeIngestInteraction(conversationKey);
+    if (!pending) {
+      return false;
+    }
+    if (pending.previousActiveSessionId) {
+      await this.restorePreviousSessionForBackgroundIngest(conversationKey, chatType, pending);
+    }
+    this.clearKnowledgeIngestInteraction(conversationKey);
+    this.knowledgeIngestQueues.delete(conversationKey);
+    this.knowledgeIngestSessionStats.delete(conversationKey);
+    return true;
+  }
+
   private getSessionWindow(conversationKey: string, chatType?: string): SessionWindowRecord {
     const mode = resolveSessionMode(chatType, this.config.bridge.sessionModes);
     return normalizeSessionWindowRecord(this.sessionMap[conversationKey], mode, this.config.bridge.maxSessionsPerWindow);
@@ -939,6 +1282,11 @@ export class BridgeApp {
   }
 
   private setPendingInteraction(conversationKey: string, interaction: PendingInteraction): void {
+    if (interaction.kind === "knowledge-ingest-await-file") {
+      this.setKnowledgeIngestInteraction(conversationKey, interaction);
+      return;
+    }
+
     this.clearPendingInteraction(conversationKey, false);
     this.pendingInteractions.set(conversationKey, interaction);
 
@@ -968,7 +1316,22 @@ export class BridgeApp {
 
   }
 
-  private clearPendingInteraction(conversationKey: string, keepNonExpiring: boolean): void {
+  private setKnowledgeIngestInteraction(conversationKey: string, interaction: PendingKnowledgeIngestInteraction): void {
+    this.clearKnowledgeIngestInteraction(conversationKey, { keepActiveKnowledgeIngest: true });
+    this.knowledgeIngestInteractions.set(conversationKey, interaction);
+    this.getKnowledgeIngestSessionStats(conversationKey);
+    const timer = setTimeout(() => {
+      void this.handleKnowledgeIngestTimeout(conversationKey, interaction);
+    }, Math.max(0, interaction.expiresAt - Date.now()));
+    this.pendingInteractionTimers.set(this.getKnowledgeIngestTimerKey(conversationKey), timer);
+    this.saveActiveKnowledgeIngest(interaction);
+  }
+
+  private clearPendingInteraction(
+    conversationKey: string,
+    keepNonExpiring: boolean,
+    options?: { keepActiveKnowledgeIngest?: boolean },
+  ): void {
     const timeout = this.pendingInteractionTimers.get(conversationKey);
     if (timeout) {
       clearTimeout(timeout);
@@ -982,7 +1345,40 @@ export class BridgeApp {
       }
     }
 
+    const current = this.pendingInteractions.get(conversationKey);
     this.pendingInteractions.delete(conversationKey);
+    if (current?.kind === "knowledge-ingest-await-file" && !options?.keepActiveKnowledgeIngest) {
+      this.deleteActiveKnowledgeIngest(conversationKey);
+    }
+  }
+
+  private clearKnowledgeIngestInteraction(
+    conversationKey: string,
+    options?: { keepActiveKnowledgeIngest?: boolean },
+  ): void {
+    const timerKey = this.getKnowledgeIngestTimerKey(conversationKey);
+    const timeout = this.pendingInteractionTimers.get(timerKey);
+    if (timeout) {
+      clearTimeout(timeout);
+      this.pendingInteractionTimers.delete(timerKey);
+    }
+    this.knowledgeIngestInteractions.delete(conversationKey);
+    if (!options?.keepActiveKnowledgeIngest) {
+      this.deleteActiveKnowledgeIngest(conversationKey);
+    }
+  }
+
+  getKnowledgeIngestInteraction(conversationKey: string): PendingKnowledgeIngestInteraction | null {
+    const interaction = this.knowledgeIngestInteractions.get(conversationKey);
+    if (interaction) {
+      return interaction;
+    }
+    const legacy = this.pendingInteractions.get(conversationKey);
+    return legacy?.kind === "knowledge-ingest-await-file" ? legacy : null;
+  }
+
+  private getKnowledgeIngestTimerKey(conversationKey: string): string {
+    return `knowledge-ingest:${conversationKey}`;
   }
 
   private clearTurnOwnedPendingInteraction(conversationKey: string, turnId: string): void {
@@ -1006,6 +1402,37 @@ export class BridgeApp {
     }
 
     await this.permissionManager.expireInteraction(current, true);
+  }
+
+  private async handleKnowledgeIngestTimeout(conversationKey: string, pending: PendingKnowledgeIngestInteraction): Promise<void> {
+    const current = this.getKnowledgeIngestInteraction(conversationKey);
+    if (
+      !current
+      || current.anchorMessageId !== pending.anchorMessageId
+      || current.expiresAt > Date.now()
+    ) {
+      return;
+    }
+    if (this.runningKnowledgeIngests.has(conversationKey)) {
+      this.refreshKnowledgeIngestPending(conversationKey, current);
+      return;
+    }
+    await this.sendKnowledgeIngestFinalSummary(current);
+    await this.clearKnowledgeIngestPending(conversationKey, current.chatType);
+    await this.sendPayload(current.chatId, buildNoticeCardPayload({
+      title: "入库任务已超时",
+      template: "yellow",
+      iconToken: "maybe_outlined",
+      message: "长时间未收到新的入库素材，已结束当前入库任务。需要继续时请重新发送 `/kb-ingest-start`。",
+      messageIconToken: "maybe_outlined",
+      messageIconColor: "yellow",
+      showMessageIcon: false,
+    }), {
+      event: "knowledge ingest timed out",
+      transcriptType: "outbound-final",
+      textPreview: "入库任务已超时",
+      len: 7,
+    }, this.getKnowledgeIngestDelivery(current));
   }
 
   private isSessionBusy(conversationKey: string, sessionId: string): boolean {
@@ -1117,16 +1544,33 @@ export class BridgeApp {
     }, replyToMessageId ? { replyToMessageId } : undefined);
   }
 
+  private async sendKnowledgeIngestMarkdown(pending: PendingKnowledgeIngestInteraction, markdown: string): Promise<void> {
+    await this.sendPayload(pending.chatId, buildPostMarkdownPayload(markdown), {
+      event: "knowledge ingest notice sent",
+      transcriptType: "outbound-final",
+      textPreview: createTextPreview(markdown),
+      len: markdown.length,
+    }, this.getKnowledgeIngestDelivery(pending));
+  }
+
+  private getKnowledgeIngestDelivery(pending: PendingKnowledgeIngestInteraction): { replyToMessageId: string; replyInThread: boolean } {
+    return {
+      replyToMessageId: pending.anchorMessageId,
+      replyInThread: pending.deliveryMode === "group_thread",
+    };
+  }
+
   private async sendPayload(
     chatId: string,
     payload: FeishuPostPayload,
     options: { event: string; transcriptType: TranscriptType; textPreview: string; len: number },
-    delivery?: { replyToMessageId: string },
+    delivery?: { replyToMessageId: string; replyInThread?: boolean },
   ): Promise<{ messageId: string }> {
-    const shouldReplyInThread = this.config.feishu.behavior.replyInThread;
-    const result = shouldReplyInThread && delivery?.replyToMessageId
-      ? await this.outbound.replyMessage(delivery.replyToMessageId, payload)
-      : await this.outbound.sendMessage(chatId, payload);
+    const result = delivery?.replyToMessageId && delivery.replyInThread !== undefined
+      ? await this.outbound.replyMessage(delivery.replyToMessageId, payload, { replyInThread: delivery.replyInThread })
+      : this.config.feishu.behavior.replyInThread && delivery?.replyToMessageId
+        ? await this.outbound.replyMessage(delivery.replyToMessageId, payload)
+        : await this.outbound.sendMessage(chatId, payload);
     this.logger.log("feishu/reply", options.event, { chatId, messageId: result.messageId, textPreview: options.textPreview, len: options.len });
     this.logger.logTranscript(options.transcriptType, { chatId, messageId: result.messageId }, prettyPrintPayload(payload));
     return result;
@@ -1152,25 +1596,58 @@ export class BridgeApp {
     this.runningKnowledgeIngests.delete(conversationKey);
   }
 
-  private maybeRefreshKnowledgeIngestPending(
+  private refreshKnowledgeIngestPending(
     conversationKey: string,
-    pending: Extract<PendingInteraction, { kind: "knowledge-ingest-await-file" }>,
-    replyToMessageId: string,
+    pending: PendingKnowledgeIngestInteraction,
   ): void {
-    const current = this.pendingInteractions.get(conversationKey);
-    if (current?.kind !== "knowledge-ingest-await-file" || current.requesterOpenId !== pending.requesterOpenId) {
+    const current = this.getKnowledgeIngestInteraction(conversationKey);
+    if (!current || current.anchorMessageId !== pending.anchorMessageId) {
       return;
     }
-    this.setPendingInteraction(conversationKey, {
+    this.setKnowledgeIngestInteraction(conversationKey, {
       ...current,
-      replyToMessageId,
+      expiresAt: Date.now() + this.config.knowledgeBase.ingest.sessionIdleMs,
+    });
+  }
+
+  private saveActiveKnowledgeIngest(pending: PendingKnowledgeIngestInteraction): void {
+    this.activeKnowledgeIngestMap[pending.conversationKey] = {
+      chatId: pending.chatId,
+      chatType: pending.chatType,
+      conversationKey: pending.conversationKey,
+      requesterOpenId: pending.requesterOpenId,
+      rootMessageId: pending.rootMessageId,
+      anchorMessageId: pending.anchorMessageId,
+      deliveryMode: pending.deliveryMode,
+      ingestSessionId: pending.ingestSessionId,
+      previousActiveSessionId: pending.previousActiveSessionId,
+      expiresAt: pending.expiresAt,
+    };
+    void this.activeKnowledgeIngests.saveRecords(this.activeKnowledgeIngestMap).catch((error) => {
+      this.logger.log("knowledge/ingest", "failed to persist active ingest", {
+        conversationKey: pending.conversationKey,
+        detail: error instanceof Error ? error.message : String(error),
+      }, "warn");
+    });
+  }
+
+  private deleteActiveKnowledgeIngest(conversationKey: string): void {
+    if (!(conversationKey in this.activeKnowledgeIngestMap)) {
+      return;
+    }
+    delete this.activeKnowledgeIngestMap[conversationKey];
+    void this.activeKnowledgeIngests.saveRecords(this.activeKnowledgeIngestMap).catch((error) => {
+      this.logger.log("knowledge/ingest", "failed to clear active ingest", {
+        conversationKey,
+        detail: error instanceof Error ? error.message : String(error),
+      }, "warn");
     });
   }
 
   private async restorePreviousSessionForBackgroundIngest(
     conversationKey: string,
     chatType: string,
-    pending: Extract<PendingInteraction, { kind: "knowledge-ingest-await-file" }>,
+    pending: Pick<PendingKnowledgeIngestInteraction, "previousActiveSessionId">,
   ): Promise<void> {
     if (!pending.previousActiveSessionId) {
       return;
@@ -1191,10 +1668,28 @@ export class BridgeApp {
     await this.saveSessionWindow(conversationKey, nextWindow);
   }
 
-  private async sendKnowledgeIngestBusyNotice(
-    message: Pick<IncomingChatMessage, "chatId" | "messageId">,
+  private async restoreOrCreateNormalSessionForBackgroundIngest(
+    message: Pick<IncomingChatMessage, "chatId" | "chatType" | "conversationKey" | "threadKey">,
+    pending: Pick<PendingKnowledgeIngestInteraction, "previousActiveSessionId" | "ingestSessionId">,
   ): Promise<void> {
-    await this.sendPayload(message.chatId, buildNoticeCardPayload({
+    if (pending.previousActiveSessionId) {
+      await this.restorePreviousSessionForBackgroundIngest(message.conversationKey, message.chatType, pending);
+      return;
+    }
+    if (!pending.ingestSessionId) {
+      return;
+    }
+    const window = this.getSessionWindow(message.conversationKey, message.chatType);
+    if (window.activeSessionId !== pending.ingestSessionId) {
+      return;
+    }
+    await this.createAndBindSession(message);
+  }
+
+  private async sendKnowledgeIngestBusyNotice(
+    pending: PendingKnowledgeIngestInteraction,
+  ): Promise<void> {
+    await this.sendPayload(pending.chatId, buildNoticeCardPayload({
       title: "知识入库处理中",
       template: "blue",
       iconToken: "upload_outlined",
@@ -1207,7 +1702,7 @@ export class BridgeApp {
       transcriptType: "outbound-final",
       textPreview: "当前正在处理知识入库任务。",
       len: 43,
-    }, { replyToMessageId: message.messageId });
+    }, this.getKnowledgeIngestDelivery(pending));
   }
 
   private async updateKnowledgeIngestProgress(
@@ -1249,6 +1744,10 @@ function createKnowledgeIngestProgressState(sourceLabel: string): KnowledgeInges
       { label: "写入知识库", detail: "等待开始", status: "pending" },
     ],
   };
+}
+
+function getKnowledgeIngestQueueItemLabel(item: KnowledgeIngestQueueItem): string {
+  return item.kind === "web" ? item.url : item.fileName;
 }
 
 function applyKnowledgeIngestProgress(state: KnowledgeIngestProgressState, update: KnowledgeIngestProgressUpdate): void {

--- a/src/runtime/command-handler.ts
+++ b/src/runtime/command-handler.ts
@@ -1,4 +1,4 @@
-import type { PendingInteraction, PendingPermissionInteraction } from "../bridge/state.js";
+import type { PendingInteraction, PendingKnowledgeIngestInteraction, PendingPermissionInteraction } from "../bridge/state.js";
 import type { RoutedText } from "../bridge/router.js";
 import {
   buildKnowledgeQueryEmptyPayload,
@@ -53,6 +53,12 @@ export type BridgeAppContext = {
       sessionListLimit: number;
       maxSessionsPerWindow: number;
     };
+    knowledgeBase: {
+      ingest: {
+        pendingTtlMs: number;
+        sessionIdleMs: number;
+      };
+    };
   };
   opencode: {
     getSessionStatuses(): Promise<Record<string, OpenCodeSessionStatus>>;
@@ -88,11 +94,13 @@ export type BridgeAppContext = {
     chatId: string,
     payload: FeishuPostPayload,
     options: { event: string; transcriptType: TranscriptType; textPreview: string; len: number },
-    delivery?: { replyToMessageId: string },
+    delivery?: { replyToMessageId: string; replyInThread?: boolean },
   ): Promise<{ messageId: string }>;
   sendMarkdown(chatId: string, markdown: string, replyToMessageId?: string): Promise<void>;
   setPendingInteraction(conversationKey: string, interaction: PendingInteraction): void;
   clearPendingInteraction(conversationKey: string, keepNonExpiring: boolean): void;
+  getKnowledgeIngestInteraction(conversationKey: string): PendingKnowledgeIngestInteraction | null;
+  clearKnowledgeIngestPending(conversationKey: string, chatType: string): Promise<boolean>;
   listOpenCodeSessionsById(): Promise<Map<string, OpenCodeSession>>;
   saveSessionWindow(conversationKey: string, window: SessionWindowRecord): Promise<void>;
   getSessionMessageCount(sessionId: string): Promise<number>;
@@ -264,7 +272,7 @@ export class CommandHandler {
         });
         return;
       }
-      const currentPending = this.context.pendingInteractions.get(message.conversationKey);
+      const currentPending = this.context.getKnowledgeIngestInteraction(message.conversationKey);
       if (currentPending?.kind === "knowledge-ingest-await-file" && currentPending.requesterOpenId === message.senderOpenId) {
         await this.sendNotice(message, {
           title: "已在知识入库模式",
@@ -285,29 +293,35 @@ export class CommandHandler {
         this.context.config.bridge.maxSessionsPerWindow,
       );
       await this.context.saveSessionWindow(message.conversationKey, nextWindow);
-      this.context.setPendingInteraction(message.conversationKey, {
-        kind: "knowledge-ingest-await-file",
-        chatId: message.chatId,
-        conversationKey: message.conversationKey,
-        requesterOpenId: message.senderOpenId,
-        replyToMessageId: message.messageId,
-        ingestSessionId: entry.sessionId,
-        previousActiveSessionId: previousSession?.sessionId ?? null,
-      });
-      if (message.chatType !== "p2p") {
-        await this.context.whitelistBind(message.chatId, message.senderOpenId);
-      }
-      await this.context.sendPayload(message.chatId, buildKnowledgeIngestReadyPayload(), {
+      const deliveryMode = message.chatType === "p2p" ? "p2p_reply" : "group_thread";
+      const ready = await this.context.sendPayload(message.chatId, buildKnowledgeIngestReadyPayload(), {
         event: "knowledge ingest pending",
         transcriptType: "outbound-final",
         textPreview: "已进入知识入库模式",
         len: 9,
-      }, { replyToMessageId: message.messageId });
+      }, { replyToMessageId: message.messageId, replyInThread: deliveryMode === "group_thread" });
+      this.context.setPendingInteraction(message.conversationKey, {
+        kind: "knowledge-ingest-await-file",
+        chatId: message.chatId,
+        chatType: message.chatType,
+        conversationKey: message.conversationKey,
+        requesterOpenId: message.senderOpenId,
+        replyToMessageId: ready.messageId,
+        rootMessageId: message.messageId,
+        anchorMessageId: ready.messageId,
+        deliveryMode,
+        ingestSessionId: entry.sessionId,
+        previousActiveSessionId: previousSession?.sessionId ?? null,
+        expiresAt: Date.now() + this.context.config.knowledgeBase.ingest.sessionIdleMs,
+      });
+      if (message.chatType !== "p2p") {
+        await this.context.whitelistBind(message.chatId, message.senderOpenId);
+      }
       return;
     }
 
     if (command.kind === "knowledge-ingest-end") {
-      const pending = this.context.pendingInteractions.get(message.conversationKey);
+      const pending = this.context.getKnowledgeIngestInteraction(message.conversationKey);
       if (pending?.kind !== "knowledge-ingest-await-file") {
         await this.sendNotice(message, {
           title: "当前未开启知识入库模式",
@@ -326,7 +340,7 @@ export class CommandHandler {
         });
         return;
       }
-      await this.clearKnowledgeIngestPending(message.conversationKey, message.chatType);
+      await this.context.clearKnowledgeIngestPending(message.conversationKey, message.chatType);
       await this.sendNotice(message, {
         title: "已退出知识入库模式",
         template: "green",
@@ -346,7 +360,7 @@ export class CommandHandler {
         });
         return;
       }
-      const clearedIngestPending = await this.clearKnowledgeIngestPending(message.conversationKey, message.chatType);
+      const clearedIngestPending = await this.context.clearKnowledgeIngestPending(message.conversationKey, message.chatType);
       const window = this.context.getSessionWindow(message.conversationKey, message.chatType);
       if (window.interactionMode === "knowledge") {
         await this.sendNotice(message, {
@@ -373,7 +387,7 @@ export class CommandHandler {
     }
 
     if (command.kind === "knowledge-mode-end") {
-      await this.clearKnowledgeIngestPending(message.conversationKey, message.chatType);
+      await this.context.clearKnowledgeIngestPending(message.conversationKey, message.chatType);
       const window = this.context.getSessionWindow(message.conversationKey, message.chatType);
       if (window.interactionMode !== "knowledge") {
         await this.sendNotice(message, {
@@ -794,27 +808,5 @@ export class CommandHandler {
       icon: "maybe_outlined",
       message: "当前会话正在执行任务，请先发送 `/abort`。",
     });
-  }
-
-  private async clearKnowledgeIngestPending(conversationKey: string, chatType: string): Promise<boolean> {
-    const pending = this.context.pendingInteractions.get(conversationKey);
-    if (pending?.kind === "knowledge-ingest-await-file") {
-      if (pending.previousActiveSessionId) {
-        const window = this.context.getSessionWindow(conversationKey, chatType);
-        const previousExists = window.sessions.some((session) => session.sessionId === pending.previousActiveSessionId);
-        if (previousExists) {
-          const nextWindow = setActiveSession(
-            window,
-            pending.previousActiveSessionId,
-            Date.now(),
-            this.context.config.bridge.maxSessionsPerWindow,
-          );
-          await this.context.saveSessionWindow(conversationKey, nextWindow);
-        }
-      }
-      this.context.clearPendingInteraction(conversationKey, false);
-      return true;
-    }
-    return false;
   }
 }

--- a/src/runtime/permission-manager.ts
+++ b/src/runtime/permission-manager.ts
@@ -25,7 +25,7 @@ type PermissionManagerCallbacks = {
     chatId: string,
     payload: FeishuPostPayload,
     options: SendPayloadOptions,
-    delivery?: { replyToMessageId: string },
+    delivery?: { replyToMessageId: string; replyInThread?: boolean },
   ): Promise<{ messageId: string }>;
   toCardContent(payload: FeishuPostPayload): Record<string, unknown>;
 };

--- a/src/runtime/turn-card-manager.ts
+++ b/src/runtime/turn-card-manager.ts
@@ -17,7 +17,7 @@ const STREAM_FLUSH_INTERVAL_MS = 750;
 
 type OutboundPort = {
   sendMessage(chatId: string, payload: FeishuPostPayload): Promise<{ messageId: string }>;
-  replyMessage(messageId: string, payload: FeishuPostPayload): Promise<{ messageId: string }>;
+  replyMessage(messageId: string, payload: FeishuPostPayload, options?: { replyInThread?: boolean }): Promise<{ messageId: string }>;
   updateMessage(messageId: string, payload: FeishuPostPayload): Promise<{ messageId: string }>;
 };
 
@@ -183,7 +183,7 @@ export class TurnCardManager {
     chatId: string,
     payload: FeishuPostPayload,
     options: { event: string; transcriptType: TranscriptType; textPreview: string; len: number },
-    delivery?: { replyToMessageId: string },
+    delivery?: { replyToMessageId: string; replyInThread?: boolean },
   ): Promise<{ messageId: string }> {
     const result = this.replyInThread && delivery?.replyToMessageId
       ? await this.outbound.replyMessage(delivery.replyToMessageId, payload)

--- a/src/runtime/turn-executor.ts
+++ b/src/runtime/turn-executor.ts
@@ -94,7 +94,7 @@ export type TurnExecutorContext = {
     chatId: string,
     payload: FeishuPostPayload,
     options: { event: string; transcriptType: TranscriptType; textPreview: string; len: number },
-    delivery?: { replyToMessageId: string },
+    delivery?: { replyToMessageId: string; replyInThread?: boolean },
   ): Promise<{ messageId: string }>;
 };
 

--- a/src/store/active-ingests.ts
+++ b/src/store/active-ingests.ts
@@ -1,0 +1,86 @@
+import { JsonStore } from "./json-store.js";
+
+export type ActiveKnowledgeIngestRecord = {
+  chatId: string;
+  chatType: string;
+  conversationKey: string;
+  requesterOpenId: string;
+  rootMessageId: string;
+  anchorMessageId: string;
+  deliveryMode: "group_thread" | "p2p_reply";
+  ingestSessionId?: string | undefined;
+  previousActiveSessionId?: string | null | undefined;
+  expiresAt: number;
+};
+
+export type ActiveKnowledgeIngestRecordMap = Record<string, ActiveKnowledgeIngestRecord>;
+
+type ActiveKnowledgeIngestFile = {
+  version: 1;
+  records: ActiveKnowledgeIngestRecordMap;
+};
+
+const ACTIVE_KNOWLEDGE_INGEST_STORE_VERSION = 1 as const;
+
+export class ActiveKnowledgeIngestStore extends JsonStore<unknown> {
+  constructor(dataDir: string, fileName = "active-knowledge-ingests.json") {
+    super(dataDir, fileName, { version: ACTIVE_KNOWLEDGE_INGEST_STORE_VERSION, records: {} } satisfies ActiveKnowledgeIngestFile);
+  }
+
+  override async load(): Promise<ActiveKnowledgeIngestRecordMap> {
+    const loaded = await super.load();
+    if (!isStoreFile(loaded)) {
+      return {};
+    }
+    return Object.fromEntries(
+      Object.entries(loaded.records)
+        .map(([conversationKey, record]) => [conversationKey, normalizeRecord(record)] as const)
+        .filter((entry): entry is readonly [string, ActiveKnowledgeIngestRecord] => entry[1] !== null),
+    );
+  }
+
+  async saveRecords(records: ActiveKnowledgeIngestRecordMap): Promise<void> {
+    await super.save({
+      version: ACTIVE_KNOWLEDGE_INGEST_STORE_VERSION,
+      records,
+    } satisfies ActiveKnowledgeIngestFile);
+  }
+}
+
+function isStoreFile(value: unknown): value is ActiveKnowledgeIngestFile {
+  return isRecord(value) && value.version === ACTIVE_KNOWLEDGE_INGEST_STORE_VERSION && isRecord(value.records);
+}
+
+function normalizeRecord(value: unknown): ActiveKnowledgeIngestRecord | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  if (
+    typeof value.chatId !== "string"
+    || typeof value.chatType !== "string"
+    || typeof value.conversationKey !== "string"
+    || typeof value.requesterOpenId !== "string"
+    || typeof value.rootMessageId !== "string"
+    || typeof value.anchorMessageId !== "string"
+    || (value.deliveryMode !== "group_thread" && value.deliveryMode !== "p2p_reply")
+    || typeof value.expiresAt !== "number"
+  ) {
+    return null;
+  }
+  return {
+    chatId: value.chatId,
+    chatType: value.chatType,
+    conversationKey: value.conversationKey,
+    requesterOpenId: value.requesterOpenId,
+    rootMessageId: value.rootMessageId,
+    anchorMessageId: value.anchorMessageId,
+    deliveryMode: value.deliveryMode,
+    ingestSessionId: typeof value.ingestSessionId === "string" ? value.ingestSessionId : undefined,
+    previousActiveSessionId: typeof value.previousActiveSessionId === "string" ? value.previousActiveSessionId : value.previousActiveSessionId === null ? null : undefined,
+    expiresAt: value.expiresAt,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/test/app-command-surface.test.ts
+++ b/test/app-command-surface.test.ts
@@ -510,13 +510,19 @@ describe("BridgeApp command surface", () => {
     const appAny = app as unknown as {
       sessionMap: Record<string, SessionWindowRecord>;
       pendingInteractions: Map<string, PendingInteraction>;
+      knowledgeIngestInteractions: Map<string, PendingInteraction>;
     };
-    appAny.pendingInteractions.set("oc_p2p_1", {
+    appAny.knowledgeIngestInteractions.set("oc_p2p_1", {
       kind: "knowledge-ingest-await-file",
       chatId: "oc_p2p_1",
+      chatType: "p2p",
       conversationKey: "oc_p2p_1",
       requesterOpenId: "ou_123",
       replyToMessageId: "om_1",
+      rootMessageId: "om_1",
+      anchorMessageId: "om_anchor",
+      deliveryMode: "p2p_reply",
+      expiresAt: Date.now() + 600_000,
     });
 
     await callHandleCommand(app, {
@@ -525,7 +531,7 @@ describe("BridgeApp command surface", () => {
     });
 
     expect(appAny.sessionMap["oc_p2p_1"]?.interactionMode).toBe("knowledge");
-    expect(appAny.pendingInteractions.has("oc_p2p_1")).toBe(false);
+    expect(appAny.knowledgeIngestInteractions.has("oc_p2p_1")).toBe(false);
     expect(extractInteractiveHeader(getReplyPayloads(outbound)[0])).toBe("已进入知识库模式");
 
     await callHandleCommand(app, {
@@ -561,6 +567,7 @@ describe("BridgeApp command surface", () => {
       opencode: { createSession: typeof createSession };
       sessionMap: Record<string, SessionWindowRecord>;
       pendingInteractions: Map<string, PendingInteraction>;
+      knowledgeIngestInteractions: Map<string, PendingInteraction>;
     };
     appAny.opencode = { createSession };
     appAny.sessionMap["oc_p2p_1"] = {
@@ -580,7 +587,7 @@ describe("BridgeApp command surface", () => {
     expect(appAny.sessionMap["oc_p2p_1"]?.activeSessionId).toBe("ses_ingest");
     expect(appAny.sessionMap["oc_p2p_1"]?.sessions.map((session) => session.sessionId)).toEqual(["ses_ingest", "ses_chat"]);
     expect(appAny.sessionMap["oc_p2p_1"]?.sessions.find((session) => session.sessionId === "ses_ingest")?.label).toBe("知识入库");
-    expect(appAny.pendingInteractions.get("oc_p2p_1")).toEqual(expect.objectContaining({
+    expect(appAny.knowledgeIngestInteractions.get("oc_p2p_1")).toEqual(expect.objectContaining({
       kind: "knowledge-ingest-await-file",
       ingestSessionId: "ses_ingest",
       previousActiveSessionId: "ses_chat",
@@ -592,7 +599,7 @@ describe("BridgeApp command surface", () => {
     });
 
     expect(appAny.sessionMap["oc_p2p_1"]?.activeSessionId).toBe("ses_chat");
-    expect(appAny.pendingInteractions.has("oc_p2p_1")).toBe(false);
+    expect(appAny.knowledgeIngestInteractions.has("oc_p2p_1")).toBe(false);
   });
 
   it("blocks close when the current session is still running", async () => {
@@ -986,7 +993,7 @@ function baseConfig(): AppConfig {
       },
       embeddingProvider: undefined,
       models: {},
-      ingest: { allowedExtensions: [".pdf", ".docx", ".txt"], maxFileSizeMb: 20, pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500 },
+      ingest: { allowedExtensions: [".pdf", ".docx", ".txt"], maxFileSizeMb: 20, pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500 },
     },
     logging: {
       dir: process.cwd(),

--- a/test/app-permission-actions.test.ts
+++ b/test/app-permission-actions.test.ts
@@ -339,7 +339,7 @@ function baseConfig(): AppConfig {
       },
       embeddingProvider: undefined,
       models: {},
-      ingest: { allowedExtensions: [".pdf", ".docx", ".txt"], maxFileSizeMb: 20, pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500 },
+      ingest: { allowedExtensions: [".pdf", ".docx", ".txt"], maxFileSizeMb: 20, pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500 },
     },
     logging: {
       dir: process.cwd(),

--- a/test/app-whitelist-commands.test.ts
+++ b/test/app-whitelist-commands.test.ts
@@ -199,7 +199,7 @@ function baseConfig(): AppConfig {
       },
       embeddingProvider: undefined,
       models: {},
-      ingest: { allowedExtensions: [".pdf", ".docx", ".txt"], maxFileSizeMb: 20, pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500 },
+      ingest: { allowedExtensions: [".pdf", ".docx", ".txt"], maxFileSizeMb: 20, pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500 },
     },
     logging: {
       dir: process.cwd(),

--- a/test/feishu-api.test.ts
+++ b/test/feishu-api.test.ts
@@ -63,6 +63,27 @@ describe("FeishuApiClient", () => {
     expect(fetch).toHaveBeenCalledTimes(2);
   });
 
+  it("sends reply_in_thread only when explicitly requested", async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ code: 0, tenant_access_token: "token_1" }))
+      .mockResolvedValueOnce(jsonResponse({ code: 0, data: { message_id: "om_thread" } }))
+      .mockResolvedValueOnce(jsonResponse({ code: 0, data: { message_id: "om_reply" } }));
+    vi.stubGlobal("fetch", fetch);
+    const client = new FeishuApiClient("app", "secret");
+    const payload = {
+      msg_type: "post" as const,
+      content: JSON.stringify({ text: "hello" }),
+    };
+
+    await expect(client.replyMessage("om_anchor", payload, { replyInThread: true })).resolves.toEqual({ messageId: "om_thread" });
+    await expect(client.replyMessage("om_anchor", payload, { replyInThread: false })).resolves.toEqual({ messageId: "om_reply" });
+
+    const threadedBody = JSON.parse(fetch.mock.calls[1]?.[1]?.body as string);
+    const p2pBody = JSON.parse(fetch.mock.calls[2]?.[1]?.body as string);
+    expect(threadedBody.reply_in_thread).toBe(true);
+    expect(p2pBody).not.toHaveProperty("reply_in_thread");
+  });
+
   it("retries createBitableRecord with a single-select tag value when 标签 is configured as single select", async () => {
     vi.useFakeTimers();
     const fetch = vi.fn()

--- a/test/formatter.test.ts
+++ b/test/formatter.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
   buildKnowledgeIngestProcessingPayload,
   buildKnowledgeIngestPayload,
+  buildKnowledgeIngestSessionFinalPayload,
+  buildKnowledgeIngestSessionPayload,
   buildKnowledgeQueryEmptyPayload,
   buildKnowledgeQueryPayload,
   buildNoticeCardPayload,
@@ -362,10 +364,51 @@ describe("buildPostPayload", () => {
     const content = JSON.parse(payload.content) as any;
     const serialized = JSON.stringify(content);
     expect(serialized).toContain("知识入库处理中");
+    expect(serialized).toContain("整体进度");
+    expect(serialized).toContain("0/3 步完成");
+    expect(serialized).toContain("当前步骤");
     expect(serialized).toContain("读取内容");
+    expect(serialized).toContain("进行中");
+    expect(serialized).toContain("2. 提取问答");
+    expect(serialized).toContain("等待中");
     expect(serialized).toContain("loading_outlined");
+    expect(serialized).toContain("time_outlined");
     expect(content.body.elements[0].columns[0].elements[0].icon).toBeUndefined();
     expect(serialized).toContain("warning_outlined");
+  });
+
+  it("renders knowledge ingest session summary and final cards", () => {
+    const sessionPayload = buildKnowledgeIngestSessionPayload({
+      completedCount: 3,
+      failedCount: 0,
+      queuedCount: 1,
+      currentLabel: "劳动合同法释义.pdf",
+      totalExtractedCount: 127,
+      totalDedupedCount: 38,
+    });
+    const finalPayload = buildKnowledgeIngestSessionFinalPayload({
+      completedCount: 5,
+      failedCount: 0,
+      queuedCount: 0,
+      totalExtractedCount: 214,
+      totalDedupedCount: 38,
+      elapsedMs: 222_000,
+      bitableUrl: "https://example.com/base/app?table=tbl",
+    });
+
+    const sessionSerialized = JSON.stringify(JSON.parse(sessionPayload.content));
+    const finalSerialized = JSON.stringify(JSON.parse(finalPayload.content));
+    expect(sessionSerialized).toContain("知识入库会话");
+    expect(sessionSerialized).toContain("已完成");
+    expect(sessionSerialized).toContain("劳动合同法释义.pdf");
+    expect(sessionSerialized).toContain("排队中");
+    expect(sessionSerialized).toContain("总入库");
+    expect(finalSerialized).toContain("知识入库完成");
+    expect(finalSerialized).toContain("本次共处理");
+    expect(finalSerialized).toContain("214 条问答");
+    expect(finalSerialized).toContain("去重合并");
+    expect(finalSerialized).toContain("3 分 42 秒");
+    expect(finalSerialized).toContain("查看多维表格");
   });
 
   it("renders a notice card without body icon when disabled", () => {

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -287,7 +287,7 @@ function createConfig(
       },
       embeddingProvider: undefined,
       models: {},
-      ingest: { allowedExtensions: [".pdf", ".docx", ".txt"], maxFileSizeMb: 20, pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500 },
+      ingest: { allowedExtensions: [".pdf", ".docx", ".txt"], maxFileSizeMb: 20, pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500 },
     },
     logging: {
       dir: process.cwd(),

--- a/test/integration/message-flow.test.ts
+++ b/test/integration/message-flow.test.ts
@@ -136,7 +136,7 @@ function baseConfig(dir: string): AppConfig {
       },
       embeddingProvider: undefined,
       models: {},
-      ingest: { allowedExtensions: [".pdf", ".docx", ".txt"], maxFileSizeMb: 20, pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500 },
+      ingest: { allowedExtensions: [".pdf", ".docx", ".txt"], maxFileSizeMb: 20, pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500 },
     },
     logging: {
       dir: dir,

--- a/test/integration/permission-flow.test.ts
+++ b/test/integration/permission-flow.test.ts
@@ -195,7 +195,7 @@ function baseConfig(dir: string): AppConfig {
       },
       embeddingProvider: undefined,
       models: {},
-      ingest: { allowedExtensions: [".pdf", ".docx", ".txt"], maxFileSizeMb: 20, pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500 },
+      ingest: { allowedExtensions: [".pdf", ".docx", ".txt"], maxFileSizeMb: 20, pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500 },
     },
     logging: {
       dir: dir,

--- a/test/integration/queue-concurrency.test.ts
+++ b/test/integration/queue-concurrency.test.ts
@@ -148,7 +148,7 @@ function baseConfig(dir: string): AppConfig {
       },
       embeddingProvider: undefined,
       models: {},
-      ingest: { allowedExtensions: [".pdf", ".docx", ".txt"], maxFileSizeMb: 20, pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500 },
+      ingest: { allowedExtensions: [".pdf", ".docx", ".txt"], maxFileSizeMb: 20, pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500 },
     },
     logging: {
       dir: dir,

--- a/test/knowledge-flow.test.ts
+++ b/test/knowledge-flow.test.ts
@@ -1,3 +1,7 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
 import { describe, expect, it, vi } from "vitest";
 
 import type { AppConfig } from "../src/config/schema.js";
@@ -81,7 +85,7 @@ describe("knowledge base bridge flow", () => {
 
     await app.handleIncomingMessage(createTextMessage("/kb-ingest-start"));
     await app.handleIncomingMessage({
-      ...createTextMessage("劳动合同.txt"),
+      ...createIngestReplyMessage("劳动合同.txt", "om_file_1"),
       messageId: "om_file_1",
       messageType: "file",
       file: {
@@ -90,18 +94,20 @@ describe("knowledge base bridge flow", () => {
       },
     });
     await app.handleIncomingMessage({
-      ...createTextMessage("劳动合同2.txt", "om_file_2"),
+      ...createIngestReplyMessage("劳动合同2.txt", "om_file_2"),
       messageType: "file",
       file: {
         fileKey: "file_2",
         fileName: "劳动合同2.txt",
       },
     });
-    await app.handleIncomingMessage(createTextMessage("/kb-ingest-end", "om_end"));
+    await app.handleIncomingMessage(createIngestReplyMessage("/kb-ingest-end", "om_end"));
+    await vi.waitFor(() => {
+      expect(ingestFile).toHaveBeenCalledTimes(2);
+    });
 
     const replyPayloads = (outbound.replyMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
     const updatedPayloads = (outbound.updateMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
-    expect(ingestFile).toHaveBeenCalledTimes(2);
     expect(JSON.stringify(replyPayloads)).toContain("知识入库处理中");
     expect(JSON.stringify(updatedPayloads)).toContain("正在提取问答（1/1）");
     expect(JSON.stringify(updatedPayloads)).toContain("正在写入知识库（2/4）");
@@ -109,7 +115,7 @@ describe("knowledge base bridge flow", () => {
     expect(JSON.stringify(updatedPayloads)).toContain("原始提取");
     expect(JSON.stringify(updatedPayloads)).toContain("去重合并");
     expect(JSON.stringify(updatedPayloads)).toContain("劳动合同.txt");
-    expect(JSON.stringify(replyPayloads)).toContain("已退出知识入库模式");
+    expect(JSON.stringify(replyPayloads)).toContain("本次共处理");
   });
 
   it("asks for intent when receiving a file outside ingest mode and can process it as a normal turn", async () => {
@@ -268,7 +274,11 @@ describe("knowledge base bridge flow", () => {
     });
 
     await app.handleIncomingMessage(createTextMessage("/kb-ingest-start"));
-    await app.handleIncomingMessage(createTextMessage("读取 https://example.com/law 这个网页并入库", "om_web"));
+    await app.handleIncomingMessage(createIngestReplyMessage("读取 https://example.com/law 这个网页并入库", "om_web"));
+    await vi.waitFor(() => {
+      const updatedPayloads = (outbound.updateMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
+      expect(JSON.stringify(updatedPayloads)).toContain("知识入库完成");
+    });
 
     const replyPayloads = (outbound.replyMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
     const updatedPayloads = (outbound.updateMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
@@ -314,13 +324,154 @@ describe("knowledge base bridge flow", () => {
     });
 
     await app.handleIncomingMessage(createTextMessage("/kb-ingest-start"));
-    await app.handleIncomingMessage(createTextMessage("https://example.com/law", "om_web"));
+    await app.handleIncomingMessage(createIngestReplyMessage("https://example.com/law", "om_web"));
 
     expect(ingestWebPage).toHaveBeenCalledWith({
       url: "https://example.com/law",
       instruction: "https://example.com/law",
       messageId: "om_web",
     }, expect.any(Object));
+  });
+
+  it("keeps P2P mainline file and URL messages out of an active ingest chain", async () => {
+    const outbound = createOutbound();
+    const eventStream = new FakeOpenCodeEventStream();
+    const opencode = new FakeOpenCodeClient(eventStream, { kind: "message-flow", finalText: "主线继续聊天。" });
+    const ingestFile = vi.fn(async () => ({
+      sourceFile: "劳动合同.txt",
+      rawExtractedCount: 1,
+      dedupedCount: 0,
+      extractedCount: 1,
+      tagCounts: { 劳动: 1 },
+      durationMs: 1,
+    }));
+    const ingestWebPage = vi.fn(async () => ({
+      sourceFile: "网页.md",
+      rawExtractedCount: 1,
+      dedupedCount: 0,
+      extractedCount: 1,
+      tagCounts: { 劳动: 1 },
+      durationMs: 1,
+    }));
+    const app = new BridgeApp(baseConfig(), outbound, logger(), createWhitelist(), {
+      knowledge: {
+        async query() {
+          return { question: "", results: [] };
+        },
+        ingestFile,
+        ingestWebPage,
+        async syncMirror() {},
+        close() {},
+      },
+      opencode,
+      eventStream,
+      memory: null,
+    });
+    const appAny = app as unknown as {
+      pendingInteractions: Map<string, unknown>;
+      knowledgeIngestInteractions: Map<string, unknown>;
+    };
+
+    await app.handleIncomingMessage(createTextMessage("/kb-ingest-start"));
+    await app.handleIncomingMessage(createTextMessage("https://example.com/law", "om_mainline_url"));
+    await app.handleIncomingMessage({
+      ...createTextMessage("劳动合同.txt", "om_mainline_file"),
+      messageType: "file",
+      file: {
+        fileKey: "file_1",
+        fileName: "劳动合同.txt",
+      },
+    });
+
+    const updatedPayloads = (outbound.updateMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
+    expect(ingestFile).not.toHaveBeenCalled();
+    expect(ingestWebPage).not.toHaveBeenCalled();
+    expect(appAny.pendingInteractions.get("oc_p2p_1")).toEqual(expect.objectContaining({
+      kind: "file-await-instruction",
+      file: expect.objectContaining({ messageId: "om_mainline_file" }),
+    }));
+    expect(appAny.knowledgeIngestInteractions.has("oc_p2p_1")).toBe(true);
+    expect(JSON.stringify(updatedPayloads)).toContain("主线继续聊天");
+  });
+
+  it("allows the requester to end P2P ingest from the mainline when the reply chain is hard to find", async () => {
+    const outbound = createOutbound();
+    const eventStream = new FakeOpenCodeEventStream();
+    const opencode = new FakeOpenCodeClient(eventStream, { kind: "message-flow", finalText: "not used" });
+    const app = new BridgeApp(baseConfig(), outbound, logger(), createWhitelist(), {
+      knowledge: {
+        async query() {
+          return { question: "", results: [] };
+        },
+        async ingestFile() {
+          throw new Error("not used");
+        },
+        async syncMirror() {},
+        close() {},
+      },
+      opencode,
+      eventStream,
+      memory: null,
+    });
+    const appAny = app as unknown as { pendingInteractions: Map<string, unknown> };
+
+    await app.handleIncomingMessage(createTextMessage("/kb-ingest-start"));
+    await app.handleIncomingMessage(createTextMessage("/kb-ingest-end", "om_mainline_end"));
+
+    const replyCalls = outbound.replyMessage.mock.calls as unknown as Array<[string, { content: string }]>;
+    expect(appAny.pendingInteractions.has("oc_p2p_1")).toBe(false);
+    expect(replyCalls.at(-1)?.[0]).toBe("om_mainline_end");
+    expect(JSON.stringify(replyCalls.at(-1)?.[1])).toContain("已退出知识入库模式");
+  });
+
+  it("only accepts the requester in a group ingest thread", async () => {
+    const outbound = createOutbound();
+    const eventStream = new FakeOpenCodeEventStream();
+    const opencode = new FakeOpenCodeClient(eventStream, { kind: "message-flow", finalText: "not used" });
+    const ingestFile = vi.fn(async () => ({
+      sourceFile: "劳动合同.txt",
+      rawExtractedCount: 1,
+      dedupedCount: 0,
+      extractedCount: 1,
+      tagCounts: { 劳动: 1 },
+      durationMs: 1_000,
+    }));
+    const app = new BridgeApp(baseConfig(), outbound, logger(), createWhitelist(), {
+      knowledge: {
+        async query() {
+          return { question: "", results: [] };
+        },
+        ingestFile,
+        async syncMirror() {},
+        close() {},
+      },
+      opencode,
+      eventStream,
+      memory: null,
+    });
+
+    await app.handleIncomingMessage(createGroupTextMessage("/kb-ingest-start", "om_group_start", "ou_123"));
+    await app.handleIncomingMessage({
+      ...createGroupThreadMessage("别人上传.txt", "om_group_file_other", "ou_456"),
+      messageType: "file",
+      file: {
+        fileKey: "file_other",
+        fileName: "别人上传.txt",
+      },
+    });
+    await app.handleIncomingMessage({
+      ...createGroupThreadMessage("劳动合同.txt", "om_group_file_requester", "ou_123"),
+      messageType: "file",
+      file: {
+        fileKey: "file_requester",
+        fileName: "劳动合同.txt",
+      },
+    });
+
+    const replyPayloads = (outbound.replyMessage.mock.calls as unknown as Array<[string, { content: string }, { replyInThread?: boolean } | undefined]>);
+    expect(replyPayloads[0]?.[2]?.replyInThread).toBe(true);
+    expect(ingestFile).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(replyPayloads.map((call) => call[1]))).toContain("当前入库任务仅允许发起人继续上传文件");
   });
 
   it("allows regular messages while ingest is running", async () => {
@@ -359,7 +510,7 @@ describe("knowledge base bridge flow", () => {
 
     await app.handleIncomingMessage(createTextMessage("/kb-ingest-start"));
     const ingestPromise = app.handleIncomingMessage({
-      ...createTextMessage("劳动合同.txt", "om_file_1"),
+      ...createIngestReplyMessage("劳动合同.txt", "om_file_1"),
       messageType: "file",
       file: {
         fileKey: "file_1",
@@ -379,9 +530,139 @@ describe("knowledge base bridge flow", () => {
     expect(JSON.stringify(replyPayloads)).not.toContain("当前正在处理知识入库任务");
     expect(JSON.stringify(updatedPayloads)).toContain("普通对话继续处理");
   });
+
+  it("rejects new ingest material when the ingest queue is full", async () => {
+    const outbound = createOutbound();
+    const eventStream = new FakeOpenCodeEventStream();
+    const opencode = new FakeOpenCodeClient(eventStream, { kind: "message-flow", finalText: "not used" });
+    let resolveIngest: (() => void) | undefined;
+    const ingestFile = vi.fn(async (_file, options?: KnowledgeIngestOptions) => {
+      await options?.onProgress?.({ step: "read", status: "running", detail: "正在下载并解析文件" });
+      await new Promise<void>((resolve) => {
+        resolveIngest = resolve;
+      });
+      return {
+        sourceFile: "劳动合同.txt",
+        rawExtractedCount: 1,
+        dedupedCount: 0,
+        extractedCount: 1,
+        tagCounts: { 劳动: 1 },
+        durationMs: 1_000,
+      };
+    });
+    const app = new BridgeApp(baseConfig({ queueLimit: 1 }), outbound, logger(), createWhitelist(), {
+      knowledge: {
+        async query() {
+          return { question: "", results: [] };
+        },
+        ingestFile,
+        async syncMirror() {},
+        close() {},
+      },
+      opencode,
+      eventStream,
+      memory: null,
+    });
+
+    await app.handleIncomingMessage(createTextMessage("/kb-ingest-start"));
+    await app.handleIncomingMessage({
+      ...createIngestReplyMessage("劳动合同.txt", "om_file_1"),
+      messageType: "file",
+      file: {
+        fileKey: "file_1",
+        fileName: "劳动合同.txt",
+      },
+    });
+    await vi.waitFor(() => {
+      expect(ingestFile).toHaveBeenCalledTimes(1);
+      expect(resolveIngest).toBeTypeOf("function");
+    });
+    await app.handleIncomingMessage({
+      ...createIngestReplyMessage("劳动合同2.txt", "om_file_2"),
+      messageType: "file",
+      file: {
+        fileKey: "file_2",
+        fileName: "劳动合同2.txt",
+      },
+    });
+    resolveIngest?.();
+    await vi.waitFor(() => {
+      const updatedPayloads = (outbound.updateMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
+      expect(JSON.stringify(updatedPayloads)).toContain("知识入库完成");
+    });
+
+    const replyPayloads = (outbound.replyMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
+    expect(ingestFile).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(replyPayloads)).toContain("已达上限，请等待当前文件处理完成");
+  });
+
+  it("marks persisted active ingest sessions interrupted on restart", async () => {
+    const dataDir = await mkdtemp(path.join(tmpdir(), "bridge-active-ingest-"));
+    await writeFile(path.join(dataDir, "mappings.json"), JSON.stringify({
+      version: 4,
+      mappings: {
+        oc_p2p_1: {
+          mode: "multi",
+          interactionMode: "default",
+          activeSessionId: "ses_ingest",
+          sessions: [
+            { sessionId: "ses_ingest", label: "知识入库", createdAt: 1, lastUsedAt: 2 },
+            { sessionId: "ses_chat", label: "普通会话", createdAt: 1, lastUsedAt: 1 },
+          ],
+        },
+      },
+    }), "utf8");
+    await writeFile(path.join(dataDir, "active-knowledge-ingests.json"), JSON.stringify({
+      version: 1,
+      records: {
+        oc_p2p_1: {
+          chatId: "oc_p2p_1",
+          chatType: "p2p",
+          conversationKey: "oc_p2p_1",
+          requesterOpenId: "ou_123",
+          rootMessageId: "om_start",
+          anchorMessageId: "om_anchor",
+          deliveryMode: "p2p_reply",
+          ingestSessionId: "ses_ingest",
+          previousActiveSessionId: "ses_chat",
+          expiresAt: Date.now() + 600_000,
+        },
+      },
+    }), "utf8");
+    const config = baseConfig();
+    config.storage.dataDir = dataDir;
+    const outbound = createOutbound();
+    const eventStream = new FakeOpenCodeEventStream();
+    const opencode = new FakeOpenCodeClient(eventStream, { kind: "message-flow", finalText: "not used" });
+    const ingestFile = vi.fn();
+    const app = new BridgeApp(config, outbound, logger(), createWhitelist(), {
+      knowledge: {
+        async query() {
+          return { question: "", results: [] };
+        },
+        ingestFile,
+        async syncMirror() {},
+        close() {},
+      },
+      opencode,
+      eventStream,
+      memory: null,
+    });
+
+    await app.start();
+    await app.stop();
+
+    const replyPayloads = (outbound.replyMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
+    const activeStore = JSON.parse(await readFile(path.join(dataDir, "active-knowledge-ingests.json"), "utf8"));
+    const mappings = JSON.parse(await readFile(path.join(dataDir, "mappings.json"), "utf8"));
+    expect(JSON.stringify(replyPayloads)).toContain("入库任务因服务重启中断");
+    expect(activeStore.records).toEqual({});
+    expect(mappings.mappings.oc_p2p_1.activeSessionId).toBe("ses_chat");
+    expect(ingestFile).not.toHaveBeenCalled();
+  });
 });
 
-function baseConfig(options?: { autoDetect?: boolean }): AppConfig {
+function baseConfig(options?: { autoDetect?: boolean; queueLimit?: number }): AppConfig {
   return {
     feishu: {
       appId: "app",
@@ -423,7 +704,7 @@ function baseConfig(options?: { autoDetect?: boolean }): AppConfig {
       storePath: "whitelist.json",
     },
     bridge: {
-      queueLimit: 3,
+      queueLimit: options?.queueLimit ?? 3,
       sessionModes: {
         p2p: "multi",
         group: "single",
@@ -474,7 +755,7 @@ function baseConfig(options?: { autoDetect?: boolean }): AppConfig {
       ingest: {
         allowedExtensions: [".pdf", ".docx", ".txt", ".md"],
         maxFileSizeMb: 20,
-        pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
+        pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
       },
     },
     logging: {
@@ -529,5 +810,37 @@ function createTextMessage(text: string, messageId = "om_1"): IncomingChatMessag
     plainText: text,
     threadKey: messageId,
     conversationKey: "oc_p2p_1",
+  };
+}
+
+function createIngestReplyMessage(text: string, messageId: string): IncomingChatMessage {
+  return {
+    ...createTextMessage(text, messageId),
+    rootId: "om_reply",
+    parentId: "om_reply",
+  };
+}
+
+function createGroupTextMessage(text: string, messageId: string, senderOpenId: string): IncomingChatMessage {
+  return {
+    chatId: "oc_group_1",
+    chatType: "group",
+    senderOpenId,
+    messageId,
+    messageType: "text",
+    rawContent: text,
+    plainText: text,
+    threadKey: messageId,
+    conversationKey: `oc_group_1:${messageId}`,
+  };
+}
+
+function createGroupThreadMessage(text: string, messageId: string, senderOpenId: string): IncomingChatMessage {
+  return {
+    ...createGroupTextMessage(text, messageId, senderOpenId),
+    rootId: "om_group_start",
+    parentId: "om_reply",
+    threadKey: "om_group_start",
+    conversationKey: "oc_group_1:om_group_start",
   };
 }

--- a/test/knowledge-service.test.ts
+++ b/test/knowledge-service.test.ts
@@ -45,7 +45,7 @@ describe("KnowledgeBaseService", () => {
         ingest: {
           allowedExtensions: [".txt"],
           maxFileSizeMb: 20,
-          pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
+          pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
         },
       },
       {
@@ -110,7 +110,7 @@ describe("KnowledgeBaseService", () => {
         ingest: {
           allowedExtensions: [".txt"],
           maxFileSizeMb: 20,
-          pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
+          pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
         },
       },
       {
@@ -178,7 +178,7 @@ describe("KnowledgeBaseService", () => {
         ingest: {
           allowedExtensions: [".txt"],
           maxFileSizeMb: 20,
-          pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
+          pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
         },
       },
       {
@@ -241,7 +241,7 @@ describe("KnowledgeBaseService", () => {
         ingest: {
           allowedExtensions: [".txt"],
           maxFileSizeMb: 20,
-          pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
+          pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
         },
       },
       {
@@ -327,7 +327,7 @@ describe("KnowledgeBaseService", () => {
         ingest: {
           allowedExtensions: [".txt"],
           maxFileSizeMb: 20,
-          pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
+          pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
         },
       },
       {
@@ -398,7 +398,7 @@ describe("KnowledgeBaseService", () => {
         ingest: {
           allowedExtensions: [".txt"],
           maxFileSizeMb: 20,
-          pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
+          pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
         },
       },
       {
@@ -469,7 +469,7 @@ describe("KnowledgeBaseService", () => {
         ingest: {
           allowedExtensions: [".txt"],
           maxFileSizeMb: 20,
-          pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
+          pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
         },
       },
       {
@@ -535,7 +535,7 @@ describe("KnowledgeBaseService", () => {
         ingest: {
           allowedExtensions: [".txt", ".md"],
           maxFileSizeMb: 20,
-          pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
+          pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
         },
       },
       {
@@ -615,7 +615,7 @@ describe("KnowledgeBaseService", () => {
         ingest: {
           allowedExtensions: [".txt"],
           maxFileSizeMb: 20,
-          pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
+          pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
         },
       },
       {
@@ -683,7 +683,7 @@ describe("KnowledgeBaseService", () => {
         ingest: {
           allowedExtensions: [".txt"],
           maxFileSizeMb: 20,
-          pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
+          pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
         },
       },
       {
@@ -743,7 +743,7 @@ describe("KnowledgeBaseService", () => {
         ingest: {
           allowedExtensions: [".txt"],
           maxFileSizeMb: 20,
-          pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
+          pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
         },
       },
       {
@@ -819,7 +819,7 @@ describe("KnowledgeBaseService", () => {
         ingest: {
           allowedExtensions: [".txt"],
           maxFileSizeMb: 20,
-          pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
+          pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
         },
       },
       {
@@ -897,7 +897,7 @@ describe("KnowledgeBaseService", () => {
         ingest: {
           allowedExtensions: [".txt"],
           maxFileSizeMb: 20,
-          pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
+          pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
         },
       },
       {
@@ -978,7 +978,7 @@ describe("KnowledgeBaseService", () => {
         ingest: {
           allowedExtensions: [".txt"],
           maxFileSizeMb: 20,
-          pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 3,
+          pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 3,
         },
       },
       {
@@ -1054,7 +1054,7 @@ describe("KnowledgeBaseService", () => {
         ingest: {
           allowedExtensions: [".txt"],
           maxFileSizeMb: 20,
-          pendingTtlMs: 600_000, concurrency: 1, maxExtractChunks: 30, maxExtractQas: 500,
+          pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 1, maxExtractChunks: 30, maxExtractQas: 500,
         },
       },
       {
@@ -1122,7 +1122,7 @@ describe("KnowledgeBaseService", () => {
         ingest: {
           allowedExtensions: [".txt"],
           maxFileSizeMb: 20,
-          pendingTtlMs: 600_000, concurrency: 1, maxExtractChunks: 2, maxExtractQas: 500,
+          pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 1, maxExtractChunks: 2, maxExtractQas: 500,
         },
       },
       {
@@ -1186,7 +1186,7 @@ describe("KnowledgeBaseService", () => {
       ingest: {
         allowedExtensions: [".txt"],
         maxFileSizeMb: 20,
-        pendingTtlMs: 600_000, concurrency: 1, maxExtractChunks: 2, maxExtractQas: 500,
+        pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 1, maxExtractChunks: 2, maxExtractQas: 500,
       },
     };
     const resources = {
@@ -1270,7 +1270,7 @@ describe("KnowledgeBaseService", () => {
         ingest: {
           allowedExtensions: [".txt"],
           maxFileSizeMb: 20,
-          pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
+          pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
         },
       },
       {

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -212,7 +212,7 @@ function baseConfig(): AppConfig {
       },
       embeddingProvider: undefined,
       models: {},
-      ingest: { allowedExtensions: [".pdf", ".docx", ".txt"], maxFileSizeMb: 20, pendingTtlMs: 600_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500 },
+      ingest: { allowedExtensions: [".pdf", ".docx", ".txt"], maxFileSizeMb: 20, pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500 },
     },
     logging: {
       dir: process.cwd(),


### PR DESCRIPTION
## 变更内容
- 为知识入库会话新增持久化状态存储，支持独立追踪进行中的入库会话。
- 将知识入库流程调整为会话级排队处理，并增加会话摘要卡片与完成汇总卡片。
- 为飞书回复补充按需 thread reply 能力，完善入库、权限与相关回归测试。
- 更新配置示例、版本号与变更记录到 `0.1.10`。

## 变更原因
- 之前知识入库依赖普通 pending 交互，长流程和后台处理场景下状态恢复与消息锚点不够稳定。
- 入库过程缺少会话级进度汇总，不利于连续上传多个素材时理解当前队列状态。
- 某些回复需要显式落在线程内，现有发送能力不够细化。

## 影响
- 知识入库的会话状态、排队与结束反馈更清晰。
- 后续重构可以直接以这版入库会话流作为主线基线。
- 对现有普通对话流程无破坏性影响。

## 验证
- `npm test`
- `npm run typecheck`
- `npm run lint`
