### PR TITLE
[codex] 重构运行时模块分层骨架

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The project follows Semantic Versioning.
 
+## 0.1.13 - 2026-04-14
+
+### Added
+- Added an Apache 2.0 `LICENSE` file for the repository.
+
 ## 0.1.12 - 2026-04-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The project follows Semantic Versioning.
 
+## 0.1.14 - 2026-04-14
+
+### Fixed
+- Fixed ordinary file handling to reject unsupported file types and oversized uploads before entering the normal follow-up flow.
+
 ## 0.1.13 - 2026-04-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The project follows Semantic Versioning.
 
+## 0.1.11 - 2026-04-14
+
+### Fixed
+- Fixed fallback final replies so direct markdown responses stay attached to the original Feishu message thread when process cards cannot be created.
+
 ## 0.1.10 - 2026-04-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The project follows Semantic Versioning.
 
+## 0.1.12 - 2026-04-14
+
+### Added
+- Added runtime version exposure through `src/version.ts`, startup logs, and the `/healthz` response.
+
 ## 0.1.11 - 2026-04-14
 
 ### Fixed

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025 Clukay_Fun
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/docs/runtime-layering.md
+++ b/docs/runtime-layering.md
@@ -1,0 +1,133 @@
+# Runtime Layering
+
+## Summary
+
+Bridge 运行时采用四层结构：
+
+- `core`: Bridge 运行时内核
+- `modules`: 运行时可插拔能力
+- `skills`: 注入 OpenCode session 的规则片段
+- `scripts`: 安装、诊断、启动类 CLI 工具
+
+当前代码已经落地第一步基础设施：
+
+- `ModuleManager` 负责模块注册、按优先级调度、启动停止和 turn hook 聚合
+- `knowledge` 已作为第一个 runtime module 接入
+- `memory` 已改为 runtime module hook，通过 `beforeTurn` / `afterTurn` 接入
+
+## Layer Contract
+
+### core
+
+`core` 只保留运行机制：
+
+- Feishu ingress / egress
+- session window 与 queue
+- turn 生命周期与事件流
+- process / final card
+- permission / question / session-select / delete-confirm
+- Bridge 自有命令面
+
+`core` 不再直接承载 knowledge 的 queue、ingest 状态和 query 路由。
+
+### modules
+
+`modules` 只承载业务能力：
+
+- `knowledge`
+- `memory`
+- 未来可继续扩展 calendar、approval、workflow 等 runtime 能力
+
+模块通过统一接口接入，不要求 `core` 知道具体场景细节。
+
+### skills
+
+`skills` 只放会注入 OpenCode prompt 的规则片段。
+
+以下内容不属于 skill：
+
+- 部署手册
+- 排障 checklist
+- 人类操作流程
+
+这些内容继续保留在 `docs/`。
+
+### scripts
+
+`scripts` 是独立层：
+
+- `onboard`
+- `doctor`
+- `checks`
+- `start`
+
+它们不进入 runtime handler chain。
+
+## Runtime Flow
+
+消息分发顺序：
+
+1. core 预处理  
+2. core 自有命令与核心交互  
+3. module chain  
+4. core fallback handlers
+
+当前 fallback handlers 主要包括：
+
+- 文件说明流
+- 默认 OpenCode 对话
+
+## Module Interface
+
+`src/bridge/module.ts` 中的 `RuntimeModule` 约定：
+
+- `handleMessage()`: 消费消息，返回 claim / not claim
+- `beforeTurn()`: 在 turn 开始前补充 system blocks
+- `afterTurn()`: 在 turn 完成后执行收尾逻辑
+- `start()` / `stop()`: 模块生命周期
+
+默认只保留两态：
+
+- `{ claimed: true }`
+- `{ claimed: false }`
+
+不引入 `continue` 语义。
+
+## Current Mapping
+
+### knowledge module
+
+`src/knowledge/runtime-module.ts` 当前负责：
+
+- ingest interaction
+- ingest queue / session stats
+- active ingest persistence / restart recovery
+- knowledge query
+- knowledge mode
+- auto-detect query
+- knowledge commands
+
+### memory module
+
+`src/memory/runtime-module.ts` 当前负责：
+
+- `beforeTurn`: recall block
+- `afterTurn`: enqueue learn
+- `start` / `stop`: service lifecycle
+
+## Next Refactor
+
+### 阶段一
+
+- 继续压缩 `app.ts`
+- 把更多 knowledge 相关 helper 从 core 挪到 module 专属文件
+
+### 阶段二
+
+- 继续清理 core 中对具体 module 的残留认知
+- 保持默认 OpenCode handler 仅作为兜底
+
+### 阶段三
+
+- 整理 `skills` 与 `docs` 的边界
+- 把 prompt 规则收敛到 skill 目录

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feishu-opencode-bridge",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feishu-opencode-bridge",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.42.0",
         "better-sqlite3": "^12.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feishu-opencode-bridge",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feishu-opencode-bridge",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.42.0",
         "better-sqlite3": "^12.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feishu-opencode-bridge",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feishu-opencode-bridge",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.42.0",
         "better-sqlite3": "^12.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feishu-opencode-bridge",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feishu-opencode-bridge",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.42.0",
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feishu-opencode-bridge",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feishu-opencode-bridge",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feishu-opencode-bridge",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feishu-opencode-bridge",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/bridge/module.ts
+++ b/src/bridge/module.ts
@@ -1,0 +1,94 @@
+import type { IncomingChatMessage } from "../runtime/app.js";
+import type { RoutedText } from "./router.js";
+import type { BridgeTurn } from "./turn.js";
+import type { SessionWindowRecord } from "../store/mappings.js";
+import type { PendingInteraction } from "./state.js";
+
+export type RuntimeModuleHandleResult =
+  | { claimed: true }
+  | { claimed: false };
+
+export type RuntimeModuleMessageContext = {
+  message: IncomingChatMessage;
+  routed: RoutedText | null;
+  pendingInteraction?: PendingInteraction | null;
+};
+
+export type RuntimeModuleBeforeTurnContext = {
+  turn: BridgeTurn & { sessionId: string };
+  window: SessionWindowRecord;
+};
+
+export type RuntimeModuleAfterTurnContext = {
+  turn: BridgeTurn & { sessionId: string };
+  reply: string;
+  window: SessionWindowRecord;
+};
+
+export interface RuntimeModule {
+  readonly name: string;
+  readonly priority: number;
+  start?(): Promise<void>;
+  stop?(): Promise<void>;
+  handleMessage?(context: RuntimeModuleMessageContext): Promise<RuntimeModuleHandleResult>;
+  beforeTurn?(context: RuntimeModuleBeforeTurnContext): Promise<{ systemBlocks?: string[] } | void>;
+  afterTurn?(context: RuntimeModuleAfterTurnContext): Promise<void>;
+}
+
+export class ModuleManager {
+  private readonly modules: RuntimeModule[] = [];
+
+  register(module: RuntimeModule): void {
+    this.modules.push(module);
+    this.modules.sort((left, right) => left.priority - right.priority);
+  }
+
+  list(): readonly RuntimeModule[] {
+    return this.modules;
+  }
+
+  async start(): Promise<void> {
+    for (const module of this.modules) {
+      await module.start?.();
+    }
+  }
+
+  async stop(): Promise<void> {
+    for (const module of [...this.modules].reverse()) {
+      await module.stop?.();
+    }
+  }
+
+  async handleMessage(context: RuntimeModuleMessageContext): Promise<RuntimeModuleHandleResult> {
+    for (const module of this.modules) {
+      const result = await module.handleMessage?.(context);
+      if (result?.claimed) {
+        return result;
+      }
+    }
+    return { claimed: false };
+  }
+
+  async collectBeforeTurnBlocks(context: RuntimeModuleBeforeTurnContext): Promise<string[]> {
+    const blocks: string[] = [];
+    for (const module of this.modules) {
+      const result = await module.beforeTurn?.(context);
+      if (!result?.systemBlocks) {
+        continue;
+      }
+      for (const block of result.systemBlocks) {
+        const normalized = block.trim();
+        if (normalized) {
+          blocks.push(normalized);
+        }
+      }
+    }
+    return blocks;
+  }
+
+  async runAfterTurnHooks(context: RuntimeModuleAfterTurnContext): Promise<void> {
+    for (const module of this.modules) {
+      await module.afterTurn?.(context);
+    }
+  }
+}

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -1,6 +1,7 @@
 import http from "node:http";
 
 import type { AppConfig } from "../config/schema.js";
+import { APP_VERSION } from "../version.js";
 
 type LoggerLike = {
   log: (scope: string, message: string, fields?: Record<string, unknown>, level?: "debug" | "info" | "warn" | "error") => void;
@@ -109,6 +110,7 @@ export async function startBridgeHttpServer(
       res.writeHead(200, { "Content-Type": "application/json; charset=utf-8" });
       res.end(JSON.stringify({
         ok: true,
+        bridgeVersion: APP_VERSION,
         uptimeSec: Math.max(0, Math.floor((Date.now() - startedAt) / 1000)),
         queueLimit: config.bridge.queueLimit,
         cardActionsEnabled: config.feishu.cardActions.enabled,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { createFeishuIngressOptions, FeishuWsClient } from "./feishu/ws.js";
 import { WhitelistStore } from "./store/whitelist.js";
 import { runStartupPreflight } from "./runtime/preflight.js";
 import { startBridgeHttpServer } from "./http/server.js";
+import { APP_VERSION } from "./version.js";
 
 async function main(): Promise<void> {
   const config = await loadConfig();
@@ -28,6 +29,9 @@ async function main(): Promise<void> {
   await ws.start();
 
   let shuttingDown = false;
+  logger.log("bridge/index", "runtime initialized", {
+    bridgeVersion: APP_VERSION,
+  });
   const shutdown = async (): Promise<void> => {
     if (shuttingDown) {
       return;

--- a/src/knowledge/runtime-module.ts
+++ b/src/knowledge/runtime-module.ts
@@ -1,0 +1,1115 @@
+import type { AppConfig } from "../config/schema.js";
+import type { RuntimeModule, RuntimeModuleHandleResult, RuntimeModuleMessageContext } from "../bridge/module.js";
+import type { PendingKnowledgeIngestInteraction } from "../bridge/state.js";
+import {
+  buildKnowledgeIngestPayload,
+  buildKnowledgeIngestProcessingPayload,
+  buildKnowledgeIngestReadyPayload,
+  buildKnowledgeIngestSessionFinalPayload,
+  buildKnowledgeIngestSessionPayload,
+  buildKnowledgeQueryEmptyPayload,
+  buildKnowledgeQueryPayload,
+  buildNoticeCardPayload,
+  buildPostMarkdownPayload,
+  type FeishuPostPayload,
+  type ToolUpdateView,
+} from "../feishu/formatter.js";
+import { createTextPreview, type Logger, type TranscriptType } from "../logging/logger.js";
+import type { IncomingChatMessage } from "../runtime/app.js";
+import {
+  getActiveSession,
+  setActiveSession,
+  setInteractionMode,
+  updateSessionLabel,
+} from "../runtime/session-windows.js";
+import type { SessionBindingRecord, SessionWindowRecord } from "../store/mappings.js";
+import { ActiveKnowledgeIngestStore, type ActiveKnowledgeIngestRecordMap } from "../store/active-ingests.js";
+import type { RoutedText } from "../bridge/router.js";
+import { detectKnowledgeWebIngest, detectLegalQuestion } from "./detector.js";
+import {
+  type KnowledgeBasePort,
+  type KnowledgeIngestProgressStep,
+  type KnowledgeIngestProgressUpdate,
+  type KnowledgeIngestResult,
+} from "./index.js";
+
+type SendPayload = (
+  chatId: string,
+  payload: FeishuPostPayload,
+  options: { event: string; transcriptType: TranscriptType; textPreview: string; len: number },
+  delivery?: { replyToMessageId: string; replyInThread?: boolean },
+) => Promise<{ messageId: string }>;
+
+type UpdatePayload = (
+  chatId: string,
+  messageId: string,
+  payload: FeishuPostPayload,
+  options: { event: string; transcriptType: TranscriptType; textPreview: string; len: number },
+) => Promise<{ messageId: string }>;
+
+type KnowledgeIngestQueueItem = {
+  conversationKey: string;
+  chatId: string;
+  requesterOpenId: string;
+  processingMessageId: string;
+  progressState: KnowledgeIngestProgressState;
+} & (
+  | {
+    kind: "file";
+    messageId: string;
+    fileKey: string;
+    fileName: string;
+    size?: number | undefined;
+  }
+  | {
+    kind: "web";
+    messageId: string;
+    url: string;
+    instruction: string;
+  }
+);
+
+type KnowledgeIngestQueueState = {
+  active: boolean;
+  closing: boolean;
+  currentLabel?: string | undefined;
+  pending: KnowledgeIngestQueueItem[];
+};
+
+type KnowledgeIngestSessionStats = {
+  startedAt: number;
+  completedCount: number;
+  failedCount: number;
+  totalExtractedCount: number;
+  totalDedupedCount: number;
+  bitableUrl?: string | undefined;
+};
+
+type KnowledgeRuntimeModuleDeps = {
+  config: AppConfig;
+  logger: Logger;
+  knowledge: KnowledgeBasePort | null;
+  sendPayload: SendPayload;
+  updatePayload: UpdatePayload;
+  getSessionWindow(conversationKey: string, chatType?: string): SessionWindowRecord;
+  saveSessionWindow(conversationKey: string, window: SessionWindowRecord): Promise<void>;
+  createAndBindSession(source: Pick<IncomingChatMessage, "chatId" | "chatType" | "conversationKey" | "threadKey">): Promise<SessionBindingRecord>;
+  whitelistBind(chatId: string, openId: string): Promise<void>;
+};
+
+type KnowledgeCommand = Extract<RoutedText, { kind: "command" }>["command"];
+
+export class KnowledgeRuntimeModule implements RuntimeModule {
+  readonly name = "knowledge";
+  readonly priority = 20;
+  readonly interactions = new Map<string, PendingKnowledgeIngestInteraction>();
+
+  private readonly activeKnowledgeIngests: ActiveKnowledgeIngestStore;
+  private activeKnowledgeIngestMap: ActiveKnowledgeIngestRecordMap = {};
+  private readonly runningKnowledgeIngests = new Map<string, { requesterOpenId: string }>();
+  private readonly knowledgeIngestQueues = new Map<string, KnowledgeIngestQueueState>();
+  private readonly knowledgeIngestSessionStats = new Map<string, KnowledgeIngestSessionStats>();
+  private readonly timers = new Map<string, NodeJS.Timeout>();
+
+  constructor(private readonly deps: KnowledgeRuntimeModuleDeps) {
+    this.activeKnowledgeIngests = new ActiveKnowledgeIngestStore(deps.config.storage.dataDir);
+  }
+
+  async start(): Promise<void> {
+    this.activeKnowledgeIngestMap = await this.activeKnowledgeIngests.load();
+    await this.interruptPersistedKnowledgeIngests();
+    if (!this.deps.knowledge) {
+      return;
+    }
+    try {
+      await this.deps.knowledge.syncMirror();
+    } catch (error) {
+      this.deps.logger.log("knowledge/sync", "mirror sync skipped", {
+        detail: error instanceof Error ? error.message : String(error),
+      }, "warn");
+    }
+  }
+
+  async stop(): Promise<void> {
+    for (const timeout of this.timers.values()) {
+      clearTimeout(timeout);
+    }
+    this.timers.clear();
+    this.deps.knowledge?.close();
+  }
+
+  async handleMessage(context: RuntimeModuleMessageContext): Promise<RuntimeModuleHandleResult> {
+    const { message, routed, pendingInteraction } = context;
+    const activeKnowledgeIngest = this.findKnowledgeIngestInteraction(message);
+    if (activeKnowledgeIngest) {
+      if (routed?.kind === "command" && routed.command.kind === "knowledge-ingest-end") {
+        await this.endKnowledgeIngestInteraction(message, activeKnowledgeIngest);
+        return { claimed: true };
+      }
+
+      const consumed = await this.enqueueKnowledgeIngestInput(message, activeKnowledgeIngest);
+      if (consumed) {
+        return { claimed: true };
+      }
+    }
+
+    if (routed?.kind === "command") {
+      const claimed = await this.handleKnowledgeCommand(message, routed.command);
+      if (claimed) {
+        return { claimed: true };
+      }
+      return { claimed: false };
+    }
+
+    const backgroundKnowledgeIngest = this.getInteraction(message.conversationKey);
+    if (backgroundKnowledgeIngest) {
+      await this.restoreOrCreateNormalSessionForBackgroundIngest(message, backgroundKnowledgeIngest);
+    }
+
+    const claimed = pendingInteraction?.kind === "file-await-instruction"
+      ? false
+      : await this.handleKnowledgeQueryMessage(message);
+    return { claimed };
+  }
+
+  getInteraction(conversationKey: string): PendingKnowledgeIngestInteraction | null {
+    return this.interactions.get(conversationKey) ?? null;
+  }
+
+  async clearPending(conversationKey: string, chatType: string): Promise<boolean> {
+    const pending = this.getInteraction(conversationKey);
+    if (!pending) {
+      return false;
+    }
+    if (pending.previousActiveSessionId) {
+      await this.restorePreviousSessionForBackgroundIngest(conversationKey, chatType, pending);
+    }
+    this.clearKnowledgeIngestInteraction(conversationKey);
+    this.knowledgeIngestQueues.delete(conversationKey);
+    this.knowledgeIngestSessionStats.delete(conversationKey);
+    return true;
+  }
+
+  private async handleKnowledgeCommand(
+    message: Pick<IncomingChatMessage, "chatId" | "chatType" | "messageId" | "conversationKey" | "threadKey" | "senderOpenId">,
+    command: KnowledgeCommand,
+  ): Promise<boolean> {
+    if (command.kind === "knowledge-query") {
+      if (!this.deps.knowledge) {
+        await this.sendNotice(message, {
+          title: "知识库未启用",
+          template: "yellow",
+          icon: "maybe_outlined",
+          message: "当前未启用法律知识库，请联系部署者补充 knowledgeBase 配置。",
+        });
+        return true;
+      }
+      try {
+        const result = await this.deps.knowledge.query(command.question);
+        await this.deps.sendPayload(
+          message.chatId,
+          result.results.length > 0 ? buildKnowledgeQueryPayload(result) : buildKnowledgeQueryEmptyPayload(command.question),
+          {
+            event: "knowledge query sent",
+            transcriptType: "outbound-final",
+            textPreview: command.question,
+            len: command.question.length,
+          },
+          { replyToMessageId: message.messageId },
+        );
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        await this.sendNotice(message, {
+          title: "知识检索失败",
+          template: "red",
+          icon: "error_filled",
+          message: detail,
+        });
+      }
+      return true;
+    }
+
+    if (command.kind === "knowledge-ingest") {
+      if (!this.deps.knowledge) {
+        await this.sendNotice(message, {
+          title: "知识库未启用",
+          template: "yellow",
+          icon: "maybe_outlined",
+          message: "当前未启用法律知识库，请联系部署者补充 knowledgeBase 配置。",
+        });
+        return true;
+      }
+      const currentPending = this.getInteraction(message.conversationKey);
+      if (currentPending?.requesterOpenId === message.senderOpenId) {
+        await this.sendNotice(message, {
+          title: "已在知识入库模式",
+          template: "blue",
+          icon: "upload_outlined",
+          message: "请继续上传 PDF / DOCX / TXT 文件；发送 `/kb-ingest-end` 可退出。",
+        });
+        return true;
+      }
+      const window = this.deps.getSessionWindow(message.conversationKey, message.chatType);
+      const previousSession = getActiveSession(window);
+      const entry = await this.deps.createAndBindSession(message);
+      const nextWindow = updateSessionLabel(
+        this.deps.getSessionWindow(message.conversationKey, message.chatType),
+        entry.sessionId,
+        "知识入库",
+        this.deps.config.bridge.maxSessionsPerWindow,
+      );
+      await this.deps.saveSessionWindow(message.conversationKey, nextWindow);
+      const deliveryMode = message.chatType === "p2p" ? "p2p_reply" : "group_thread";
+      const ready = await this.deps.sendPayload(message.chatId, buildKnowledgeIngestReadyPayload(), {
+        event: "knowledge ingest pending",
+        transcriptType: "outbound-final",
+        textPreview: "已进入知识入库模式",
+        len: 9,
+      }, { replyToMessageId: message.messageId, replyInThread: deliveryMode === "group_thread" });
+      this.setKnowledgeIngestInteraction(message.conversationKey, {
+        kind: "knowledge-ingest-await-file",
+        chatId: message.chatId,
+        chatType: message.chatType,
+        conversationKey: message.conversationKey,
+        requesterOpenId: message.senderOpenId,
+        replyToMessageId: ready.messageId,
+        rootMessageId: message.messageId,
+        anchorMessageId: ready.messageId,
+        deliveryMode,
+        ingestSessionId: entry.sessionId,
+        previousActiveSessionId: previousSession?.sessionId ?? null,
+        expiresAt: Date.now() + this.deps.config.knowledgeBase.ingest.sessionIdleMs,
+      });
+      if (message.chatType !== "p2p") {
+        await this.deps.whitelistBind(message.chatId, message.senderOpenId);
+      }
+      return true;
+    }
+
+    if (command.kind === "knowledge-ingest-end") {
+      const pending = this.getInteraction(message.conversationKey);
+      if (!pending) {
+        await this.sendNotice(message, {
+          title: "当前未开启知识入库模式",
+          template: "grey",
+          icon: "info-hollow_filled",
+          message: "发送 `/kb-ingest-start` 可进入知识入库模式。",
+        });
+        return true;
+      }
+      await this.endKnowledgeIngestInteraction(message, pending, { replyToMessageId: message.messageId });
+      return true;
+    }
+
+    if (command.kind === "knowledge-mode-start") {
+      if (!this.deps.knowledge) {
+        await this.sendNotice(message, {
+          title: "知识库未启用",
+          template: "yellow",
+          icon: "maybe_outlined",
+          message: "当前未启用法律知识库，请联系部署者补充 knowledgeBase 配置。",
+        });
+        return true;
+      }
+      const clearedIngestPending = await this.clearPending(message.conversationKey, message.chatType);
+      const window = this.deps.getSessionWindow(message.conversationKey, message.chatType);
+      if (window.interactionMode === "knowledge") {
+        await this.sendNotice(message, {
+          title: "已在知识库模式",
+          template: "blue",
+          icon: "search_outlined",
+          message: clearedIngestPending
+            ? "已退出知识入库模式；当前仍是知识库模式。接下来直接发送问题即可检索知识库，发送 `/legal-query-end` 可退出。"
+            : "接下来直接发送问题即可检索知识库，发送 `/legal-query-end` 可退出。",
+        });
+        return true;
+      }
+      const nextWindow = setInteractionMode(window, "knowledge", this.deps.config.bridge.maxSessionsPerWindow);
+      await this.deps.saveSessionWindow(message.conversationKey, nextWindow);
+      await this.sendNotice(message, {
+        title: "已进入知识库模式",
+        template: "indigo",
+        icon: "search_outlined",
+        message: clearedIngestPending
+          ? "已退出知识入库模式，并切换到知识库查询模式。接下来直接发送问题即可检索知识库，发送 `/legal-query-end` 可退出。"
+          : "接下来直接发送问题即可检索知识库，发送 `/legal-query-end` 可退出。",
+      });
+      return true;
+    }
+
+    if (command.kind === "knowledge-mode-end") {
+      await this.clearPending(message.conversationKey, message.chatType);
+      const window = this.deps.getSessionWindow(message.conversationKey, message.chatType);
+      if (window.interactionMode !== "knowledge") {
+        await this.sendNotice(message, {
+          title: "当前未开启知识库模式",
+          template: "grey",
+          icon: "info-hollow_filled",
+          message: "当前仍是普通对话模式，发送 `/legal-query-start` 可进入知识库模式。",
+        });
+        return true;
+      }
+      const nextWindow = setInteractionMode(window, "default", this.deps.config.bridge.maxSessionsPerWindow);
+      await this.deps.saveSessionWindow(message.conversationKey, nextWindow);
+      await this.sendNotice(message, {
+        title: "已退出知识库模式",
+        template: "green",
+        icon: "chat_outlined",
+        message: "后续消息将恢复为普通 OpenCode 对话，仍可用 `/legal-query <问题>` 单次查询。",
+      });
+      return true;
+    }
+
+    return false;
+  }
+
+  private async handleKnowledgeQueryMessage(message: IncomingChatMessage): Promise<boolean> {
+    if (message.messageType === "file" || !this.deps.knowledge) {
+      return false;
+    }
+
+    const window = this.deps.getSessionWindow(message.conversationKey, message.chatType);
+    const knowledgeModeDetection = window.interactionMode === "knowledge"
+      ? detectLegalQuestion(message.plainText)
+      : null;
+    if (
+      window.interactionMode === "knowledge"
+      && knowledgeModeDetection?.matched
+      && knowledgeModeDetection.confidence >= this.deps.config.knowledgeBase.autoDetect.minConfidence
+    ) {
+      try {
+        const result = await this.deps.knowledge.query(message.plainText);
+        await this.deps.sendPayload(
+          message.chatId,
+          result.results.length > 0 ? buildKnowledgeQueryPayload(result) : buildKnowledgeQueryEmptyPayload(message.plainText),
+          {
+            event: "knowledge query sent",
+            transcriptType: "outbound-final",
+            textPreview: message.plainText,
+            len: message.plainText.length,
+          },
+          { replyToMessageId: message.messageId },
+        );
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        await this.deps.sendPayload(message.chatId, buildNoticeCardPayload({
+          title: "知识检索失败",
+          template: "red",
+          iconToken: "error_filled",
+          message: detail,
+          messageIconToken: "error_filled",
+          messageIconColor: "red",
+        }), {
+          event: "knowledge query failed",
+          transcriptType: "outbound-final",
+          textPreview: detail,
+          len: detail.length,
+        }, { replyToMessageId: message.messageId });
+      }
+      return true;
+    }
+
+    if (!this.deps.config.knowledgeBase.autoDetect.enabled) {
+      return false;
+    }
+
+    const detection = detectLegalQuestion(message.plainText);
+    if (!detection.matched || detection.confidence < this.deps.config.knowledgeBase.autoDetect.minConfidence) {
+      return false;
+    }
+
+    try {
+      const result = await this.deps.knowledge.query(message.plainText);
+      if (result.results.length === 0) {
+        return false;
+      }
+      await this.deps.sendPayload(
+        message.chatId,
+        buildKnowledgeQueryPayload(result),
+        {
+          event: "knowledge query sent",
+          transcriptType: "outbound-final",
+          textPreview: message.plainText,
+          len: message.plainText.length,
+        },
+        { replyToMessageId: message.messageId },
+      );
+      return true;
+    } catch (error) {
+      this.deps.logger.log("knowledge/query", "auto-detect query failed", {
+        detail: error instanceof Error ? error.message : String(error),
+        confidence: detection.confidence,
+      }, "warn");
+      return false;
+    }
+  }
+
+  private async enqueueKnowledgeIngestInput(message: IncomingChatMessage, pending: PendingKnowledgeIngestInteraction): Promise<boolean> {
+    if (message.senderOpenId !== pending.requesterOpenId) {
+      await this.sendKnowledgeIngestMarkdown(pending, "当前入库任务仅允许发起人继续上传文件。");
+      return true;
+    }
+    if (!this.deps.knowledge) {
+      await this.sendKnowledgeIngestMarkdown(pending, "当前未启用法律知识库，请联系部署者补充 knowledgeBase 配置。");
+      return true;
+    }
+
+    let sourceLabel: string;
+    let itemInput:
+      | Omit<Extract<KnowledgeIngestQueueItem, { kind: "file" }>, "processingMessageId" | "progressState">
+      | Omit<Extract<KnowledgeIngestQueueItem, { kind: "web" }>, "processingMessageId" | "progressState">;
+    if (message.messageType === "file") {
+      sourceLabel = message.file.fileName;
+      itemInput = {
+        kind: "file",
+        conversationKey: pending.conversationKey,
+        chatId: message.chatId,
+        requesterOpenId: pending.requesterOpenId,
+        messageId: message.messageId,
+        fileKey: message.file.fileKey,
+        fileName: message.file.fileName,
+        size: message.file.size,
+      };
+    } else {
+      const webIngest = detectKnowledgeWebIngest(message.plainText, { requireIngestIntent: false });
+      if (!webIngest.matched || !webIngest.url || !this.deps.knowledge.ingestWebPage) {
+        await this.sendKnowledgeIngestMarkdown(pending, "请继续上传 PDF / DOCX / TXT / MD 文件，或直接发送网页 URL / 带 URL 的入库请求；发送 `/kb-ingest-end` 退出。");
+        return true;
+      }
+      sourceLabel = webIngest.url;
+      itemInput = {
+        kind: "web",
+        conversationKey: pending.conversationKey,
+        chatId: message.chatId,
+        requesterOpenId: pending.requesterOpenId,
+        messageId: message.messageId,
+        url: webIngest.url,
+        instruction: message.plainText,
+      };
+    }
+
+    const queue = this.getKnowledgeIngestQueue(pending.conversationKey);
+    if (queue.closing) {
+      await this.sendKnowledgeIngestMarkdown(pending, "已收到结束指令，当前队列处理完成后会自动结束。");
+      return true;
+    }
+    const queuedCount = queue.pending.length + (queue.active ? 1 : 0);
+    if (queuedCount >= this.deps.config.bridge.queueLimit) {
+      await this.sendKnowledgeIngestMarkdown(pending, "已达上限，请等待当前文件处理完成。");
+      return true;
+    }
+
+    const progressState = createKnowledgeIngestProgressState(sourceLabel);
+    const processing = await this.deps.sendPayload(message.chatId, buildKnowledgeIngestProcessingPayload(progressState), {
+      event: itemInput.kind === "web" ? "knowledge web ingest queued" : "knowledge ingest queued",
+      transcriptType: "outbound-final",
+      textPreview: sourceLabel,
+      len: sourceLabel.length,
+    }, this.getKnowledgeIngestDelivery(pending));
+    queue.pending.push({
+      ...itemInput,
+      processingMessageId: processing.messageId,
+      progressState,
+    });
+    this.refreshKnowledgeIngestPending(pending.conversationKey, pending);
+    await this.updateKnowledgeIngestSessionSummary(pending.conversationKey);
+    void this.processKnowledgeIngestQueue(pending.conversationKey);
+    return true;
+  }
+
+  private async processKnowledgeIngestQueue(conversationKey: string): Promise<void> {
+    const queue = this.knowledgeIngestQueues.get(conversationKey);
+    if (!queue || queue.active) {
+      return;
+    }
+    queue.active = true;
+    try {
+      let item = queue.pending.shift();
+      while (item) {
+        const currentItem = item;
+        const pending = this.getInteraction(conversationKey);
+        if (!pending || !this.deps.knowledge) {
+          break;
+        }
+        queue.currentLabel = getKnowledgeIngestQueueItemLabel(currentItem);
+        await this.updateKnowledgeIngestSessionSummary(conversationKey);
+        this.setRunningKnowledgeIngest(conversationKey, currentItem.requesterOpenId);
+        try {
+          if (currentItem.kind === "web") {
+            const result = await this.deps.knowledge.ingestWebPage!({
+              url: currentItem.url,
+              instruction: currentItem.instruction,
+              messageId: currentItem.messageId,
+            }, {
+              onProgress: async (update) => await this.updateKnowledgeIngestProgress(currentItem.chatId, currentItem.processingMessageId, currentItem.progressState, update),
+            });
+            this.refreshKnowledgeIngestPending(conversationKey, pending);
+            await this.deps.updatePayload(currentItem.chatId, currentItem.processingMessageId, buildKnowledgeIngestPayload(result), {
+              event: "knowledge web ingest updated",
+              transcriptType: "outbound-final",
+              textPreview: result.sourceFile,
+              len: result.sourceFile.length,
+            });
+            this.recordKnowledgeIngestResult(conversationKey, result);
+          } else {
+            const result = await this.deps.knowledge.ingestFile({
+              messageId: currentItem.messageId,
+              fileKey: currentItem.fileKey,
+              fileName: currentItem.fileName,
+              size: currentItem.size,
+            }, {
+              onProgress: async (update) => await this.updateKnowledgeIngestProgress(currentItem.chatId, currentItem.processingMessageId, currentItem.progressState, update),
+            });
+            this.refreshKnowledgeIngestPending(conversationKey, pending);
+            await this.deps.updatePayload(currentItem.chatId, currentItem.processingMessageId, buildKnowledgeIngestPayload(result), {
+              event: "knowledge ingest updated",
+              transcriptType: "outbound-final",
+              textPreview: result.sourceFile,
+              len: result.sourceFile.length,
+            });
+            this.recordKnowledgeIngestResult(conversationKey, result);
+          }
+        } catch (error) {
+          this.recordKnowledgeIngestFailure(conversationKey);
+          const detail = error instanceof Error ? error.message : String(error);
+          await this.deps.updatePayload(currentItem.chatId, currentItem.processingMessageId, buildNoticeCardPayload({
+            title: currentItem.kind === "web" ? "网页入库失败" : "知识入库失败",
+            template: "red",
+            iconToken: "error_filled",
+            message: detail,
+            messageIconToken: "error_filled",
+            messageIconColor: "red",
+            showMessageIcon: false,
+          }), {
+            event: currentItem.kind === "web" ? "knowledge web ingest failed" : "knowledge ingest failed",
+            transcriptType: "outbound-final",
+            textPreview: detail,
+            len: detail.length,
+          });
+        } finally {
+          this.clearRunningKnowledgeIngest(conversationKey);
+        }
+        queue.currentLabel = undefined;
+        await this.updateKnowledgeIngestSessionSummary(conversationKey);
+        item = queue.pending.shift();
+      }
+    } finally {
+      queue.active = false;
+      queue.currentLabel = undefined;
+      let shouldUpdateSummary = true;
+      if (queue.pending.length === 0) {
+        if (queue.closing) {
+          shouldUpdateSummary = false;
+          const pending = this.getInteraction(conversationKey);
+          if (pending) {
+            await this.sendKnowledgeIngestFinalSummary(pending);
+            await this.clearPending(conversationKey, pending.chatType);
+          } else {
+            this.knowledgeIngestQueues.delete(conversationKey);
+          }
+        } else {
+          this.knowledgeIngestQueues.delete(conversationKey);
+          shouldUpdateSummary = false;
+        }
+      }
+      if (shouldUpdateSummary) {
+        await this.updateKnowledgeIngestSessionSummary(conversationKey);
+      }
+    }
+  }
+
+  private getKnowledgeIngestQueue(conversationKey: string): KnowledgeIngestQueueState {
+    const existing = this.knowledgeIngestQueues.get(conversationKey);
+    if (existing) {
+      return existing;
+    }
+    const queue: KnowledgeIngestQueueState = { active: false, closing: false, pending: [] };
+    this.knowledgeIngestQueues.set(conversationKey, queue);
+    return queue;
+  }
+
+  private getKnowledgeIngestSessionStats(conversationKey: string): KnowledgeIngestSessionStats {
+    const existing = this.knowledgeIngestSessionStats.get(conversationKey);
+    if (existing) {
+      return existing;
+    }
+    const stats: KnowledgeIngestSessionStats = {
+      startedAt: Date.now(),
+      completedCount: 0,
+      failedCount: 0,
+      totalExtractedCount: 0,
+      totalDedupedCount: 0,
+    };
+    this.knowledgeIngestSessionStats.set(conversationKey, stats);
+    return stats;
+  }
+
+  private recordKnowledgeIngestResult(conversationKey: string, result: KnowledgeIngestResult): void {
+    const stats = this.getKnowledgeIngestSessionStats(conversationKey);
+    const rawExtractedCount = result.rawExtractedCount ?? result.extractedCount;
+    stats.completedCount += 1;
+    stats.totalExtractedCount += result.extractedCount;
+    stats.totalDedupedCount += result.dedupedCount ?? Math.max(0, rawExtractedCount - result.extractedCount);
+    stats.bitableUrl = result.bitableUrl ?? stats.bitableUrl;
+  }
+
+  private recordKnowledgeIngestFailure(conversationKey: string): void {
+    const stats = this.getKnowledgeIngestSessionStats(conversationKey);
+    stats.failedCount += 1;
+  }
+
+  private async updateKnowledgeIngestSessionSummary(conversationKey: string): Promise<void> {
+    const pending = this.getInteraction(conversationKey);
+    if (!pending) {
+      return;
+    }
+    const stats = this.getKnowledgeIngestSessionStats(conversationKey);
+    const queue = this.knowledgeIngestQueues.get(conversationKey);
+    await this.deps.updatePayload(pending.chatId, pending.anchorMessageId, buildKnowledgeIngestSessionPayload({
+      completedCount: stats.completedCount,
+      failedCount: stats.failedCount,
+      queuedCount: queue?.pending.length ?? 0,
+      currentLabel: queue?.currentLabel,
+      totalExtractedCount: stats.totalExtractedCount,
+      totalDedupedCount: stats.totalDedupedCount,
+      elapsedMs: Date.now() - stats.startedAt,
+      bitableUrl: stats.bitableUrl,
+    }), {
+      event: "knowledge ingest session summary updated",
+      transcriptType: "outbound-final",
+      textPreview: "知识入库会话汇总",
+      len: 10,
+    });
+  }
+
+  private async sendKnowledgeIngestFinalSummary(pending: PendingKnowledgeIngestInteraction): Promise<void> {
+    const stats = this.getKnowledgeIngestSessionStats(pending.conversationKey);
+    await this.deps.sendPayload(pending.chatId, buildKnowledgeIngestSessionFinalPayload({
+      completedCount: stats.completedCount,
+      failedCount: stats.failedCount,
+      queuedCount: 0,
+      totalExtractedCount: stats.totalExtractedCount,
+      totalDedupedCount: stats.totalDedupedCount,
+      elapsedMs: Date.now() - stats.startedAt,
+      bitableUrl: stats.bitableUrl,
+    }), {
+      event: "knowledge ingest session final summary sent",
+      transcriptType: "outbound-final",
+      textPreview: "知识入库完成汇总",
+      len: 10,
+    }, this.getKnowledgeIngestDelivery(pending));
+  }
+
+  private findKnowledgeIngestInteraction(message: IncomingChatMessage): PendingKnowledgeIngestInteraction | null {
+    const direct = this.getInteraction(message.conversationKey);
+    if (direct && this.isMessageInKnowledgeIngestChain(message, direct)) {
+      return direct;
+    }
+
+    for (const pending of this.interactions.values()) {
+      if (pending.conversationKey === message.conversationKey) {
+        continue;
+      }
+      if (this.isMessageInKnowledgeIngestChain(message, pending)) {
+        return pending;
+      }
+    }
+
+    return null;
+  }
+
+  private isMessageInKnowledgeIngestChain(message: IncomingChatMessage, pending: PendingKnowledgeIngestInteraction): boolean {
+    if (message.chatId !== pending.chatId) {
+      return false;
+    }
+    if (message.chatType === "p2p") {
+      return message.rootId === pending.anchorMessageId
+        || message.parentId === pending.anchorMessageId
+        || message.rootId === pending.rootMessageId
+        || message.parentId === pending.rootMessageId;
+    }
+    const candidates = new Set([
+      message.rootId,
+      message.parentId,
+      message.threadKey,
+    ].filter((value): value is string => Boolean(value)));
+    return message.conversationKey === pending.conversationKey
+      || candidates.has(pending.anchorMessageId)
+      || candidates.has(pending.rootMessageId);
+  }
+
+  private async endKnowledgeIngestInteraction(
+    message: Pick<IncomingChatMessage, "messageId" | "senderOpenId">,
+    pending: PendingKnowledgeIngestInteraction,
+    delivery?: { replyToMessageId: string },
+  ): Promise<void> {
+    if (pending.requesterOpenId !== message.senderOpenId) {
+      await this.deps.sendPayload(pending.chatId, buildNoticeCardPayload({
+        title: "无法结束入库模式",
+        template: "yellow",
+        iconToken: "maybe_outlined",
+        message: "当前入库模式仅允许发起人结束。",
+        messageIconToken: "maybe_outlined",
+        messageIconColor: "yellow",
+        showMessageIcon: false,
+      }), {
+        event: "knowledge ingest end rejected",
+        transcriptType: "outbound-final",
+        textPreview: "当前入库模式仅允许发起人结束。",
+        len: 16,
+      }, delivery ?? this.getKnowledgeIngestDelivery(pending));
+      return;
+    }
+    const queue = this.knowledgeIngestQueues.get(pending.conversationKey);
+    let endedImmediately = true;
+    if (queue && (queue.active || queue.pending.length > 0)) {
+      endedImmediately = false;
+      queue.closing = true;
+      await this.sendKnowledgeIngestMarkdown(pending, "已收到结束指令，将处理完当前队列后结束。");
+      await this.updateKnowledgeIngestSessionSummary(pending.conversationKey);
+    } else {
+      await this.sendKnowledgeIngestFinalSummary(pending);
+      await this.clearPending(pending.conversationKey, pending.chatType);
+    }
+    if (!delivery || !endedImmediately) {
+      return;
+    }
+    await this.deps.sendPayload(pending.chatId, buildNoticeCardPayload({
+      title: "已退出知识入库模式",
+      template: "green",
+      iconToken: "yes_filled",
+      message: "后续文件消息将不再自动入库；如需继续入库，请发送 `/kb-ingest-start`。",
+      messageIconToken: "yes_filled",
+      messageIconColor: "green",
+      showMessageIcon: false,
+    }), {
+      event: "knowledge ingest ended",
+      transcriptType: "outbound-final",
+      textPreview: "已退出知识入库模式",
+      len: 9,
+    }, delivery);
+  }
+
+  private setKnowledgeIngestInteraction(conversationKey: string, interaction: PendingKnowledgeIngestInteraction): void {
+    this.clearKnowledgeIngestInteraction(conversationKey, { keepActiveKnowledgeIngest: true });
+    this.interactions.set(conversationKey, interaction);
+    this.getKnowledgeIngestSessionStats(conversationKey);
+    const timer = setTimeout(() => {
+      void this.handleKnowledgeIngestTimeout(conversationKey, interaction);
+    }, Math.max(0, interaction.expiresAt - Date.now()));
+    this.timers.set(this.getKnowledgeIngestTimerKey(conversationKey), timer);
+    this.saveActiveKnowledgeIngest(interaction);
+  }
+
+  private clearKnowledgeIngestInteraction(
+    conversationKey: string,
+    options?: { keepActiveKnowledgeIngest?: boolean },
+  ): void {
+    const timerKey = this.getKnowledgeIngestTimerKey(conversationKey);
+    const timeout = this.timers.get(timerKey);
+    if (timeout) {
+      clearTimeout(timeout);
+      this.timers.delete(timerKey);
+    }
+    this.interactions.delete(conversationKey);
+    if (!options?.keepActiveKnowledgeIngest) {
+      this.deleteActiveKnowledgeIngest(conversationKey);
+    }
+  }
+
+  private getKnowledgeIngestTimerKey(conversationKey: string): string {
+    return `knowledge-ingest:${conversationKey}`;
+  }
+
+  private async handleKnowledgeIngestTimeout(conversationKey: string, pending: PendingKnowledgeIngestInteraction): Promise<void> {
+    const current = this.getInteraction(conversationKey);
+    if (
+      !current
+      || current.anchorMessageId !== pending.anchorMessageId
+      || current.expiresAt > Date.now()
+    ) {
+      return;
+    }
+    if (this.runningKnowledgeIngests.has(conversationKey)) {
+      this.refreshKnowledgeIngestPending(conversationKey, current);
+      return;
+    }
+    await this.sendKnowledgeIngestFinalSummary(current);
+    await this.clearPending(conversationKey, current.chatType);
+    await this.deps.sendPayload(current.chatId, buildNoticeCardPayload({
+      title: "入库任务已超时",
+      template: "yellow",
+      iconToken: "maybe_outlined",
+      message: "长时间未收到新的入库素材，已结束当前入库任务。需要继续时请重新发送 `/kb-ingest-start`。",
+      messageIconToken: "maybe_outlined",
+      messageIconColor: "yellow",
+      showMessageIcon: false,
+    }), {
+      event: "knowledge ingest timed out",
+      transcriptType: "outbound-final",
+      textPreview: "入库任务已超时",
+      len: 7,
+    }, this.getKnowledgeIngestDelivery(current));
+  }
+
+  private async sendKnowledgeIngestMarkdown(pending: PendingKnowledgeIngestInteraction, markdown: string): Promise<void> {
+    await this.deps.sendPayload(pending.chatId, buildPostMarkdownPayload(markdown), {
+      event: "knowledge ingest notice sent",
+      transcriptType: "outbound-final",
+      textPreview: createTextPreview(markdown),
+      len: markdown.length,
+    }, this.getKnowledgeIngestDelivery(pending));
+  }
+
+  private getKnowledgeIngestDelivery(pending: PendingKnowledgeIngestInteraction): { replyToMessageId: string; replyInThread: boolean } {
+    return {
+      replyToMessageId: pending.anchorMessageId,
+      replyInThread: pending.deliveryMode === "group_thread",
+    };
+  }
+
+  private setRunningKnowledgeIngest(conversationKey: string, requesterOpenId: string): void {
+    this.runningKnowledgeIngests.set(conversationKey, { requesterOpenId });
+  }
+
+  private clearRunningKnowledgeIngest(conversationKey: string): void {
+    this.runningKnowledgeIngests.delete(conversationKey);
+  }
+
+  private refreshKnowledgeIngestPending(
+    conversationKey: string,
+    pending: PendingKnowledgeIngestInteraction,
+  ): void {
+    const current = this.getInteraction(conversationKey);
+    if (!current || current.anchorMessageId !== pending.anchorMessageId) {
+      return;
+    }
+    this.setKnowledgeIngestInteraction(conversationKey, {
+      ...current,
+      expiresAt: Date.now() + this.deps.config.knowledgeBase.ingest.sessionIdleMs,
+    });
+  }
+
+  private saveActiveKnowledgeIngest(pending: PendingKnowledgeIngestInteraction): void {
+    this.activeKnowledgeIngestMap[pending.conversationKey] = {
+      chatId: pending.chatId,
+      chatType: pending.chatType,
+      conversationKey: pending.conversationKey,
+      requesterOpenId: pending.requesterOpenId,
+      rootMessageId: pending.rootMessageId,
+      anchorMessageId: pending.anchorMessageId,
+      deliveryMode: pending.deliveryMode,
+      ingestSessionId: pending.ingestSessionId,
+      previousActiveSessionId: pending.previousActiveSessionId,
+      expiresAt: pending.expiresAt,
+    };
+    void this.activeKnowledgeIngests.saveRecords(this.activeKnowledgeIngestMap).catch((error) => {
+      this.deps.logger.log("knowledge/ingest", "failed to persist active ingest", {
+        conversationKey: pending.conversationKey,
+        detail: error instanceof Error ? error.message : String(error),
+      }, "warn");
+    });
+  }
+
+  private deleteActiveKnowledgeIngest(conversationKey: string): void {
+    if (!(conversationKey in this.activeKnowledgeIngestMap)) {
+      return;
+    }
+    delete this.activeKnowledgeIngestMap[conversationKey];
+    void this.activeKnowledgeIngests.saveRecords(this.activeKnowledgeIngestMap).catch((error) => {
+      this.deps.logger.log("knowledge/ingest", "failed to clear active ingest", {
+        conversationKey,
+        detail: error instanceof Error ? error.message : String(error),
+      }, "warn");
+    });
+  }
+
+  private async restorePreviousSessionForBackgroundIngest(
+    conversationKey: string,
+    chatType: string,
+    pending: Pick<PendingKnowledgeIngestInteraction, "previousActiveSessionId">,
+  ): Promise<void> {
+    if (!pending.previousActiveSessionId) {
+      return;
+    }
+    const window = this.deps.getSessionWindow(conversationKey, chatType);
+    if (window.activeSessionId === pending.previousActiveSessionId) {
+      return;
+    }
+    if (!window.sessions.some((session) => session.sessionId === pending.previousActiveSessionId)) {
+      return;
+    }
+    const nextWindow = setActiveSession(
+      window,
+      pending.previousActiveSessionId,
+      Date.now(),
+      this.deps.config.bridge.maxSessionsPerWindow,
+    );
+    await this.deps.saveSessionWindow(conversationKey, nextWindow);
+  }
+
+  private async restoreOrCreateNormalSessionForBackgroundIngest(
+    message: Pick<IncomingChatMessage, "chatId" | "chatType" | "conversationKey" | "threadKey">,
+    pending: Pick<PendingKnowledgeIngestInteraction, "previousActiveSessionId" | "ingestSessionId">,
+  ): Promise<void> {
+    if (pending.previousActiveSessionId) {
+      await this.restorePreviousSessionForBackgroundIngest(message.conversationKey, message.chatType, pending);
+      return;
+    }
+    if (!pending.ingestSessionId) {
+      return;
+    }
+    const window = this.deps.getSessionWindow(message.conversationKey, message.chatType);
+    if (window.activeSessionId !== pending.ingestSessionId) {
+      return;
+    }
+    await this.deps.createAndBindSession(message);
+  }
+
+  private async interruptPersistedKnowledgeIngests(): Promise<void> {
+    const records = Object.values(this.activeKnowledgeIngestMap);
+    if (records.length === 0) {
+      return;
+    }
+
+    for (const record of records) {
+      await this.restorePreviousSessionForBackgroundIngest(record.conversationKey, record.chatType, record).catch((error) => {
+        this.deps.logger.log("knowledge/ingest", "failed to restore interrupted ingest session", {
+          conversationKey: record.conversationKey,
+          detail: error instanceof Error ? error.message : String(error),
+        }, "warn");
+      });
+      await this.deps.sendPayload(record.chatId, buildNoticeCardPayload({
+        title: "入库任务已中断",
+        template: "yellow",
+        iconToken: "maybe_outlined",
+        message: "入库任务因服务重启中断，请重新发送 `/kb-ingest-start`。",
+        messageIconToken: "maybe_outlined",
+        messageIconColor: "yellow",
+        showMessageIcon: false,
+      }), {
+        event: "knowledge ingest interrupted",
+        transcriptType: "outbound-final",
+        textPreview: "入库任务因服务重启中断",
+        len: 12,
+      }, {
+        replyToMessageId: record.anchorMessageId,
+        replyInThread: record.deliveryMode === "group_thread",
+      }).catch((error) => {
+        this.deps.logger.log("knowledge/ingest", "failed to notify interrupted ingest", {
+          conversationKey: record.conversationKey,
+          detail: error instanceof Error ? error.message : String(error),
+        }, "warn");
+      });
+    }
+
+    this.activeKnowledgeIngestMap = {};
+    await this.activeKnowledgeIngests.saveRecords(this.activeKnowledgeIngestMap);
+  }
+
+  private async updateKnowledgeIngestProgress(
+    chatId: string,
+    messageId: string,
+    state: KnowledgeIngestProgressState,
+    update: KnowledgeIngestProgressUpdate,
+  ): Promise<void> {
+    applyKnowledgeIngestProgress(state, update);
+    const payload = buildKnowledgeIngestProcessingPayload(state);
+    try {
+      await this.deps.updatePayload(chatId, messageId, payload, {
+        event: "knowledge ingest progress updated",
+        transcriptType: "outbound-final",
+        textPreview: `${state.sourceLabel} ${state.steps.map((step) => `${step.label}:${step.detail}`).join(" | ")}`,
+        len: state.steps.map((step) => `${step.label}:${step.detail}`).join("\n").length,
+      });
+    } catch (error) {
+      this.deps.logger.log("feishu/reply", "knowledge ingest progress update failed", {
+        chatId,
+        messageId,
+        detail: error instanceof Error ? error.message : String(error),
+      }, "warn");
+    }
+  }
+
+  private async sendNotice(
+    message: Pick<IncomingChatMessage, "chatId" | "messageId">,
+    input: {
+      title: string;
+      template: "blue" | "green" | "red" | "wathet" | "grey" | "orange" | "yellow" | "purple" | "indigo";
+      icon: string;
+      message: string;
+    },
+  ): Promise<void> {
+    await this.deps.sendPayload(message.chatId, buildNoticeCardPayload({
+      title: input.title,
+      template: input.template,
+      iconToken: input.icon,
+      message: input.message,
+      messageIconToken: input.icon,
+      messageIconColor: input.template === "red"
+        ? "red"
+        : input.template === "green"
+          ? "green"
+          : input.template === "yellow"
+            ? "yellow"
+            : input.template === "indigo"
+              ? "indigo"
+              : "blue",
+      showMessageIcon: false,
+    }), {
+      event: "final message sent",
+      transcriptType: "outbound-final",
+      textPreview: input.title,
+      len: input.title.length,
+    }, { replyToMessageId: message.messageId });
+  }
+}
+
+type KnowledgeIngestProgressState = {
+  sourceLabel: string;
+  steps: ToolUpdateView[];
+};
+
+function createKnowledgeIngestProgressState(sourceLabel: string): KnowledgeIngestProgressState {
+  return {
+    sourceLabel,
+    steps: [
+      { label: "读取内容", detail: "等待开始", status: "pending" },
+      { label: "提取问答", detail: "等待开始", status: "pending" },
+      { label: "写入知识库", detail: "等待开始", status: "pending" },
+    ],
+  };
+}
+
+function getKnowledgeIngestQueueItemLabel(item: KnowledgeIngestQueueItem): string {
+  return item.kind === "web" ? item.url : item.fileName;
+}
+
+function applyKnowledgeIngestProgress(state: KnowledgeIngestProgressState, update: KnowledgeIngestProgressUpdate): void {
+  const label = mapKnowledgeProgressLabel(update.step);
+  const step = state.steps.find((item) => item.label === label);
+  if (!step) {
+    return;
+  }
+  step.status = update.status;
+  if (update.detail) {
+    step.detail = update.detail;
+  } else if (update.status === "completed") {
+    step.detail = "已完成";
+  } else if (update.status === "running") {
+    step.detail = "处理中";
+  } else if (update.status === "error") {
+    step.detail = "执行失败";
+  }
+}
+
+function mapKnowledgeProgressLabel(step: KnowledgeIngestProgressStep): ToolUpdateView["label"] {
+  switch (step) {
+    case "read":
+      return "读取内容";
+    case "extract":
+      return "提取问答";
+    case "write":
+      return "写入知识库";
+  }
+}

--- a/src/memory/runtime-module.ts
+++ b/src/memory/runtime-module.ts
@@ -1,0 +1,32 @@
+import type { RuntimeModule, RuntimeModuleAfterTurnContext, RuntimeModuleBeforeTurnContext } from "../bridge/module.js";
+import type { MemoryService } from "./index.js";
+
+export class MemoryRuntimeModule implements RuntimeModule {
+  readonly name = "memory";
+  readonly priority = 30;
+
+  constructor(private readonly memory: MemoryService) {}
+
+  async start(): Promise<void> {
+    await this.memory.start();
+  }
+
+  async stop(): Promise<void> {
+    await this.memory.stop();
+  }
+
+  async beforeTurn(context: RuntimeModuleBeforeTurnContext): Promise<{ systemBlocks?: string[] } | void> {
+    const recallBlock = await this.memory.buildRecallBlock(context.turn.senderOpenId, context.turn.plainText);
+    if (!recallBlock.trim()) {
+      return;
+    }
+    return { systemBlocks: [recallBlock] };
+  }
+
+  async afterTurn(context: RuntimeModuleAfterTurnContext): Promise<void> {
+    if (!context.reply.trim()) {
+      return;
+    }
+    this.memory.enqueueLearn(context.turn.senderOpenId, context.turn.plainText, context.reply);
+  }
+}

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -1,32 +1,24 @@
 import { QueueRegistry } from "../bridge/queue.js";
 import { type PendingInteraction, type PendingKnowledgeIngestInteraction, type PendingPermissionInteraction } from "../bridge/state.js";
+import { ModuleManager } from "../bridge/module.js";
 import { routeIncomingText, type RoutedText } from "../bridge/router.js";
 import type { BridgeTurn } from "../bridge/turn.js";
 import {
-  buildKnowledgeIngestProcessingPayload,
-  buildKnowledgeIngestPayload,
-  buildKnowledgeIngestSessionFinalPayload,
-  buildKnowledgeIngestSessionPayload,
-  buildKnowledgeQueryEmptyPayload,
-  buildKnowledgeQueryPayload,
   buildNoticeCardPayload,
   buildPostMarkdownPayload,
   buildQueueNoticePayload,
   type FeishuPostPayload,
-  type ToolUpdateView,
   toInteractiveCardContent,
 } from "../feishu/formatter.js";
 import { createTextPreview, type Logger, type TranscriptType } from "../logging/logger.js";
-import { detectKnowledgeWebIngest, detectLegalQuestion } from "../knowledge/detector.js";
 import {
   KnowledgeBaseService,
   type KnowledgeBasePort,
-  type KnowledgeIngestResult,
-  type KnowledgeIngestProgressStep,
-  type KnowledgeIngestProgressUpdate,
 } from "../knowledge/index.js";
 import { parseKnowledgeFile } from "../knowledge/parser.js";
+import { KnowledgeRuntimeModule } from "../knowledge/runtime-module.js";
 import { MemoryService } from "../memory/index.js";
+import { MemoryRuntimeModule } from "../memory/runtime-module.js";
 import {
   OpenCodeClient,
   type OpenCodeSession,
@@ -34,7 +26,6 @@ import {
 } from "../opencode/client.js";
 import { getEventSessionId, OpenCodeEventStream, type OpenCodeEvent } from "../opencode/events.js";
 import { MappingStore, type MappingRecord, type SessionBindingRecord, type SessionWindowRecord } from "../store/mappings.js";
-import { ActiveKnowledgeIngestStore, type ActiveKnowledgeIngestRecordMap } from "../store/active-ingests.js";
 import type { WhitelistStore } from "../store/whitelist.js";
 import type { AppConfig } from "../config/schema.js";
 import {
@@ -49,7 +40,7 @@ import {
   toOpencodePromptText,
 } from "./app-helpers.js";
 import { PermissionManager } from "./permission-manager.js";
-import { CommandHandler } from "./command-handler.js";
+import { CommandHandler, isBridgeOwnedCommand } from "./command-handler.js";
 import { TurnCardManager } from "./turn-card-manager.js";
 import { TurnExecutor } from "./turn-executor.js";
 import { SlidingWindowRateLimiter } from "./rate-limiter.js";
@@ -135,6 +126,8 @@ type OpenCodePort = Pick<OpenCodeClient,
 
 type OpenCodeEventStreamPort = Pick<OpenCodeEventStream, "start" | "stop" | "subscribe" | "getConnectionState">;
 
+const REGULAR_FILE_ALLOWED_EXTENSIONS = [".pdf", ".docx", ".txt", ".md"] as const;
+
 export type PermissionCardActionValue = {
   kind: "permission";
   conversationKey: string;
@@ -145,61 +138,20 @@ export type PermissionCardActionValue = {
   nonce: string;
 };
 
-type KnowledgeIngestQueueItem = {
-  conversationKey: string;
-  chatId: string;
-  requesterOpenId: string;
-  processingMessageId: string;
-  progressState: KnowledgeIngestProgressState;
-} & (
-  | {
-    kind: "file";
-    messageId: string;
-    fileKey: string;
-    fileName: string;
-    size?: number | undefined;
-  }
-  | {
-    kind: "web";
-    messageId: string;
-    url: string;
-    instruction: string;
-  }
-);
-
-type KnowledgeIngestQueueState = {
-  active: boolean;
-  closing: boolean;
-  currentLabel?: string | undefined;
-  pending: KnowledgeIngestQueueItem[];
-};
-
-type KnowledgeIngestSessionStats = {
-  startedAt: number;
-  completedCount: number;
-  failedCount: number;
-  totalExtractedCount: number;
-  totalDedupedCount: number;
-  bitableUrl?: string | undefined;
-};
-
 export class BridgeApp {
   private readonly queues: QueueRegistry;
   private readonly mappings: MappingStore;
-  private readonly activeKnowledgeIngests: ActiveKnowledgeIngestStore;
   private readonly opencode: OpenCodePort;
   private readonly eventStream: OpenCodeEventStreamPort;
   private readonly permissionManager: PermissionManager;
   private readonly turnCardManager: TurnCardManager;
   private readonly turnExecutor: TurnExecutor;
+  private readonly moduleManager: ModuleManager;
+  private readonly knowledgeModule: KnowledgeRuntimeModule;
   private readonly rateLimiter = new SlidingWindowRateLimiter(20, 60_000);
   private sessionMap: MappingRecord = {};
-  private activeKnowledgeIngestMap: ActiveKnowledgeIngestRecordMap = {};
   private readonly runningChats = new Map<string, Promise<void>>();
-  private readonly runningKnowledgeIngests = new Map<string, { requesterOpenId: string }>();
-  private readonly knowledgeIngestQueues = new Map<string, KnowledgeIngestQueueState>();
-  private readonly knowledgeIngestSessionStats = new Map<string, KnowledgeIngestSessionStats>();
-  private readonly knowledgeIngestInteractions = new Map<string, PendingKnowledgeIngestInteraction>();
+  private readonly knowledgeIngestInteractions: Map<string, PendingKnowledgeIngestInteraction>;
   private readonly pendingInteractions = new Map<string, PendingInteraction>();
   private readonly pendingInteractionTimers = new Map<string, NodeJS.Timeout>();
   private readonly sessionStatuses = new Map<string, OpenCodeSessionStatus>();
@@ -216,7 +168,6 @@ export class BridgeApp {
   ) {
     this.queues = new QueueRegistry(config.bridge.queueLimit, logger);
     this.mappings = new MappingStore(config.storage.dataDir, config.storage.mappingsFile, 200, logger);
-    this.activeKnowledgeIngests = new ActiveKnowledgeIngestStore(config.storage.dataDir);
     this.opencode = deps?.opencode ?? new OpenCodeClient(config.opencode.baseUrl);
     this.eventStream = deps?.eventStream ?? new OpenCodeEventStream(config.opencode.baseUrl, logger);
     this.memory = deps && "memory" in deps
@@ -256,6 +207,23 @@ export class BridgeApp {
       toCardContent: (payload) => this.toCardContent(payload),
     });
     this.turnCardManager = new TurnCardManager(this.outbound, this.logger, this.config.feishu.behavior.replyInThread);
+    this.moduleManager = new ModuleManager();
+    this.knowledgeModule = new KnowledgeRuntimeModule({
+      config: this.config,
+      logger: this.logger,
+      knowledge: this.knowledge,
+      sendPayload: async (chatId, payload, options, delivery) => await this.sendPayload(chatId, payload, options, delivery),
+      updatePayload: async (chatId, messageId, payload, options) => await this.updatePayload(chatId, messageId, payload, options),
+      getSessionWindow: (conversationKey, chatType) => this.getSessionWindow(conversationKey, chatType),
+      saveSessionWindow: async (conversationKey, window) => await this.saveSessionWindow(conversationKey, window),
+      createAndBindSession: async (source) => await this.createAndBindSession(source),
+      whitelistBind: async (chatId, openId) => await this.whitelist.bind(chatId, openId),
+    });
+    this.knowledgeIngestInteractions = this.knowledgeModule.interactions;
+    this.moduleManager.register(this.knowledgeModule);
+    if (this.memory) {
+      this.moduleManager.register(new MemoryRuntimeModule(this.memory));
+    }
     this.turnExecutor = new TurnExecutor({
       config: this.config,
       logger: this.logger,
@@ -265,7 +233,7 @@ export class BridgeApp {
       sessionStatuses: this.sessionStatuses,
       turnCardManager: this.turnCardManager,
       permissionManager: this.permissionManager,
-      memory: this.memory,
+      moduleManager: this.moduleManager,
       getSessionWindow: (conversationKey, chatType) => this.getSessionWindow(conversationKey, chatType),
       ensureSession: async (source) => await this.ensureSession(source),
       maybeUpdateSessionLabel: async (turn) => await this.maybeUpdateSessionLabel(turn),
@@ -278,24 +246,13 @@ export class BridgeApp {
 
   async start(): Promise<void> {
     this.sessionMap = await this.mappings.load();
-    this.activeKnowledgeIngestMap = await this.activeKnowledgeIngests.load();
     const health = await this.opencode.health();
     const project = await this.opencode.getCurrentProject();
     if (project.worktree !== this.config.opencode.directory) {
       throw new Error(`opencode serve 当前在 ${project.worktree}，bridge 配置的是 ${this.config.opencode.directory}，请在正确目录重启 opencode serve`);
     }
     await this.syncStoredSessionLabels();
-    await this.interruptPersistedKnowledgeIngests();
-    await this.memory?.start();
-    if (this.knowledge) {
-      try {
-        await this.knowledge.syncMirror();
-      } catch (error) {
-        this.logger.log("knowledge/sync", "mirror sync skipped", {
-          detail: error instanceof Error ? error.message : String(error),
-        }, "warn");
-      }
-    }
+    await this.moduleManager.start();
 
     await this.eventStream.start();
     this.globalEventUnsubscribe = this.eventStream.subscribe(async (event) => {
@@ -318,8 +275,7 @@ export class BridgeApp {
     }
     this.pendingInteractionTimers.clear();
     this.turnCardManager.stop();
-    await this.memory?.stop();
-    this.knowledge?.close();
+    await this.moduleManager.stop();
     await this.eventStream.stop();
   }
 
@@ -365,42 +321,52 @@ export class BridgeApp {
     const routed = message.messageType === "file"
       ? null
       : routeIncomingText(message.plainText);
-    const activeKnowledgeIngest = this.findKnowledgeIngestInteraction(message);
-    if (activeKnowledgeIngest) {
-      if (routed?.kind === "command" && routed.command.kind === "knowledge-ingest-end") {
-        await this.endKnowledgeIngestInteraction(message, activeKnowledgeIngest);
-        return;
-      }
-
-      const consumed = await this.handlePendingInteraction(message, activeKnowledgeIngest);
-      if (consumed) return;
-    }
-
     if (routed?.kind === "command") {
-      const backgroundKnowledgeIngest = this.getKnowledgeIngestInteraction(message.conversationKey);
-      if (
-        routed.command.kind === "knowledge-ingest-end"
-        && backgroundKnowledgeIngest?.kind === "knowledge-ingest-await-file"
-      ) {
-        await this.endKnowledgeIngestInteraction(message, backgroundKnowledgeIngest, { replyToMessageId: message.messageId });
-        return;
-      }
       await this.handleCommand(message, routed);
       return;
     }
 
     const pending = this.pendingInteractions.get(message.conversationKey);
-    const backgroundKnowledgeIngest = this.getKnowledgeIngestInteraction(message.conversationKey);
-    if (backgroundKnowledgeIngest) {
-      await this.restoreOrCreateNormalSessionForBackgroundIngest(message, backgroundKnowledgeIngest);
+    if (pending && this.isCorePendingInteraction(pending)) {
+      const consumed = await this.handlePendingInteraction(message, pending);
+      if (consumed) {
+        return;
+      }
     }
 
-    if (pending) {
-      const consumed = await this.handlePendingInteraction(message, pending);
-      if (consumed) return;
+    const moduleResult = await this.moduleManager.handleMessage({ message, routed, pendingInteraction: pending ?? null });
+    if (moduleResult.claimed) {
+      return;
+    }
+
+    if (pending?.kind === "file-await-instruction") {
+      const consumed = await this.handleFileInstructionPending(message, pending);
+      if (consumed) {
+        return;
+      }
     }
 
     if (message.messageType === "file") {
+      try {
+        this.validateRegularFileInput(message.file.fileName, message.file.size);
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        await this.sendPayload(message.chatId, buildNoticeCardPayload({
+          title: "文件暂不支持",
+          template: "red",
+          iconToken: "error_filled",
+          message: detail,
+          messageIconToken: "error_filled",
+          messageIconColor: "red",
+          showMessageIcon: false,
+        }), {
+          event: "file rejected",
+          transcriptType: "outbound-final",
+          textPreview: detail,
+          len: detail.length,
+        }, { replyToMessageId: message.messageId });
+        return;
+      }
       this.setPendingInteraction(message.conversationKey, {
         kind: "file-await-instruction",
         chatId: message.chatId,
@@ -434,76 +400,6 @@ export class BridgeApp {
         len: 14,
       }, { replyToMessageId: message.messageId });
       return;
-    }
-
-    const window = this.getSessionWindow(message.conversationKey, message.chatType);
-    const knowledgeModeDetection = window.interactionMode === "knowledge"
-      ? detectLegalQuestion(message.plainText)
-      : null;
-    if (
-      this.knowledge
-      && window.interactionMode === "knowledge"
-      && knowledgeModeDetection?.matched
-      && knowledgeModeDetection.confidence >= this.config.knowledgeBase.autoDetect.minConfidence
-    ) {
-      try {
-        const result = await this.knowledge.query(message.plainText);
-        await this.sendPayload(
-          message.chatId,
-          result.results.length > 0 ? buildKnowledgeQueryPayload(result) : buildKnowledgeQueryEmptyPayload(message.plainText),
-          {
-            event: "knowledge query sent",
-            transcriptType: "outbound-final",
-            textPreview: message.plainText,
-            len: message.plainText.length,
-          },
-          { replyToMessageId: message.messageId },
-        );
-      } catch (error) {
-        const detail = error instanceof Error ? error.message : String(error);
-        await this.sendPayload(message.chatId, buildNoticeCardPayload({
-          title: "知识检索失败",
-          template: "red",
-          iconToken: "error_filled",
-          message: detail,
-          messageIconToken: "error_filled",
-          messageIconColor: "red",
-        }), {
-          event: "knowledge query failed",
-          transcriptType: "outbound-final",
-          textPreview: detail,
-          len: detail.length,
-        }, { replyToMessageId: message.messageId });
-      }
-      return;
-    }
-
-    if (this.knowledge && this.config.knowledgeBase.autoDetect.enabled) {
-      const detection = detectLegalQuestion(message.plainText);
-      if (detection.matched && detection.confidence >= this.config.knowledgeBase.autoDetect.minConfidence) {
-        try {
-          const result = await this.knowledge.query(message.plainText);
-          if (result.results.length > 0) {
-            await this.sendPayload(
-              message.chatId,
-              buildKnowledgeQueryPayload(result),
-              {
-                event: "knowledge query sent",
-                transcriptType: "outbound-final",
-                textPreview: message.plainText,
-                len: message.plainText.length,
-              },
-              { replyToMessageId: message.messageId },
-            );
-            return;
-          }
-        } catch (error) {
-          this.logger.log("knowledge/query", "auto-detect query failed", {
-            detail: error instanceof Error ? error.message : String(error),
-            confidence: detection.confidence,
-          }, "warn");
-        }
-      }
     }
 
     if (!await this.ensureServerAvailableForMessage(message)) {
@@ -565,33 +461,33 @@ export class BridgeApp {
     message: Pick<IncomingChatMessage, "chatId" | "chatType" | "messageId" | "conversationKey" | "threadKey" | "senderOpenId">,
     routed: Extract<RoutedText, { kind: "command" }>,
   ): Promise<void> {
-    return new CommandHandler({
-      config: this.config,
-      opencode: this.opencode,
-      whitelist: this.whitelist,
-      queues: this.queues,
-      eventStream: this.eventStream,
-      sessionStatuses: this.sessionStatuses,
-      pendingInteractions: this.pendingInteractions,
-      permissionManager: this.permissionManager,
-      knowledge: this.knowledge,
-      getSessionWindow: (conversationKey, chatType) => this.getSessionWindow(conversationKey, chatType),
-      createAndBindSession: async (source) => await this.createAndBindSession(source),
-      sendPayload: async (chatId, payload, options, delivery) => await this.sendPayload(chatId, payload, options, delivery),
-      sendMarkdown: async (chatId, markdown, replyToMessageId) => await this.sendMarkdown(chatId, markdown, replyToMessageId),
-      setPendingInteraction: (conversationKey, interaction) => this.setPendingInteraction(conversationKey, interaction),
-      clearPendingInteraction: (conversationKey, keepNonExpiring) => this.clearPendingInteraction(conversationKey, keepNonExpiring),
-      getKnowledgeIngestInteraction: (conversationKey) => this.getKnowledgeIngestInteraction(conversationKey),
-      clearKnowledgeIngestPending: async (conversationKey, chatType) => await this.clearKnowledgeIngestPending(conversationKey, chatType),
-      listOpenCodeSessionsById: async () => await this.listOpenCodeSessionsById(),
-      saveSessionWindow: async (conversationKey, window) => await this.saveSessionWindow(conversationKey, window),
-      getSessionMessageCount: async (sessionId) => await this.getSessionMessageCount(sessionId),
-      isSessionBusy: (conversationKey, sessionId) => this.isSessionBusy(conversationKey, sessionId),
-      whitelistBind: async (chatId, openId) => await this.whitelist.bind(chatId, openId),
-      resolveSessionCommandTarget: async (msg, index) => await this.resolveSessionCommandTarget(msg, index),
-      resolveSessionCommandTargets: async (msg, range) => await this.resolveSessionCommandTargets(msg, range),
-      ensureSession: async (source: Pick<IncomingChatMessage, "chatId" | "chatType" | "conversationKey" | "threadKey">) => await this.ensureSession(source),
-    }).handleCommand(message, routed);
+    if (isBridgeOwnedCommand(routed.command)) {
+      return await new CommandHandler({
+        config: this.config,
+        opencode: this.opencode,
+        whitelist: this.whitelist,
+        queues: this.queues,
+        eventStream: this.eventStream,
+        sessionStatuses: this.sessionStatuses,
+        pendingInteractions: this.pendingInteractions,
+        permissionManager: this.permissionManager,
+        getSessionWindow: (conversationKey, chatType) => this.getSessionWindow(conversationKey, chatType),
+        createAndBindSession: async (source) => await this.createAndBindSession(source),
+        sendPayload: async (chatId, payload, options, delivery) => await this.sendPayload(chatId, payload, options, delivery),
+        sendMarkdown: async (chatId, markdown, replyToMessageId) => await this.sendMarkdown(chatId, markdown, replyToMessageId),
+        setPendingInteraction: (conversationKey, interaction) => this.setPendingInteraction(conversationKey, interaction),
+        clearPendingInteraction: (conversationKey, keepNonExpiring) => this.clearPendingInteraction(conversationKey, keepNonExpiring),
+        listOpenCodeSessionsById: async () => await this.listOpenCodeSessionsById(),
+        saveSessionWindow: async (conversationKey, window) => await this.saveSessionWindow(conversationKey, window),
+        getSessionMessageCount: async (sessionId) => await this.getSessionMessageCount(sessionId),
+        isSessionBusy: (conversationKey, sessionId) => this.isSessionBusy(conversationKey, sessionId),
+        resolveSessionCommandTarget: async (msg, index) => await this.resolveSessionCommandTarget(msg, index),
+        resolveSessionCommandTargets: async (msg, range) => await this.resolveSessionCommandTargets(msg, range),
+        ensureSession: async (source: Pick<IncomingChatMessage, "chatId" | "chatType" | "conversationKey" | "threadKey">) => await this.ensureSession(source),
+      }).handleCommand(message, routed);
+    }
+
+    await this.moduleManager.handleMessage({ message: message as IncomingChatMessage, routed });
   }
 
   private async handlePendingInteraction(message: IncomingChatMessage, pending: PendingInteraction): Promise<boolean> {
@@ -631,339 +527,94 @@ export class BridgeApp {
       return true;
     }
 
-    if (pending.kind === "knowledge-ingest-await-file") {
-      return await this.enqueueKnowledgeIngestInput(message, pending);
-    }
-
-    if (pending.kind === "file-await-instruction") {
-      if (message.senderOpenId !== pending.requesterOpenId) {
-        await this.sendMarkdown(message.chatId, "当前文件处理仅允许文件发送者继续说明需求。", message.messageId);
-        return true;
-      }
-      if (message.messageType === "file") {
-        await this.sendMarkdown(message.chatId, "已收到上一个文件，请先发送文字说明你希望我如何处理；如需入库，请发送 `/kb-ingest-start`。", message.messageId);
-        return true;
-      }
-      const instruction = message.plainText.trim();
-      if (!instruction) {
-        await this.sendMarkdown(message.chatId, "请发送文字说明你希望我如何处理这个文件。", message.messageId);
-        return true;
-      }
-      const processed = await this.prepareFileForOpenCodeTurn(pending, instruction, message.messageId).catch(async (error) => {
-        const detail = error instanceof Error ? error.message : String(error);
-        await this.sendPayload(message.chatId, buildNoticeCardPayload({
-          title: "文件读取失败",
-          template: "red",
-          iconToken: "error_filled",
-          message: detail,
-          messageIconToken: "error_filled",
-          messageIconColor: "red",
-          showMessageIcon: false,
-        }), {
-          event: "file instruction failed",
-          transcriptType: "outbound-final",
-          textPreview: detail,
-          len: detail.length,
-        }, { replyToMessageId: message.messageId });
-        return null;
-      });
-      if (!processed) {
-        this.clearPendingInteraction(message.conversationKey, false);
-        return true;
-      }
-      this.clearPendingInteraction(message.conversationKey, false);
-      if (!await this.ensureServerAvailableForMessage(message)) {
-        return true;
-      }
-      const queue = this.queues.get(message.conversationKey);
-      const turn: BridgeTurn = {
-        turnId: crypto.randomUUID(),
-        chatId: message.chatId,
-        conversationKey: message.conversationKey,
-        threadKey: message.threadKey,
-        chatType: message.chatType,
-        senderOpenId: message.senderOpenId,
-        inboundMessageId: message.messageId,
-        plainText: `${instruction}\n\n[文件] ${pending.file.fileName}`,
-        text: processed.prompt,
-      };
-      const result = queue.enqueue(turn);
-      if (!result.accepted) {
-        await this.sendPayload(message.chatId, buildQueueNoticePayload(result.notice ?? { message: "当前不可用。" }), {
-          event: "final message sent",
-          transcriptType: "outbound-final",
-          textPreview: result.notice?.message ?? "当前不可用。",
-          len: (result.notice?.message ?? "当前不可用。").length,
-        }, { replyToMessageId: message.messageId });
-        return true;
-      }
-      if (!this.runningChats.has(message.conversationKey)) {
-        const runner = this.processChat(message.conversationKey).finally(() => {
-          this.runningChats.delete(message.conversationKey);
-        });
-        this.runningChats.set(message.conversationKey, runner);
-        await runner;
-      }
-      return true;
-    }
-
     return false;
   }
 
-  private async enqueueKnowledgeIngestInput(message: IncomingChatMessage, pending: PendingKnowledgeIngestInteraction): Promise<boolean> {
+  private isCorePendingInteraction(pending: PendingInteraction): boolean {
+    return pending.kind === "question" || pending.kind === "permission";
+  }
+
+  private async handleFileInstructionPending(
+    message: IncomingChatMessage,
+    pending: Extract<PendingInteraction, { kind: "file-await-instruction" }>,
+  ): Promise<boolean> {
     if (message.senderOpenId !== pending.requesterOpenId) {
-      await this.sendKnowledgeIngestMarkdown(pending, "当前入库任务仅允许发起人继续上传文件。");
+      await this.sendMarkdown(message.chatId, "当前文件处理仅允许文件发送者继续说明需求。", message.messageId);
       return true;
     }
-    if (!this.knowledge) {
-      await this.sendKnowledgeIngestMarkdown(pending, "当前未启用法律知识库，请联系部署者补充 knowledgeBase 配置。");
-      return true;
-    }
-
-    let sourceLabel: string;
-    let itemInput:
-      | Omit<Extract<KnowledgeIngestQueueItem, { kind: "file" }>, "processingMessageId" | "progressState">
-      | Omit<Extract<KnowledgeIngestQueueItem, { kind: "web" }>, "processingMessageId" | "progressState">;
     if (message.messageType === "file") {
-      sourceLabel = message.file.fileName;
-      itemInput = {
-        kind: "file",
-        conversationKey: pending.conversationKey,
-        chatId: message.chatId,
-        requesterOpenId: pending.requesterOpenId,
-        messageId: message.messageId,
-        fileKey: message.file.fileKey,
-        fileName: message.file.fileName,
-        size: message.file.size,
-      };
-    } else {
-      const webIngest = detectKnowledgeWebIngest(message.plainText, { requireIngestIntent: false });
-      if (!webIngest.matched || !webIngest.url || !this.knowledge.ingestWebPage) {
-        await this.sendKnowledgeIngestMarkdown(pending, "请继续上传 PDF / DOCX / TXT / MD 文件，或直接发送网页 URL / 带 URL 的入库请求；发送 `/kb-ingest-end` 退出。");
-        return true;
-      }
-      sourceLabel = webIngest.url;
-      itemInput = {
-        kind: "web",
-        conversationKey: pending.conversationKey,
-        chatId: message.chatId,
-        requesterOpenId: pending.requesterOpenId,
-        messageId: message.messageId,
-        url: webIngest.url,
-        instruction: message.plainText,
-      };
-    }
-
-    const queue = this.getKnowledgeIngestQueue(pending.conversationKey);
-    if (queue.closing) {
-      await this.sendKnowledgeIngestMarkdown(pending, "已收到结束指令，当前队列处理完成后会自动结束。");
+      await this.sendMarkdown(message.chatId, "已收到上一个文件，请先发送文字说明你希望我如何处理；如需入库，请发送 `/kb-ingest-start`。", message.messageId);
       return true;
     }
-    const queuedCount = queue.pending.length + (queue.active ? 1 : 0);
-    if (queuedCount >= this.config.bridge.queueLimit) {
-      await this.sendKnowledgeIngestMarkdown(pending, "已达上限，请等待当前文件处理完成。");
+    const instruction = message.plainText.trim();
+    if (!instruction) {
+      await this.sendMarkdown(message.chatId, "请发送文字说明你希望我如何处理这个文件。", message.messageId);
       return true;
     }
-
-    const progressState = createKnowledgeIngestProgressState(sourceLabel);
-    const processing = await this.sendPayload(message.chatId, buildKnowledgeIngestProcessingPayload(progressState), {
-      event: itemInput.kind === "web" ? "knowledge web ingest queued" : "knowledge ingest queued",
-      transcriptType: "outbound-final",
-      textPreview: sourceLabel,
-      len: sourceLabel.length,
-    }, this.getKnowledgeIngestDelivery(pending));
-    queue.pending.push({
-      ...itemInput,
-      processingMessageId: processing.messageId,
-      progressState,
+    const processed = await this.prepareFileForOpenCodeTurn(pending, instruction, message.messageId).catch(async (error) => {
+      const detail = error instanceof Error ? error.message : String(error);
+      await this.sendPayload(message.chatId, buildNoticeCardPayload({
+        title: "文件读取失败",
+        template: "red",
+        iconToken: "error_filled",
+        message: detail,
+        messageIconToken: "error_filled",
+        messageIconColor: "red",
+        showMessageIcon: false,
+      }), {
+        event: "file instruction failed",
+        transcriptType: "outbound-final",
+        textPreview: detail,
+        len: detail.length,
+      }, { replyToMessageId: message.messageId });
+      return null;
     });
-    this.refreshKnowledgeIngestPending(pending.conversationKey, pending);
-    await this.updateKnowledgeIngestSessionSummary(pending.conversationKey);
-    void this.processKnowledgeIngestQueue(pending.conversationKey);
+    if (!processed) {
+      this.clearPendingInteraction(message.conversationKey, false);
+      return true;
+    }
+    this.clearPendingInteraction(message.conversationKey, false);
+    if (!await this.ensureServerAvailableForMessage(message)) {
+      return true;
+    }
+    const queue = this.queues.get(message.conversationKey);
+    const turn: BridgeTurn = {
+      turnId: crypto.randomUUID(),
+      chatId: message.chatId,
+      conversationKey: message.conversationKey,
+      threadKey: message.threadKey,
+      chatType: message.chatType,
+      senderOpenId: message.senderOpenId,
+      inboundMessageId: message.messageId,
+      plainText: `${instruction}\n\n[文件] ${pending.file.fileName}`,
+      text: processed.prompt,
+    };
+    const result = queue.enqueue(turn);
+    if (!result.accepted) {
+      await this.sendPayload(message.chatId, buildQueueNoticePayload(result.notice ?? { message: "当前不可用。" }), {
+        event: "final message sent",
+        transcriptType: "outbound-final",
+        textPreview: result.notice?.message ?? "当前不可用。",
+        len: (result.notice?.message ?? "当前不可用。").length,
+      }, { replyToMessageId: message.messageId });
+      return true;
+    }
+    if (!this.runningChats.has(message.conversationKey)) {
+      const runner = this.processChat(message.conversationKey).finally(() => {
+        this.runningChats.delete(message.conversationKey);
+      });
+      this.runningChats.set(message.conversationKey, runner);
+      await runner;
+    }
     return true;
   }
 
-  private async processKnowledgeIngestQueue(conversationKey: string): Promise<void> {
-    const queue = this.knowledgeIngestQueues.get(conversationKey);
-    if (!queue || queue.active) {
-      return;
-    }
-    queue.active = true;
-    try {
-      let item = queue.pending.shift();
-      while (item) {
-        const currentItem = item;
-        const pending = this.getKnowledgeIngestInteraction(conversationKey);
-        if (!pending || !this.knowledge) {
-          break;
-        }
-        queue.currentLabel = getKnowledgeIngestQueueItemLabel(currentItem);
-        await this.updateKnowledgeIngestSessionSummary(conversationKey);
-        this.setRunningKnowledgeIngest(conversationKey, currentItem.requesterOpenId);
-        try {
-          if (currentItem.kind === "web") {
-            const result = await this.knowledge.ingestWebPage!({
-              url: currentItem.url,
-              instruction: currentItem.instruction,
-              messageId: currentItem.messageId,
-            }, {
-              onProgress: async (update) => await this.updateKnowledgeIngestProgress(currentItem.chatId, currentItem.processingMessageId, currentItem.progressState, update),
-            });
-            this.refreshKnowledgeIngestPending(conversationKey, pending);
-            await this.updatePayload(currentItem.chatId, currentItem.processingMessageId, buildKnowledgeIngestPayload(result), {
-              event: "knowledge web ingest updated",
-              transcriptType: "outbound-final",
-              textPreview: result.sourceFile,
-              len: result.sourceFile.length,
-            });
-            this.recordKnowledgeIngestResult(conversationKey, result);
-          } else {
-            const result = await this.knowledge.ingestFile({
-              messageId: currentItem.messageId,
-              fileKey: currentItem.fileKey,
-              fileName: currentItem.fileName,
-              size: currentItem.size,
-            }, {
-              onProgress: async (update) => await this.updateKnowledgeIngestProgress(currentItem.chatId, currentItem.processingMessageId, currentItem.progressState, update),
-            });
-            this.refreshKnowledgeIngestPending(conversationKey, pending);
-            await this.updatePayload(currentItem.chatId, currentItem.processingMessageId, buildKnowledgeIngestPayload(result), {
-              event: "knowledge ingest updated",
-              transcriptType: "outbound-final",
-              textPreview: result.sourceFile,
-              len: result.sourceFile.length,
-            });
-            this.recordKnowledgeIngestResult(conversationKey, result);
-          }
-        } catch (error) {
-          this.recordKnowledgeIngestFailure(conversationKey);
-          const detail = error instanceof Error ? error.message : String(error);
-          await this.updatePayload(currentItem.chatId, currentItem.processingMessageId, buildNoticeCardPayload({
-            title: currentItem.kind === "web" ? "网页入库失败" : "知识入库失败",
-            template: "red",
-            iconToken: "error_filled",
-            message: detail,
-            messageIconToken: "error_filled",
-            messageIconColor: "red",
-            showMessageIcon: false,
-          }), {
-            event: currentItem.kind === "web" ? "knowledge web ingest failed" : "knowledge ingest failed",
-            transcriptType: "outbound-final",
-            textPreview: detail,
-            len: detail.length,
-          });
-        } finally {
-          this.clearRunningKnowledgeIngest(conversationKey);
-        }
-        queue.currentLabel = undefined;
-        await this.updateKnowledgeIngestSessionSummary(conversationKey);
-        item = queue.pending.shift();
-      }
-    } finally {
-      queue.active = false;
-      queue.currentLabel = undefined;
-      let shouldUpdateSummary = true;
-      if (queue.pending.length === 0) {
-        if (queue.closing) {
-          shouldUpdateSummary = false;
-          const pending = this.getKnowledgeIngestInteraction(conversationKey);
-          if (pending) {
-            await this.sendKnowledgeIngestFinalSummary(pending);
-            await this.clearKnowledgeIngestPending(conversationKey, pending.chatType);
-          } else {
-            this.knowledgeIngestQueues.delete(conversationKey);
-          }
-        } else {
-          this.knowledgeIngestQueues.delete(conversationKey);
-          shouldUpdateSummary = false;
-        }
-      }
-      if (shouldUpdateSummary) {
-        await this.updateKnowledgeIngestSessionSummary(conversationKey);
-      }
-    }
+  getKnowledgeIngestInteraction(conversationKey: string): PendingKnowledgeIngestInteraction | null {
+    return this.knowledgeModule.getInteraction(conversationKey);
   }
 
-  private getKnowledgeIngestQueue(conversationKey: string): KnowledgeIngestQueueState {
-    const existing = this.knowledgeIngestQueues.get(conversationKey);
-    if (existing) {
-      return existing;
-    }
-    const queue: KnowledgeIngestQueueState = { active: false, closing: false, pending: [] };
-    this.knowledgeIngestQueues.set(conversationKey, queue);
-    return queue;
-  }
-
-  private getKnowledgeIngestSessionStats(conversationKey: string): KnowledgeIngestSessionStats {
-    const existing = this.knowledgeIngestSessionStats.get(conversationKey);
-    if (existing) {
-      return existing;
-    }
-    const stats: KnowledgeIngestSessionStats = {
-      startedAt: Date.now(),
-      completedCount: 0,
-      failedCount: 0,
-      totalExtractedCount: 0,
-      totalDedupedCount: 0,
-    };
-    this.knowledgeIngestSessionStats.set(conversationKey, stats);
-    return stats;
-  }
-
-  private recordKnowledgeIngestResult(conversationKey: string, result: KnowledgeIngestResult): void {
-    const stats = this.getKnowledgeIngestSessionStats(conversationKey);
-    const rawExtractedCount = result.rawExtractedCount ?? result.extractedCount;
-    stats.completedCount += 1;
-    stats.totalExtractedCount += result.extractedCount;
-    stats.totalDedupedCount += result.dedupedCount ?? Math.max(0, rawExtractedCount - result.extractedCount);
-    stats.bitableUrl = result.bitableUrl ?? stats.bitableUrl;
-  }
-
-  private recordKnowledgeIngestFailure(conversationKey: string): void {
-    const stats = this.getKnowledgeIngestSessionStats(conversationKey);
-    stats.failedCount += 1;
-  }
-
-  private async updateKnowledgeIngestSessionSummary(conversationKey: string): Promise<void> {
-    const pending = this.getKnowledgeIngestInteraction(conversationKey);
-    if (!pending) {
-      return;
-    }
-    const stats = this.getKnowledgeIngestSessionStats(conversationKey);
-    const queue = this.knowledgeIngestQueues.get(conversationKey);
-    await this.updatePayload(pending.chatId, pending.anchorMessageId, buildKnowledgeIngestSessionPayload({
-      completedCount: stats.completedCount,
-      failedCount: stats.failedCount,
-      queuedCount: queue?.pending.length ?? 0,
-      currentLabel: queue?.currentLabel,
-      totalExtractedCount: stats.totalExtractedCount,
-      totalDedupedCount: stats.totalDedupedCount,
-      elapsedMs: Date.now() - stats.startedAt,
-      bitableUrl: stats.bitableUrl,
-    }), {
-      event: "knowledge ingest session summary updated",
-      transcriptType: "outbound-final",
-      textPreview: "知识入库会话汇总",
-      len: 10,
-    });
-  }
-
-  private async sendKnowledgeIngestFinalSummary(pending: PendingKnowledgeIngestInteraction): Promise<void> {
-    const stats = this.getKnowledgeIngestSessionStats(pending.conversationKey);
-    await this.sendPayload(pending.chatId, buildKnowledgeIngestSessionFinalPayload({
-      completedCount: stats.completedCount,
-      failedCount: stats.failedCount,
-      queuedCount: 0,
-      totalExtractedCount: stats.totalExtractedCount,
-      totalDedupedCount: stats.totalDedupedCount,
-      elapsedMs: Date.now() - stats.startedAt,
-      bitableUrl: stats.bitableUrl,
-    }), {
-      event: "knowledge ingest session final summary sent",
-      transcriptType: "outbound-final",
-      textPreview: "知识入库完成汇总",
-      len: 10,
-    }, this.getKnowledgeIngestDelivery(pending));
+  async clearKnowledgeIngestPending(conversationKey: string, chatType: string): Promise<boolean> {
+    return await this.knowledgeModule.clearPending(conversationKey, chatType);
   }
 
   private async ensureSession(source: Pick<BridgeTurn, "chatId" | "chatType" | "conversationKey" | "threadKey">): Promise<string> {
@@ -1000,6 +651,7 @@ export class BridgeApp {
       throw new Error("当前运行环境不支持下载飞书文件。");
     }
     const downloaded = await resources.downloadMessageResource(pending.file.messageId, pending.file.fileKey, "file");
+    this.validateRegularFileInput(downloaded.fileName, downloaded.buffer.byteLength);
     const parsed = await parseKnowledgeFile(downloaded.fileName, downloaded.buffer);
     if (!parsed.normalizedMarkdown.trim()) {
       throw new Error("文件中未提取到可用文本。");
@@ -1023,6 +675,20 @@ export class BridgeApp {
         "---文件内容结束---",
       ].join("\n"),
     };
+  }
+
+  private validateRegularFileInput(fileName: string, sizeBytes?: number): void {
+    const extension = fileName.toLowerCase().match(/\.[a-z0-9]+$/)?.[0] ?? "";
+    if (!REGULAR_FILE_ALLOWED_EXTENSIONS.includes(extension as typeof REGULAR_FILE_ALLOWED_EXTENSIONS[number])) {
+      throw new Error(`仅支持 ${REGULAR_FILE_ALLOWED_EXTENSIONS.join(" / ")} 文件`);
+    }
+    if (typeof sizeBytes !== "number") {
+      return;
+    }
+    const maxSizeBytes = this.config.knowledgeBase.ingest.maxFileSizeMb * 1024 * 1024;
+    if (sizeBytes > maxSizeBytes) {
+      throw new Error(`文件过大，请控制在 ${this.config.knowledgeBase.ingest.maxFileSizeMb}MB 以内`);
+    }
   }
 
   private async ensureServerAvailableForMessage(message: Pick<IncomingChatMessage, "chatId" | "messageId">): Promise<boolean> {
@@ -1055,151 +721,6 @@ export class BridgeApp {
         this.sessionStatuses.set(sessionId, { type: "idle" });
       }
     }
-  }
-
-  private async interruptPersistedKnowledgeIngests(): Promise<void> {
-    const records = Object.values(this.activeKnowledgeIngestMap);
-    if (records.length === 0) {
-      return;
-    }
-
-    for (const record of records) {
-      await this.restorePreviousSessionForBackgroundIngest(record.conversationKey, record.chatType, record).catch((error) => {
-        this.logger.log("knowledge/ingest", "failed to restore interrupted ingest session", {
-          conversationKey: record.conversationKey,
-          detail: error instanceof Error ? error.message : String(error),
-        }, "warn");
-      });
-      await this.sendPayload(record.chatId, buildNoticeCardPayload({
-        title: "入库任务已中断",
-        template: "yellow",
-        iconToken: "maybe_outlined",
-        message: "入库任务因服务重启中断，请重新发送 `/kb-ingest-start`。",
-        messageIconToken: "maybe_outlined",
-        messageIconColor: "yellow",
-        showMessageIcon: false,
-      }), {
-        event: "knowledge ingest interrupted",
-        transcriptType: "outbound-final",
-        textPreview: "入库任务因服务重启中断",
-        len: 12,
-      }, {
-        replyToMessageId: record.anchorMessageId,
-        replyInThread: record.deliveryMode === "group_thread",
-      }).catch((error) => {
-        this.logger.log("knowledge/ingest", "failed to notify interrupted ingest", {
-          conversationKey: record.conversationKey,
-          detail: error instanceof Error ? error.message : String(error),
-        }, "warn");
-      });
-    }
-
-    this.activeKnowledgeIngestMap = {};
-    await this.activeKnowledgeIngests.saveRecords(this.activeKnowledgeIngestMap);
-  }
-
-  private findKnowledgeIngestInteraction(message: IncomingChatMessage): PendingKnowledgeIngestInteraction | null {
-    const direct = this.getKnowledgeIngestInteraction(message.conversationKey);
-    if (direct && this.isMessageInKnowledgeIngestChain(message, direct)) {
-      return direct;
-    }
-
-    for (const pending of this.knowledgeIngestInteractions.values()) {
-      if (pending.conversationKey === message.conversationKey) {
-        continue;
-      }
-      if (this.isMessageInKnowledgeIngestChain(message, pending)) {
-        return pending;
-      }
-    }
-
-    return null;
-  }
-
-  private isMessageInKnowledgeIngestChain(message: IncomingChatMessage, pending: PendingKnowledgeIngestInteraction): boolean {
-    if (message.chatId !== pending.chatId) {
-      return false;
-    }
-    if (message.chatType === "p2p") {
-      return message.rootId === pending.anchorMessageId
-        || message.parentId === pending.anchorMessageId
-        || message.rootId === pending.rootMessageId
-        || message.parentId === pending.rootMessageId;
-    }
-    const candidates = new Set([
-      message.rootId,
-      message.parentId,
-      message.threadKey,
-    ].filter((value): value is string => Boolean(value)));
-    return message.conversationKey === pending.conversationKey
-      || candidates.has(pending.anchorMessageId)
-      || candidates.has(pending.rootMessageId);
-  }
-
-  private async endKnowledgeIngestInteraction(
-    message: Pick<IncomingChatMessage, "messageId" | "senderOpenId">,
-    pending: PendingKnowledgeIngestInteraction,
-    delivery?: { replyToMessageId: string },
-  ): Promise<void> {
-    if (pending.requesterOpenId !== message.senderOpenId) {
-      await this.sendPayload(pending.chatId, buildNoticeCardPayload({
-        title: "无法结束入库模式",
-        template: "yellow",
-        iconToken: "maybe_outlined",
-        message: "当前入库模式仅允许发起人结束。",
-        messageIconToken: "maybe_outlined",
-        messageIconColor: "yellow",
-        showMessageIcon: false,
-      }), {
-        event: "knowledge ingest end rejected",
-        transcriptType: "outbound-final",
-        textPreview: "当前入库模式仅允许发起人结束。",
-        len: 16,
-      }, delivery ?? this.getKnowledgeIngestDelivery(pending));
-      return;
-    }
-    const queue = this.knowledgeIngestQueues.get(pending.conversationKey);
-    let endedImmediately = true;
-    if (queue && (queue.active || queue.pending.length > 0)) {
-      endedImmediately = false;
-      queue.closing = true;
-      await this.sendKnowledgeIngestMarkdown(pending, "已收到结束指令，将处理完当前队列后结束。");
-      await this.updateKnowledgeIngestSessionSummary(pending.conversationKey);
-    } else {
-      await this.sendKnowledgeIngestFinalSummary(pending);
-      await this.clearKnowledgeIngestPending(pending.conversationKey, pending.chatType);
-    }
-    if (!delivery || !endedImmediately) {
-      return;
-    }
-    await this.sendPayload(pending.chatId, buildNoticeCardPayload({
-      title: "已退出知识入库模式",
-      template: "green",
-      iconToken: "yes_filled",
-      message: "后续文件消息将不再自动入库；如需继续入库，请发送 `/kb-ingest-start`。",
-      messageIconToken: "yes_filled",
-      messageIconColor: "green",
-      showMessageIcon: false,
-    }), {
-      event: "knowledge ingest ended",
-      transcriptType: "outbound-final",
-      textPreview: "已退出知识入库模式",
-      len: 9,
-    }, delivery);
-  }
-
-  async clearKnowledgeIngestPending(conversationKey: string, chatType: string): Promise<boolean> {
-    const pending = this.getKnowledgeIngestInteraction(conversationKey);
-    if (!pending) {
-      return false;
-    }
-    if (pending.previousActiveSessionId) {
-      await this.restorePreviousSessionForBackgroundIngest(conversationKey, chatType, pending);
-    }
-    this.clearKnowledgeIngestInteraction(conversationKey);
-    this.knowledgeIngestQueues.delete(conversationKey);
-    this.knowledgeIngestSessionStats.delete(conversationKey);
-    return true;
   }
 
   private getSessionWindow(conversationKey: string, chatType?: string): SessionWindowRecord {
@@ -1282,11 +803,6 @@ export class BridgeApp {
   }
 
   private setPendingInteraction(conversationKey: string, interaction: PendingInteraction): void {
-    if (interaction.kind === "knowledge-ingest-await-file") {
-      this.setKnowledgeIngestInteraction(conversationKey, interaction);
-      return;
-    }
-
     this.clearPendingInteraction(conversationKey, false);
     this.pendingInteractions.set(conversationKey, interaction);
 
@@ -1316,21 +832,9 @@ export class BridgeApp {
 
   }
 
-  private setKnowledgeIngestInteraction(conversationKey: string, interaction: PendingKnowledgeIngestInteraction): void {
-    this.clearKnowledgeIngestInteraction(conversationKey, { keepActiveKnowledgeIngest: true });
-    this.knowledgeIngestInteractions.set(conversationKey, interaction);
-    this.getKnowledgeIngestSessionStats(conversationKey);
-    const timer = setTimeout(() => {
-      void this.handleKnowledgeIngestTimeout(conversationKey, interaction);
-    }, Math.max(0, interaction.expiresAt - Date.now()));
-    this.pendingInteractionTimers.set(this.getKnowledgeIngestTimerKey(conversationKey), timer);
-    this.saveActiveKnowledgeIngest(interaction);
-  }
-
   private clearPendingInteraction(
     conversationKey: string,
     keepNonExpiring: boolean,
-    options?: { keepActiveKnowledgeIngest?: boolean },
   ): void {
     const timeout = this.pendingInteractionTimers.get(conversationKey);
     if (timeout) {
@@ -1345,40 +849,7 @@ export class BridgeApp {
       }
     }
 
-    const current = this.pendingInteractions.get(conversationKey);
     this.pendingInteractions.delete(conversationKey);
-    if (current?.kind === "knowledge-ingest-await-file" && !options?.keepActiveKnowledgeIngest) {
-      this.deleteActiveKnowledgeIngest(conversationKey);
-    }
-  }
-
-  private clearKnowledgeIngestInteraction(
-    conversationKey: string,
-    options?: { keepActiveKnowledgeIngest?: boolean },
-  ): void {
-    const timerKey = this.getKnowledgeIngestTimerKey(conversationKey);
-    const timeout = this.pendingInteractionTimers.get(timerKey);
-    if (timeout) {
-      clearTimeout(timeout);
-      this.pendingInteractionTimers.delete(timerKey);
-    }
-    this.knowledgeIngestInteractions.delete(conversationKey);
-    if (!options?.keepActiveKnowledgeIngest) {
-      this.deleteActiveKnowledgeIngest(conversationKey);
-    }
-  }
-
-  getKnowledgeIngestInteraction(conversationKey: string): PendingKnowledgeIngestInteraction | null {
-    const interaction = this.knowledgeIngestInteractions.get(conversationKey);
-    if (interaction) {
-      return interaction;
-    }
-    const legacy = this.pendingInteractions.get(conversationKey);
-    return legacy?.kind === "knowledge-ingest-await-file" ? legacy : null;
-  }
-
-  private getKnowledgeIngestTimerKey(conversationKey: string): string {
-    return `knowledge-ingest:${conversationKey}`;
   }
 
   private clearTurnOwnedPendingInteraction(conversationKey: string, turnId: string): void {
@@ -1402,37 +873,6 @@ export class BridgeApp {
     }
 
     await this.permissionManager.expireInteraction(current, true);
-  }
-
-  private async handleKnowledgeIngestTimeout(conversationKey: string, pending: PendingKnowledgeIngestInteraction): Promise<void> {
-    const current = this.getKnowledgeIngestInteraction(conversationKey);
-    if (
-      !current
-      || current.anchorMessageId !== pending.anchorMessageId
-      || current.expiresAt > Date.now()
-    ) {
-      return;
-    }
-    if (this.runningKnowledgeIngests.has(conversationKey)) {
-      this.refreshKnowledgeIngestPending(conversationKey, current);
-      return;
-    }
-    await this.sendKnowledgeIngestFinalSummary(current);
-    await this.clearKnowledgeIngestPending(conversationKey, current.chatType);
-    await this.sendPayload(current.chatId, buildNoticeCardPayload({
-      title: "入库任务已超时",
-      template: "yellow",
-      iconToken: "maybe_outlined",
-      message: "长时间未收到新的入库素材，已结束当前入库任务。需要继续时请重新发送 `/kb-ingest-start`。",
-      messageIconToken: "maybe_outlined",
-      messageIconColor: "yellow",
-      showMessageIcon: false,
-    }), {
-      event: "knowledge ingest timed out",
-      transcriptType: "outbound-final",
-      textPreview: "入库任务已超时",
-      len: 7,
-    }, this.getKnowledgeIngestDelivery(current));
   }
 
   private isSessionBusy(conversationKey: string, sessionId: string): boolean {
@@ -1544,22 +984,6 @@ export class BridgeApp {
     }, replyToMessageId ? { replyToMessageId } : undefined);
   }
 
-  private async sendKnowledgeIngestMarkdown(pending: PendingKnowledgeIngestInteraction, markdown: string): Promise<void> {
-    await this.sendPayload(pending.chatId, buildPostMarkdownPayload(markdown), {
-      event: "knowledge ingest notice sent",
-      transcriptType: "outbound-final",
-      textPreview: createTextPreview(markdown),
-      len: markdown.length,
-    }, this.getKnowledgeIngestDelivery(pending));
-  }
-
-  private getKnowledgeIngestDelivery(pending: PendingKnowledgeIngestInteraction): { replyToMessageId: string; replyInThread: boolean } {
-    return {
-      replyToMessageId: pending.anchorMessageId,
-      replyInThread: pending.deliveryMode === "group_thread",
-    };
-  }
-
   private async sendPayload(
     chatId: string,
     payload: FeishuPostPayload,
@@ -1586,195 +1010,5 @@ export class BridgeApp {
     this.logger.log("feishu/reply", options.event, { chatId, messageId: result.messageId, textPreview: options.textPreview, len: options.len });
     this.logger.logTranscript(options.transcriptType, { chatId, messageId: result.messageId }, prettyPrintPayload(payload));
     return result;
-  }
-
-  private setRunningKnowledgeIngest(conversationKey: string, requesterOpenId: string): void {
-    this.runningKnowledgeIngests.set(conversationKey, { requesterOpenId });
-  }
-
-  private clearRunningKnowledgeIngest(conversationKey: string): void {
-    this.runningKnowledgeIngests.delete(conversationKey);
-  }
-
-  private refreshKnowledgeIngestPending(
-    conversationKey: string,
-    pending: PendingKnowledgeIngestInteraction,
-  ): void {
-    const current = this.getKnowledgeIngestInteraction(conversationKey);
-    if (!current || current.anchorMessageId !== pending.anchorMessageId) {
-      return;
-    }
-    this.setKnowledgeIngestInteraction(conversationKey, {
-      ...current,
-      expiresAt: Date.now() + this.config.knowledgeBase.ingest.sessionIdleMs,
-    });
-  }
-
-  private saveActiveKnowledgeIngest(pending: PendingKnowledgeIngestInteraction): void {
-    this.activeKnowledgeIngestMap[pending.conversationKey] = {
-      chatId: pending.chatId,
-      chatType: pending.chatType,
-      conversationKey: pending.conversationKey,
-      requesterOpenId: pending.requesterOpenId,
-      rootMessageId: pending.rootMessageId,
-      anchorMessageId: pending.anchorMessageId,
-      deliveryMode: pending.deliveryMode,
-      ingestSessionId: pending.ingestSessionId,
-      previousActiveSessionId: pending.previousActiveSessionId,
-      expiresAt: pending.expiresAt,
-    };
-    void this.activeKnowledgeIngests.saveRecords(this.activeKnowledgeIngestMap).catch((error) => {
-      this.logger.log("knowledge/ingest", "failed to persist active ingest", {
-        conversationKey: pending.conversationKey,
-        detail: error instanceof Error ? error.message : String(error),
-      }, "warn");
-    });
-  }
-
-  private deleteActiveKnowledgeIngest(conversationKey: string): void {
-    if (!(conversationKey in this.activeKnowledgeIngestMap)) {
-      return;
-    }
-    delete this.activeKnowledgeIngestMap[conversationKey];
-    void this.activeKnowledgeIngests.saveRecords(this.activeKnowledgeIngestMap).catch((error) => {
-      this.logger.log("knowledge/ingest", "failed to clear active ingest", {
-        conversationKey,
-        detail: error instanceof Error ? error.message : String(error),
-      }, "warn");
-    });
-  }
-
-  private async restorePreviousSessionForBackgroundIngest(
-    conversationKey: string,
-    chatType: string,
-    pending: Pick<PendingKnowledgeIngestInteraction, "previousActiveSessionId">,
-  ): Promise<void> {
-    if (!pending.previousActiveSessionId) {
-      return;
-    }
-    const window = this.getSessionWindow(conversationKey, chatType);
-    if (window.activeSessionId === pending.previousActiveSessionId) {
-      return;
-    }
-    if (!window.sessions.some((session) => session.sessionId === pending.previousActiveSessionId)) {
-      return;
-    }
-    const nextWindow = setActiveSession(
-      window,
-      pending.previousActiveSessionId,
-      Date.now(),
-      this.config.bridge.maxSessionsPerWindow,
-    );
-    await this.saveSessionWindow(conversationKey, nextWindow);
-  }
-
-  private async restoreOrCreateNormalSessionForBackgroundIngest(
-    message: Pick<IncomingChatMessage, "chatId" | "chatType" | "conversationKey" | "threadKey">,
-    pending: Pick<PendingKnowledgeIngestInteraction, "previousActiveSessionId" | "ingestSessionId">,
-  ): Promise<void> {
-    if (pending.previousActiveSessionId) {
-      await this.restorePreviousSessionForBackgroundIngest(message.conversationKey, message.chatType, pending);
-      return;
-    }
-    if (!pending.ingestSessionId) {
-      return;
-    }
-    const window = this.getSessionWindow(message.conversationKey, message.chatType);
-    if (window.activeSessionId !== pending.ingestSessionId) {
-      return;
-    }
-    await this.createAndBindSession(message);
-  }
-
-  private async sendKnowledgeIngestBusyNotice(
-    pending: PendingKnowledgeIngestInteraction,
-  ): Promise<void> {
-    await this.sendPayload(pending.chatId, buildNoticeCardPayload({
-      title: "知识入库处理中",
-      template: "blue",
-      iconToken: "upload_outlined",
-      message: "当前正在处理知识入库任务。\n新的入库文件或入库链接请等待当前任务完成后再发送。\n发送 `/kb-ingest-end` 可退出入库模式；普通对话可直接发送。",
-      messageIconToken: "upload_outlined",
-      messageIconColor: "blue",
-      showMessageIcon: false,
-    }), {
-      event: "knowledge ingest busy",
-      transcriptType: "outbound-final",
-      textPreview: "当前正在处理知识入库任务。",
-      len: 43,
-    }, this.getKnowledgeIngestDelivery(pending));
-  }
-
-  private async updateKnowledgeIngestProgress(
-    chatId: string,
-    messageId: string,
-    state: KnowledgeIngestProgressState,
-    update: KnowledgeIngestProgressUpdate,
-  ): Promise<void> {
-    applyKnowledgeIngestProgress(state, update);
-    const payload = buildKnowledgeIngestProcessingPayload(state);
-    try {
-      await this.updatePayload(chatId, messageId, payload, {
-        event: "knowledge ingest progress updated",
-        transcriptType: "outbound-final",
-        textPreview: `${state.sourceLabel} ${state.steps.map((step) => `${step.label}:${step.detail}`).join(" | ")}`,
-        len: state.steps.map((step) => `${step.label}:${step.detail}`).join("\n").length,
-      });
-    } catch (error) {
-      this.logger.log("feishu/reply", "knowledge ingest progress update failed", {
-        chatId,
-        messageId,
-        detail: error instanceof Error ? error.message : String(error),
-      }, "warn");
-    }
-  }
-}
-
-type KnowledgeIngestProgressState = {
-  sourceLabel: string;
-  steps: ToolUpdateView[];
-};
-
-function createKnowledgeIngestProgressState(sourceLabel: string): KnowledgeIngestProgressState {
-  return {
-    sourceLabel,
-    steps: [
-      { label: "读取内容", detail: "等待开始", status: "pending" },
-      { label: "提取问答", detail: "等待开始", status: "pending" },
-      { label: "写入知识库", detail: "等待开始", status: "pending" },
-    ],
-  };
-}
-
-function getKnowledgeIngestQueueItemLabel(item: KnowledgeIngestQueueItem): string {
-  return item.kind === "web" ? item.url : item.fileName;
-}
-
-function applyKnowledgeIngestProgress(state: KnowledgeIngestProgressState, update: KnowledgeIngestProgressUpdate): void {
-  const label = mapKnowledgeProgressLabel(update.step);
-  const step = state.steps.find((item) => item.label === label);
-  if (!step) {
-    return;
-  }
-  step.status = update.status;
-  if (update.detail) {
-    step.detail = update.detail;
-  } else if (update.status === "completed") {
-    step.detail = "已完成";
-  } else if (update.status === "running") {
-    step.detail = "处理中";
-  } else if (update.status === "error") {
-    step.detail = "执行失败";
-  }
-}
-
-function mapKnowledgeProgressLabel(step: KnowledgeIngestProgressStep): ToolUpdateView["label"] {
-  switch (step) {
-    case "read":
-      return "读取内容";
-    case "extract":
-      return "提取问答";
-    case "write":
-      return "写入知识库";
   }
 }

--- a/src/runtime/command-handler.ts
+++ b/src/runtime/command-handler.ts
@@ -1,11 +1,8 @@
-import type { PendingInteraction, PendingKnowledgeIngestInteraction, PendingPermissionInteraction } from "../bridge/state.js";
+import type { PendingInteraction, PendingPermissionInteraction } from "../bridge/state.js";
 import type { RoutedText } from "../bridge/router.js";
 import {
-  buildKnowledgeQueryEmptyPayload,
-  buildKnowledgeQueryPayload,
   buildModelListCardPayload,
   buildNoticeCardPayload,
-  buildKnowledgeIngestReadyPayload,
   buildLeaveCommandCardPayload,
   buildSessionListCardPayload,
   buildSessionTransitionCardPayload,
@@ -13,7 +10,6 @@ import {
   buildWhoCommandCardPayload,
   type FeishuPostPayload,
 } from "../feishu/formatter.js";
-import type { KnowledgeBasePort } from "../knowledge/index.js";
 import type { TranscriptType } from "../logging/logger.js";
 import type { OpenCodeMessage, OpenCodeProvidersResponse, OpenCodeSession, OpenCodeSessionStatus } from "../opencode/client.js";
 import type { SessionWindowRecord } from "../store/mappings.js";
@@ -35,7 +31,6 @@ import {
   normalizeSessionWindowRecord,
   removeSession,
   setActiveSession,
-  setInteractionMode,
   updateSessionLabel,
 } from "./session-windows.js";
 
@@ -52,12 +47,6 @@ export type BridgeAppContext = {
     bridge: {
       sessionListLimit: number;
       maxSessionsPerWindow: number;
-    };
-    knowledgeBase: {
-      ingest: {
-        pendingTtlMs: number;
-        sessionIdleMs: number;
-      };
     };
   };
   opencode: {
@@ -87,7 +76,6 @@ export type BridgeAppContext = {
     resolveInteraction(interaction: PendingPermissionInteraction, resolution: PermissionResolution): Promise<void>;
     buildResolutionPayload(resolution: PermissionResolution): FeishuPostPayload;
   };
-  knowledge: KnowledgeBasePort | null;
   getSessionWindow(conversationKey: string, chatType: string): SessionWindowRecord;
   createAndBindSession(message: Pick<IncomingChatMessage, "chatId" | "chatType" | "conversationKey" | "threadKey">): Promise<{ sessionId: string; label: string }>;
   sendPayload(
@@ -99,14 +87,11 @@ export type BridgeAppContext = {
   sendMarkdown(chatId: string, markdown: string, replyToMessageId?: string): Promise<void>;
   setPendingInteraction(conversationKey: string, interaction: PendingInteraction): void;
   clearPendingInteraction(conversationKey: string, keepNonExpiring: boolean): void;
-  getKnowledgeIngestInteraction(conversationKey: string): PendingKnowledgeIngestInteraction | null;
-  clearKnowledgeIngestPending(conversationKey: string, chatType: string): Promise<boolean>;
   listOpenCodeSessionsById(): Promise<Map<string, OpenCodeSession>>;
   saveSessionWindow(conversationKey: string, window: SessionWindowRecord): Promise<void>;
   getSessionMessageCount(sessionId: string): Promise<number>;
   ensureSession(source: Pick<IncomingChatMessage, "chatId" | "chatType" | "conversationKey" | "threadKey">): Promise<string>;
   isSessionBusy(conversationKey: string, sessionId: string): boolean;
-  whitelistBind(chatId: string, openId: string): Promise<void>;
   resolveSessionCommandTarget(
     message: Pick<IncomingChatMessage, "chatId" | "chatType" | "messageId" | "conversationKey">,
     index: number | undefined,
@@ -122,6 +107,27 @@ export type BridgeAppContext = {
     | { ok: false; message: string }
   >;
 };
+
+const BRIDGE_OWNED_COMMAND_KINDS = new Set<Extract<RoutedText, { kind: "command" }>["command"]["kind"]>([
+  "new",
+  "status",
+  "abort",
+  "models",
+  "leave",
+  "who",
+  "sessions",
+  "sessions-all",
+  "sessions-select",
+  "close",
+  "delete",
+  "allow",
+  "deny",
+  "passthrough",
+]);
+
+export function isBridgeOwnedCommand(command: Extract<RoutedText, { kind: "command" }>["command"]): boolean {
+  return BRIDGE_OWNED_COMMAND_KINDS.has(command.kind);
+}
 
 export class CommandHandler {
   constructor(private readonly context: BridgeAppContext) {}
@@ -224,188 +230,6 @@ export class CommandHandler {
         textPreview: "可用模型",
         len: 4,
       }, { replyToMessageId: message.messageId });
-      return;
-    }
-
-    if (command.kind === "knowledge-query") {
-      if (!this.context.knowledge) {
-        await this.sendNotice(message, {
-          title: "知识库未启用",
-          template: "yellow",
-          icon: "maybe_outlined",
-          message: "当前未启用法律知识库，请联系部署者补充 knowledgeBase 配置。",
-        });
-        return;
-      }
-      try {
-        const result = await this.context.knowledge.query(command.question);
-        await this.context.sendPayload(
-          message.chatId,
-          result.results.length > 0 ? buildKnowledgeQueryPayload(result) : buildKnowledgeQueryEmptyPayload(command.question),
-          {
-            event: "knowledge query sent",
-            transcriptType: "outbound-final",
-            textPreview: command.question,
-            len: command.question.length,
-          },
-          { replyToMessageId: message.messageId },
-        );
-      } catch (error) {
-        const detail = error instanceof Error ? error.message : String(error);
-        await this.sendNotice(message, {
-          title: "知识检索失败",
-          template: "red",
-          icon: "error_filled",
-          message: detail,
-        });
-      }
-      return;
-    }
-
-    if (command.kind === "knowledge-ingest") {
-      if (!this.context.knowledge) {
-        await this.sendNotice(message, {
-          title: "知识库未启用",
-          template: "yellow",
-          icon: "maybe_outlined",
-          message: "当前未启用法律知识库，请联系部署者补充 knowledgeBase 配置。",
-        });
-        return;
-      }
-      const currentPending = this.context.getKnowledgeIngestInteraction(message.conversationKey);
-      if (currentPending?.kind === "knowledge-ingest-await-file" && currentPending.requesterOpenId === message.senderOpenId) {
-        await this.sendNotice(message, {
-          title: "已在知识入库模式",
-          template: "blue",
-          icon: "upload_outlined",
-          message: "请继续上传 PDF / DOCX / TXT 文件；发送 `/kb-ingest-end` 可退出。",
-        });
-        return;
-      }
-      const window = this.context.getSessionWindow(message.conversationKey, message.chatType);
-      const previousSession = getActiveSession(window);
-      const entry = await this.context.createAndBindSession(message);
-      const ingestLabel = "知识入库";
-      const nextWindow = updateSessionLabel(
-        this.context.getSessionWindow(message.conversationKey, message.chatType),
-        entry.sessionId,
-        ingestLabel,
-        this.context.config.bridge.maxSessionsPerWindow,
-      );
-      await this.context.saveSessionWindow(message.conversationKey, nextWindow);
-      const deliveryMode = message.chatType === "p2p" ? "p2p_reply" : "group_thread";
-      const ready = await this.context.sendPayload(message.chatId, buildKnowledgeIngestReadyPayload(), {
-        event: "knowledge ingest pending",
-        transcriptType: "outbound-final",
-        textPreview: "已进入知识入库模式",
-        len: 9,
-      }, { replyToMessageId: message.messageId, replyInThread: deliveryMode === "group_thread" });
-      this.context.setPendingInteraction(message.conversationKey, {
-        kind: "knowledge-ingest-await-file",
-        chatId: message.chatId,
-        chatType: message.chatType,
-        conversationKey: message.conversationKey,
-        requesterOpenId: message.senderOpenId,
-        replyToMessageId: ready.messageId,
-        rootMessageId: message.messageId,
-        anchorMessageId: ready.messageId,
-        deliveryMode,
-        ingestSessionId: entry.sessionId,
-        previousActiveSessionId: previousSession?.sessionId ?? null,
-        expiresAt: Date.now() + this.context.config.knowledgeBase.ingest.sessionIdleMs,
-      });
-      if (message.chatType !== "p2p") {
-        await this.context.whitelistBind(message.chatId, message.senderOpenId);
-      }
-      return;
-    }
-
-    if (command.kind === "knowledge-ingest-end") {
-      const pending = this.context.getKnowledgeIngestInteraction(message.conversationKey);
-      if (pending?.kind !== "knowledge-ingest-await-file") {
-        await this.sendNotice(message, {
-          title: "当前未开启知识入库模式",
-          template: "grey",
-          icon: "info-hollow_filled",
-          message: "发送 `/kb-ingest-start` 可进入知识入库模式。",
-        });
-        return;
-      }
-      if (pending.requesterOpenId !== message.senderOpenId) {
-        await this.sendNotice(message, {
-          title: "无法结束入库模式",
-          template: "yellow",
-          icon: "maybe_outlined",
-          message: "当前入库模式仅允许发起人结束。",
-        });
-        return;
-      }
-      await this.context.clearKnowledgeIngestPending(message.conversationKey, message.chatType);
-      await this.sendNotice(message, {
-        title: "已退出知识入库模式",
-        template: "green",
-        icon: "yes_filled",
-        message: "后续文件消息将不再自动入库；如需继续入库，请发送 `/kb-ingest-start`。",
-      });
-      return;
-    }
-
-    if (command.kind === "knowledge-mode-start") {
-      if (!this.context.knowledge) {
-        await this.sendNotice(message, {
-          title: "知识库未启用",
-          template: "yellow",
-          icon: "maybe_outlined",
-          message: "当前未启用法律知识库，请联系部署者补充 knowledgeBase 配置。",
-        });
-        return;
-      }
-      const clearedIngestPending = await this.context.clearKnowledgeIngestPending(message.conversationKey, message.chatType);
-      const window = this.context.getSessionWindow(message.conversationKey, message.chatType);
-      if (window.interactionMode === "knowledge") {
-        await this.sendNotice(message, {
-          title: "已在知识库模式",
-          template: "blue",
-          icon: "search_outlined",
-          message: clearedIngestPending
-            ? "已退出知识入库模式；当前仍是知识库模式。接下来直接发送问题即可检索知识库，发送 `/legal-query-end` 可退出。"
-            : "接下来直接发送问题即可检索知识库，发送 `/legal-query-end` 可退出。",
-        });
-        return;
-      }
-      const nextWindow = setInteractionMode(window, "knowledge", this.context.config.bridge.maxSessionsPerWindow);
-      await this.context.saveSessionWindow(message.conversationKey, nextWindow);
-      await this.sendNotice(message, {
-        title: "已进入知识库模式",
-        template: "indigo",
-        icon: "search_outlined",
-        message: clearedIngestPending
-          ? "已退出知识入库模式，并切换到知识库查询模式。接下来直接发送问题即可检索知识库，发送 `/legal-query-end` 可退出。"
-          : "接下来直接发送问题即可检索知识库，发送 `/legal-query-end` 可退出。",
-      });
-      return;
-    }
-
-    if (command.kind === "knowledge-mode-end") {
-      await this.context.clearKnowledgeIngestPending(message.conversationKey, message.chatType);
-      const window = this.context.getSessionWindow(message.conversationKey, message.chatType);
-      if (window.interactionMode !== "knowledge") {
-        await this.sendNotice(message, {
-          title: "当前未开启知识库模式",
-          template: "grey",
-          icon: "info-hollow_filled",
-          message: "当前仍是普通对话模式，发送 `/legal-query-start` 可进入知识库模式。",
-        });
-        return;
-      }
-      const nextWindow = setInteractionMode(window, "default", this.context.config.bridge.maxSessionsPerWindow);
-      await this.context.saveSessionWindow(message.conversationKey, nextWindow);
-      await this.sendNotice(message, {
-        title: "已退出知识库模式",
-        template: "green",
-        icon: "chat_outlined",
-        message: "后续消息将恢复为普通 OpenCode 对话，仍可用 `/legal-query <问题>` 单次查询。",
-      });
       return;
     }
 
@@ -771,6 +595,9 @@ export class CommandHandler {
       return;
     }
 
+    if (command.kind !== "passthrough") {
+      return;
+    }
     const sessionId = await this.context.ensureSession(message);
     const result = await this.context.opencode.runCommand(sessionId, { command: command.name, arguments: command.arguments });
     const text = extractAssistantText(result) || "命令已执行。";

--- a/src/runtime/turn-executor.ts
+++ b/src/runtime/turn-executor.ts
@@ -139,7 +139,7 @@ export class TurnExecutor {
         this.context.memory?.enqueueLearn(turn.senderOpenId, turn.plainText, reply);
       }
       if (!card && reply) {
-        await this.sendTurnFallbackMarkdown(turn.chatId, reply);
+        await this.sendTurnFallbackMarkdown(turn.chatId, reply, turn.inboundMessageId);
       }
       await this.context.turnCardManager.flushStreamUpdate(turn.turnId, reply, true);
       await this.context.turnCardManager.updateTurnCard(turn.turnId, { status: "已完成", update: `最终回复已生成（${reply.length} 字）`, target: "step" });
@@ -149,7 +149,7 @@ export class TurnExecutor {
       const detail = normalizeTurnFailureDetail(error);
       this.context.logger.log("bridge/queue", "run turn failed", { chatId: turn.chatId, conversationKey, turnId: turn.turnId, detail }, "error");
       if (!hasProcessCard) {
-        await this.sendTurnFallbackMarkdown(turn.chatId, `处理失败：${escapeMarkdownText(detail)}`);
+        await this.sendTurnFallbackMarkdown(turn.chatId, `处理失败：${escapeMarkdownText(detail)}`, turn.inboundMessageId);
       }
       await this.context.turnCardManager.updateTurnCard(turn.turnId, { status: detail.includes("超时") ? "已超时" : "处理失败", update: detail, target: "step" });
       queue.replaceActive(transitionTurn(turn, detail.includes("超时") ? "timeout" : "aborted"));
@@ -533,13 +533,13 @@ export class TurnExecutor {
     return messages.find((message) => message.info.id === messageId && message.info.role === "assistant") ?? null;
   }
 
-  private async sendTurnFallbackMarkdown(chatId: string, markdown: string): Promise<void> {
+  private async sendTurnFallbackMarkdown(chatId: string, markdown: string, replyToMessageId: string): Promise<void> {
     await this.context.sendPayload(chatId, buildPostMarkdownPayload(markdown), {
       event: "fallback final message sent",
       transcriptType: "outbound-final",
       textPreview: createTextPreview(markdown),
       len: markdown.length,
-    });
+    }, { replyToMessageId });
   }
 }
 

--- a/src/runtime/turn-executor.ts
+++ b/src/runtime/turn-executor.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 
 import type { PendingPermissionInteraction } from "../bridge/state.js";
+import type { ModuleManager } from "../bridge/module.js";
 import { transitionTurn } from "../bridge/state-machine.js";
 import { TurnWatchdog } from "../bridge/watchdog.js";
 import type { BridgeTurn } from "../bridge/turn.js";
@@ -80,10 +81,7 @@ export type TurnExecutorContext = {
       value: Record<string, unknown>;
     }>;
   };
-  memory: {
-    buildRecallBlock(openId: string, plainText: string): Promise<string>;
-    enqueueLearn(openId: string, userText: string, assistantText: string): void;
-  } | null;
+  moduleManager: Pick<ModuleManager, "collectBeforeTurnBlocks" | "runAfterTurnHooks">;
   getSessionWindow(conversationKey: string, chatType?: string): SessionWindowRecord;
   ensureSession(source: Pick<BridgeTurn, "chatId" | "chatType" | "conversationKey" | "threadKey">): Promise<string>;
   maybeUpdateSessionLabel(turn: BridgeTurn & { sessionId: string }): Promise<void>;
@@ -136,7 +134,11 @@ export class TurnExecutor {
       this.context.logger.logTranscript("opencode-reply", { sessionId, turnId: turn.turnId }, reply);
       await this.context.maybeUpdateSessionLabel(turn as BridgeTurn & { sessionId: string });
       if (reply) {
-        this.context.memory?.enqueueLearn(turn.senderOpenId, turn.plainText, reply);
+        await this.context.moduleManager.runAfterTurnHooks({
+          turn: turn as BridgeTurn & { sessionId: string },
+          reply,
+          window: this.context.getSessionWindow(turn.conversationKey, turn.chatType),
+        });
       }
       if (!card && reply) {
         await this.sendTurnFallbackMarkdown(turn.chatId, reply, turn.inboundMessageId);
@@ -167,10 +169,11 @@ export class TurnExecutor {
     const bridgeSystemPrompt = this.context.config.bridge.injectSystemState
       ? buildBridgeSystemPrompt(turn, this.context.getSessionWindow(turn.conversationKey, turn.chatType))
       : undefined;
-    const memoryRecall = this.context.memory
-      ? await this.context.memory.buildRecallBlock(turn.senderOpenId, turn.plainText)
-      : "";
-    const systemPrompt = composeSystemPrompt(bridgeSystemPrompt, memoryRecall);
+    const moduleSystemBlocks = await this.context.moduleManager.collectBeforeTurnBlocks({
+      turn,
+      window: this.context.getSessionWindow(turn.conversationKey, turn.chatType),
+    });
+    const systemPrompt = composeSystemPrompt(bridgeSystemPrompt, ...moduleSystemBlocks);
 
     return new Promise<string>((resolve, reject) => {
       let assistantMessageId: string | null = null;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+function findPackageJsonPath(startDir: string): string | null {
+  let currentDir = startDir;
+
+  for (let depth = 0; depth < 4; depth += 1) {
+    const candidate = path.join(currentDir, "package.json");
+    try {
+      const raw = readFileSync(candidate, "utf8");
+      const parsed = JSON.parse(raw) as { name?: unknown };
+      if (parsed.name === "feishu-opencode-bridge") {
+        return candidate;
+      }
+    } catch {
+      // Keep searching upward.
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      break;
+    }
+    currentDir = parentDir;
+  }
+
+  return null;
+}
+
+function loadAppVersion(): string {
+  const currentDir = path.dirname(fileURLToPath(import.meta.url));
+  const packageJsonPath = findPackageJsonPath(currentDir);
+
+  if (!packageJsonPath) {
+    return "0.0.0";
+  }
+
+  try {
+    const raw = readFileSync(packageJsonPath, "utf8");
+    const parsed = JSON.parse(raw) as { version?: unknown };
+    if (typeof parsed.version === "string" && parsed.version.trim()) {
+      return parsed.version;
+    }
+  } catch {
+    // Fall through to the safe default below.
+  }
+
+  return "0.0.0";
+}
+
+export const APP_VERSION = loadAppVersion();

--- a/test/app-command-surface.test.ts
+++ b/test/app-command-surface.test.ts
@@ -676,8 +676,10 @@ describe("BridgeApp command surface", () => {
 
     await appAny.runTurn("oc_p2p_1");
 
-    expect(outbound.sendMessage).toHaveBeenCalledTimes(1);
-    expect(extractMarkdown(getSendPayloads(outbound)[0])).toContain("最终回复");
+    expect(outbound.sendMessage).not.toHaveBeenCalled();
+    expect(outbound.replyMessage).toHaveBeenCalledTimes(1);
+    expect(outbound.replyMessage).toHaveBeenCalledWith("om_1", expect.any(Object));
+    expect(extractMarkdown(getReplyPayloads(outbound)[0])).toContain("最终回复");
   });
 
   it("falls back to a direct error message when the process card cannot be created", async () => {
@@ -718,8 +720,10 @@ describe("BridgeApp command surface", () => {
 
     await appAny.runTurn("oc_p2p_1");
 
-    expect(outbound.sendMessage).toHaveBeenCalledTimes(1);
-    expect(extractMarkdown(getSendPayloads(outbound)[0])).toContain("处理失败：服务暂时不可用");
+    expect(outbound.sendMessage).not.toHaveBeenCalled();
+    expect(outbound.replyMessage).toHaveBeenCalledTimes(1);
+    expect(outbound.replyMessage).toHaveBeenCalledWith("om_1", expect.any(Object));
+    expect(extractMarkdown(getReplyPayloads(outbound)[0])).toContain("处理失败：服务暂时不可用");
   });
 
   it("maps token refresh failures to an actionable provider login hint", async () => {
@@ -760,8 +764,10 @@ describe("BridgeApp command surface", () => {
 
     await appAny.runTurn("oc_p2p_1");
 
-    expect(outbound.sendMessage).toHaveBeenCalledTimes(1);
-    expect(extractMarkdown(getSendPayloads(outbound)[0])).toContain("请重新执行 `opencode providers login`");
+    expect(outbound.sendMessage).not.toHaveBeenCalled();
+    expect(outbound.replyMessage).toHaveBeenCalledTimes(1);
+    expect(outbound.replyMessage).toHaveBeenCalledWith("om_1", expect.any(Object));
+    expect(extractMarkdown(getReplyPayloads(outbound)[0])).toContain("请重新执行 `opencode providers login`");
   });
 
   it("keeps session selection state after an unrelated turn finishes", async () => {
@@ -1080,8 +1086,4 @@ function extractInteractiveHeader(payload: { content: string } | undefined): str
 
 function getReplyPayloads(outbound: ReturnType<typeof createOutbound>): Array<{ content: string } | undefined> {
   return (outbound.replyMessage.mock.calls as unknown[][]).map((call) => call[1] as { content: string } | undefined);
-}
-
-function getSendPayloads(outbound: ReturnType<typeof createOutbound>): Array<{ content: string } | undefined> {
-  return (outbound.sendMessage.mock.calls as unknown[][]).map((call) => call[1] as { content: string } | undefined);
 }

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -59,6 +59,7 @@ describe("startBridgeHttpServer", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual(expect.objectContaining({
       ok: true,
+      bridgeVersion: "0.1.12",
       queueLimit: 3,
       cardActionsEnabled: false,
       cardActionsPath: "/webhook/card",

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -34,6 +34,7 @@ vi.mock("@larksuiteoapi/node-sdk", () => {
 
 import { startBridgeHttpServer, type BridgeHttpServer } from "../src/http/server.js";
 import type { AppConfig } from "../src/config/schema.js";
+import { APP_VERSION } from "../src/version.js";
 
 describe("startBridgeHttpServer", () => {
   const servers: BridgeHttpServer[] = [];
@@ -59,7 +60,7 @@ describe("startBridgeHttpServer", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual(expect.objectContaining({
       ok: true,
-      bridgeVersion: "0.1.12",
+      bridgeVersion: APP_VERSION,
       queueLimit: 3,
       cardActionsEnabled: false,
       cardActionsPath: "/webhook/card",

--- a/test/knowledge-flow.test.ts
+++ b/test/knowledge-flow.test.ts
@@ -154,6 +154,60 @@ describe("knowledge base bridge flow", () => {
     expect(JSON.stringify(updatePayloads)).toContain("文件总结完成");
   });
 
+  it("rejects unsupported file types before entering the normal file flow", async () => {
+    const outbound = {
+      ...createOutbound(),
+      downloadMessageResource: vi.fn(),
+    };
+    const app = new BridgeApp(baseConfig(), outbound, logger(), createWhitelist(), {
+      knowledge: null,
+      memory: null,
+    });
+    const appAny = app as unknown as { pendingInteractions: Map<string, unknown> };
+
+    await app.handleIncomingMessage({
+      ...createTextMessage("归档.zip", "om_file_zip"),
+      messageType: "file",
+      file: {
+        fileKey: "file_zip",
+        fileName: "归档.zip",
+        size: 1_024,
+      },
+    });
+
+    const replyPayloads = (outbound.replyMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
+    expect(JSON.stringify(replyPayloads)).toContain("仅支持 .pdf / .docx / .txt / .md 文件");
+    expect(appAny.pendingInteractions.has("oc_p2p_1")).toBe(false);
+    expect(outbound.downloadMessageResource).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized files before entering the normal file flow", async () => {
+    const outbound = {
+      ...createOutbound(),
+      downloadMessageResource: vi.fn(),
+    };
+    const app = new BridgeApp(baseConfig(), outbound, logger(), createWhitelist(), {
+      knowledge: null,
+      memory: null,
+    });
+    const appAny = app as unknown as { pendingInteractions: Map<string, unknown> };
+
+    await app.handleIncomingMessage({
+      ...createTextMessage("超大文件.pdf", "om_file_large"),
+      messageType: "file",
+      file: {
+        fileKey: "file_large",
+        fileName: "超大文件.pdf",
+        size: 25 * 1024 * 1024,
+      },
+    });
+
+    const replyPayloads = (outbound.replyMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
+    expect(JSON.stringify(replyPayloads)).toContain("文件过大，请控制在 20MB 以内");
+    expect(appAny.pendingInteractions.has("oc_p2p_1")).toBe(false);
+    expect(outbound.downloadMessageResource).not.toHaveBeenCalled();
+  });
+
   it("queries the knowledge base directly while knowledge mode is enabled, then falls back to OpenCode after exit", async () => {
     const outbound = createOutbound();
     const eventStream = new FakeOpenCodeEventStream();

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -9,6 +9,7 @@ import { createLogger, createTextPreview } from "../src/logging/logger.js";
 describe("logger", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("creates previews", () => {
@@ -132,6 +133,7 @@ describe("logger", () => {
 
     const content = await readFile(path.join(dir, "bridge-2026-04-12.log"), "utf8");
     expect(content).toContain("scope");
+    expect(content).toContain("message");
   });
 });
 

--- a/test/module-manager.test.ts
+++ b/test/module-manager.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import { ModuleManager, type RuntimeModule } from "../src/bridge/module.js";
+
+describe("module manager", () => {
+  it("runs handlers by priority and stops after the first claim", async () => {
+    const calls: string[] = [];
+    const manager = new ModuleManager();
+
+    manager.register({
+      name: "late",
+      priority: 20,
+      async handleMessage() {
+        calls.push("late");
+        return { claimed: false };
+      },
+    } satisfies RuntimeModule);
+    manager.register({
+      name: "first",
+      priority: 10,
+      async handleMessage() {
+        calls.push("first");
+        return { claimed: true };
+      },
+    } satisfies RuntimeModule);
+    manager.register({
+      name: "skipped",
+      priority: 30,
+      async handleMessage() {
+        calls.push("skipped");
+        return { claimed: false };
+      },
+    } satisfies RuntimeModule);
+
+    const result = await manager.handleMessage({
+      message: {
+        chatId: "oc_p2p_1",
+        chatType: "p2p",
+        senderOpenId: "ou_123",
+        messageId: "om_1",
+        rawContent: "hello",
+        plainText: "hello",
+        threadKey: "om_1",
+        conversationKey: "oc_p2p_1",
+        messageType: "text",
+      },
+      routed: { kind: "message", text: "hello" },
+      pendingInteraction: null,
+    });
+
+    expect(result).toEqual({ claimed: true });
+    expect(calls).toEqual(["first"]);
+  });
+
+  it("collects system blocks and after-turn hooks in priority order", async () => {
+    const calls: string[] = [];
+    const manager = new ModuleManager();
+
+    manager.register({
+      name: "memory",
+      priority: 30,
+      async beforeTurn() {
+        calls.push("before-memory");
+        return { systemBlocks: ["[Memory Recall]\n- A", "   "] };
+      },
+      async afterTurn() {
+        calls.push("after-memory");
+      },
+    } satisfies RuntimeModule);
+    manager.register({
+      name: "knowledge",
+      priority: 20,
+      async beforeTurn() {
+        calls.push("before-knowledge");
+        return { systemBlocks: ["[Knowledge Hint]\n- B"] };
+      },
+      async afterTurn() {
+        calls.push("after-knowledge");
+      },
+    } satisfies RuntimeModule);
+
+    const turn = {
+      turnId: "turn_1",
+      chatId: "oc_p2p_1",
+      conversationKey: "oc_p2p_1",
+      threadKey: "om_1",
+      chatType: "p2p",
+      senderOpenId: "ou_123",
+      inboundMessageId: "om_1",
+      plainText: "hello",
+      text: "hello",
+      sessionId: "ses_1",
+    };
+    const window = {
+      mode: "multi" as const,
+      activeSessionId: "ses_1",
+      sessions: [{ sessionId: "ses_1", label: "当前会话", createdAt: 1, lastUsedAt: 1 }],
+      interactionMode: "default" as const,
+    };
+
+    const blocks = await manager.collectBeforeTurnBlocks({ turn, window });
+    await manager.runAfterTurnHooks({ turn, window, reply: "done" });
+
+    expect(blocks).toEqual([
+      "[Knowledge Hint]\n- B",
+      "[Memory Recall]\n- A",
+    ]);
+    expect(calls).toEqual([
+      "before-knowledge",
+      "before-memory",
+      "after-knowledge",
+      "after-memory",
+    ]);
+  });
+});


### PR DESCRIPTION
## 变更内容
- 引入 `RuntimeModule` / `ModuleManager`，建立 `core / modules / skills / scripts` 的运行时分层骨架
- 将 `knowledge` 改造成独立 runtime module，承接知识库命令、query、ingest 状态、队列与重启恢复逻辑
- 将 `memory` 改为 `beforeTurn / afterTurn` hook 形式接入，移除对 `app.ts` 的直接耦合
- 收敛 `app.ts`、`command-handler.ts`、`turn-executor.ts` 中对具体业务能力的直接认知，保留 bridge core 与默认兜底流程
- 补充普通文件类型与大小前置校验，避免不支持文件或超大文件进入普通文件跟进流程
- 补充 `src/version.ts`、`/healthz bridgeVersion`、`LICENSE`、运行时分层文档与相关测试

## 变更原因
- 当前功能已经进入可持续扩展阶段，需要稳定的运行时骨架承接后续模块化能力
- `knowledge` 与 `memory` 继续堆叠在 `app.ts` 中会让主链越来越难维护、测试和扩展
- 普通文件处理缺少前置校验，会带来资源风险和错误体验
- 旧 PR `#15` `#16` `#17` `#18` 中的有效内容已经在此分支吸收或重做，需要统一收敛到一个新的集成入口

## 影响
- 后续新运行时能力可以优先按 runtime module 接入，而不必继续把业务状态塞回 `app.ts`
- 知识库与记忆能力的生命周期、消息 claim 和 turn hook 边界更清晰
- `/healthz` 会暴露 `bridgeVersion`，启动日志也会记录当前版本
- 普通文件上传在进入说明流前会先校验类型和大小
- 旧 PR `#15` `#16` `#17` `#18` 已关闭，后续以本 PR 作为唯一合并入口

## 验证
- `npm test`
- `npm run typecheck`
- `npm run lint`