### PR TITLE
[codex] 打磨知识入库汇总与启动前检查

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The project follows Semantic Versioning.
 
+## 0.1.24 - 2026-04-17
+
+### Fixed
+- Fixed startup preflight directory checks so writable directories with dotted names such as `data.v1` are validated directly instead of accidentally falling back to their parent directory.
+- Fixed knowledge-ingest runtime flow so queued materials continue to be accepted during an active ingest session instead of being blocked by the bridge queue limit.
+
+### Changed
+- Updated knowledge-ingest final summary cards to use a denser overview plus compact per-file details for larger batch imports.
+
 ## 0.1.23 - 2026-04-17
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feishu-opencode-bridge",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feishu-opencode-bridge",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.42.0",
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feishu-opencode-bridge",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/feishu/formatter.ts
+++ b/src/feishu/formatter.ts
@@ -465,44 +465,61 @@ export function buildKnowledgeIngestSessionPayload(view: KnowledgeIngestSessionS
 }
 
 export function buildKnowledgeIngestSessionFinalPayload(view: KnowledgeIngestSessionSummaryView): FeishuPostPayload {
-  const bodyElements: Array<Record<string, unknown>> = [];
   const results = view.results ?? [];
   const failures = view.failures ?? [];
-
-  if (results.length > 0 || failures.length > 0) {
-    results.forEach((result, index) => {
-      if (bodyElements.length > 0) {
-        bodyElements.push(buildDivider());
-      }
-      bodyElements.push(buildKnowledgeIngestSummaryItem(result, "success"));
-      if (index === results.length - 1 && failures.length === 0) {
-        return;
-      }
-    });
-    failures.forEach((failure) => {
-      if (bodyElements.length > 0) {
-        bodyElements.push(buildDivider());
-      }
-      bodyElements.push(buildKnowledgeIngestFailureSummaryItem(failure));
-    });
-  } else {
-    bodyElements.push(buildStatsRow([
-      `入库 ${view.totalExtractedCount}`,
-      `失败 ${view.failedCount}`,
-      `去重 ${view.totalDedupedCount}`,
-    ]));
-  }
+  const summaryLines = [
+    `**成功**：${view.completedCount} 个素材`,
+    `**失败**：${view.failedCount} 个素材`,
+    `**总入库**：${view.totalExtractedCount} 条问答`,
+    `**去重合并**：${view.totalDedupedCount} 条`,
+    ...(view.elapsedMs ? [`**总耗时**：${formatDurationMs(view.elapsedMs)}`] : []),
+  ];
+  const detailLines = buildKnowledgeIngestFinalDetailLines(results, failures);
 
   return buildInteractivePayload({
     title: "本次入库完成",
     template: "indigo",
     iconToken: "grid-view_filled",
     bodyElements: [
-      ...bodyElements,
+      buildGreyPanel([
+        cardMarkdown(summaryLines.join("\n"), "normal_v2"),
+      ]),
+      ...(detailLines.length > 0 ? [
+        buildDivider(),
+        cardMarkdown(detailLines.join("\n\n"), "normal_v2"),
+      ] : []),
       buildDivider(),
       ...(view.bitableUrl ? [cardMarkdown(`[查看知识库 →](${escapeText(view.bitableUrl)})`, "normal")] : []),
     ],
   });
+}
+
+function buildKnowledgeIngestFinalDetailLines(
+  results: KnowledgeIngestResult[],
+  failures: Array<{ sourceFile: string; reason: string }>,
+): string[] {
+  const maxVisibleItems = 12;
+  const lines: string[] = [];
+  const successLines = results.map((result) => {
+    const rawExtractedCount = result.rawExtractedCount ?? result.extractedCount;
+    const dedupedCount = result.dedupedCount ?? Math.max(0, rawExtractedCount - result.extractedCount);
+    return [
+      `**${escapeText(result.sourceFile)}**`,
+      `入库 ${result.extractedCount} · 提取 ${rawExtractedCount} · 去重 ${dedupedCount}`,
+    ].join("\n");
+  });
+  const failureLines = failures.map((failure) => [
+    `**${escapeText(failure.sourceFile)}**`,
+    `失败 · ${escapeText(failure.reason)}`,
+  ].join("\n"));
+  const allLines = [...successLines, ...failureLines];
+  const visibleLines = allLines.slice(0, maxVisibleItems);
+  lines.push(...visibleLines);
+  const omittedCount = allLines.length - visibleLines.length;
+  if (omittedCount > 0) {
+    lines.push(`其余 ${omittedCount} 个素材已省略，请查看知识库或日志获取完整结果。`);
+  }
+  return lines;
 }
 
 export function buildKnowledgeIngestPayload(view: KnowledgeIngestResult): FeishuPostPayload {
@@ -892,37 +909,6 @@ function buildKnowledgeIngestProgressStepElements(step: ToolUpdateView): Array<R
     elements.push(buildQuoteLine(detail));
   }
   return elements;
-}
-
-function buildKnowledgeIngestSummaryItem(result: KnowledgeIngestResult, state: "success" | "error"): Record<string, unknown> {
-  const rawExtractedCount = result.rawExtractedCount ?? result.extractedCount;
-  const dedupedCount = result.dedupedCount ?? Math.max(0, rawExtractedCount - result.extractedCount);
-  return buildStretchColumnSet([
-    buildWeightedColumn([
-      buildTitleLine(`文件：**${escapeText(result.sourceFile)}**`, {
-        token: state === "success" ? "succeed-hollow_filled" : "error-hollow_filled",
-        color: state === "success" ? "green" : "red",
-      }),
-      buildStatsRow([
-        `入库 ${result.extractedCount}`,
-        `提取 ${rawExtractedCount}`,
-        `去重 ${dedupedCount}`,
-      ]),
-      buildTagChartSection(result.tagCounts),
-    ], { padding: "0px 0px 0px 0px", verticalSpacing: "8px" }),
-  ], "8px");
-}
-
-function buildKnowledgeIngestFailureSummaryItem(failure: { sourceFile: string; reason: string }): Record<string, unknown> {
-  return buildStretchColumnSet([
-    buildWeightedColumn([
-      buildTitleLine(`文件：**${escapeText(failure.sourceFile)}**`, {
-        token: "error-hollow_filled",
-        color: "red",
-      }),
-      buildQuoteLine(escapeText(failure.reason)),
-    ], { padding: "0px 0px 0px 0px", verticalSpacing: "8px" }),
-  ], "8px");
 }
 
 function resolveElapsedText(view: { elapsedMs?: number | undefined; startedAt?: number | undefined }): string {

--- a/src/knowledge/runtime-module.ts
+++ b/src/knowledge/runtime-module.ts
@@ -50,7 +50,7 @@ type KnowledgeIngestQueueItem = {
   conversationKey: string;
   chatId: string;
   requesterOpenId: string;
-  receiptMessageId: string;
+  receiptMessageId?: string | undefined;
   processingMessageId?: string | undefined;
   progressState: KnowledgeIngestProgressState;
 } & (
@@ -534,14 +534,14 @@ export class KnowledgeRuntimeModule implements RuntimeModule {
       await this.sendKnowledgeIngestMarkdown(pending, "已收到结束指令，当前队列处理完成后会自动结束。");
       return true;
     }
-    const queuedCount = queue.pending.length + (queue.active ? 1 : 0);
-    if (queuedCount >= this.deps.config.bridge.queueLimit) {
-      await this.sendKnowledgeIngestMarkdown(pending, "已达上限，请等待当前文件处理完成。");
-      return true;
-    }
-
     const progressState = createKnowledgeIngestProgressState(sourceLabel);
-    const processing = await this.deps.sendPayload(message.chatId, buildNoticeCardPayload({
+    const queuedItem: KnowledgeIngestQueueItem = {
+      ...itemInput,
+      progressState,
+    };
+    queue.pending.push(queuedItem);
+    this.refreshKnowledgeIngestPending(pending.conversationKey, pending);
+    const receipt = await this.deps.sendPayload(message.chatId, buildNoticeCardPayload({
       title: "已收到入库素材",
       template: "blue",
       iconToken: itemInput.kind === "web" ? "global-link_outlined" : "file-link-docx_outlined",
@@ -557,12 +557,7 @@ export class KnowledgeRuntimeModule implements RuntimeModule {
       textPreview: sourceLabel,
       len: sourceLabel.length,
     }, this.getKnowledgeIngestDelivery(pending));
-    queue.pending.push({
-      ...itemInput,
-      receiptMessageId: processing.messageId,
-      progressState,
-    });
-    this.refreshKnowledgeIngestPending(pending.conversationKey, pending);
+    queuedItem.receiptMessageId = receipt.messageId;
     return true;
   }
 

--- a/src/runtime/preflight.ts
+++ b/src/runtime/preflight.ts
@@ -1,6 +1,5 @@
 import { constants } from "node:fs";
 import { access } from "node:fs/promises";
-import path from "node:path";
 
 import type { AppConfig } from "../config/schema.js";
 import { OpenCodeClient } from "../opencode/client.js";
@@ -75,6 +74,5 @@ async function runCheck(name: string, report: ReportFn, fn: () => Promise<void>)
 }
 
 async function ensureWritable(target: string): Promise<void> {
-  const dir = path.extname(target) ? path.dirname(target) : target;
-  await access(dir, constants.R_OK | constants.W_OK);
+  await access(target, constants.R_OK | constants.W_OK);
 }

--- a/test/knowledge-flow.test.ts
+++ b/test/knowledge-flow.test.ts
@@ -701,7 +701,7 @@ describe("knowledge base bridge flow", () => {
     expect(JSON.stringify(updatedPayloads)).toContain("普通对话继续处理");
   });
 
-  it("rejects new ingest material when the ingest queue is full", async () => {
+  it("keeps accepting queued ingest material even when bridge queueLimit is small", async () => {
     const outbound = createOutbound();
     const eventStream = new FakeOpenCodeEventStream();
     const opencode = new FakeOpenCodeClient(eventStream, { kind: "message-flow", finalText: "not used" });
@@ -759,13 +759,13 @@ describe("knowledge base bridge flow", () => {
     });
     resolveIngest?.();
     await vi.waitFor(() => {
-      const updatedPayloads = (outbound.updateMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
-      expect(JSON.stringify(updatedPayloads)).toContain("本次入库完成");
+      expect(ingestFile).toHaveBeenCalledTimes(2);
     });
 
     const replyPayloads = (outbound.replyMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
-    expect(ingestFile).toHaveBeenCalledTimes(1);
-    expect(JSON.stringify(replyPayloads)).toContain("已达上限，请等待当前文件处理完成");
+    expect(JSON.stringify(replyPayloads)).toContain("已收到入库素材");
+    expect(JSON.stringify(replyPayloads)).toContain("劳动合同2.txt");
+    expect(JSON.stringify(replyPayloads)).not.toContain("已达上限，请等待当前文件处理完成");
   });
 
   it("marks persisted active ingest sessions interrupted on restart", async () => {

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -1,3 +1,7 @@
+import { chmod, mkdir, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { AppConfig } from "../src/config/schema.js";
@@ -68,6 +72,27 @@ describe("runStartupPreflight", () => {
     await expect(runStartupPreflight(config, {
       getTenantToken: async () => "tenant-token",
     }, () => {})).rejects.toThrow(/数据目录/i);
+  });
+
+  it("fails when a dotted data directory exists but is not writable", async () => {
+    stubHealthyFetch();
+
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "preflight-"));
+    const dataDir = path.join(tempRoot, "data.v1");
+    await mkdir(dataDir);
+    await chmod(dataDir, 0o555);
+
+    try {
+      const config = baseConfig();
+      config.storage.dataDir = dataDir;
+
+      await expect(runStartupPreflight(config, {
+        getTenantToken: async () => "tenant-token",
+      }, () => {})).rejects.toThrow(/数据目录/i);
+    } finally {
+      await chmod(dataDir, 0o755);
+      await rm(tempRoot, { recursive: true, force: true });
+    }
   });
 
   it("fails when Feishu credentials are invalid", async () => {


### PR DESCRIPTION
### 变更内容
- 调整知识入库会话流，允许在进行中的批量入库会话里继续追加素材，不再受 bridge queueLimit 阻塞。
- 压缩知识入库完成卡片的汇总布局，改为总览统计加紧凑的按文件明细。
- 修正启动前目录可写性检查，对 `data.v1` 这类带点目录直接校验目标目录本身。
- 补充对应的 knowledge-flow 与 preflight 回归测试，并更新版本到 0.1.24。

### 变更原因
- 当前知识入库更接近会话式批处理，继续沿用 bridge 队列上限会让用户在一次入库中被意外拦截。
- 入库完成卡片在素材较多时过长，不利于直接在飞书里快速看结果。
- 启动前检查对带点目录的判断有误，可能把不可写数据目录漏判为可用。

### 影响
- 知识入库体验更连贯，批量追加素材时不会再收到错误的“已达上限”提示。
- 飞书里的知识入库汇总更紧凑，但仍保留每个素材的入库/失败明细。
- 预检能更早挡住真实的数据目录权限问题。

### 验证
- `npm test`
- `npm run typecheck`
- `npm run lint`