### PR TITLE
[codex] 收敛运行时结算与资源边界

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The project follows Semantic Versioning.
 
+## 0.1.26 - 2026-04-19
+
+### Changed
+- Refactored TurnExecutor settlement handling so fallback timers, watchdog cleanup, unsubscribe, and final resolution are owned by a dedicated settlement helper.
+- Tightened runtime module resource wiring so BridgeApp adapts the outbound resource port once before assembling resource-backed modules.
+- Closed the post-freeze runtime cleanup backlog with verification notes and a smaller follow-up candidate.
+
+### Fixed
+- Fixed persisted interaction handling so already-expired interactions are dropped instead of scheduling immediate expiry work.
+- Fixed first-SSE fallback coverage to verify the latest completed assistant message is streamed and settled when OpenCode events never arrive.
+
 ## 0.1.25 - 2026-04-19
 
 ### Added

--- a/docs/plans/post-freeze-backlog.md
+++ b/docs/plans/post-freeze-backlog.md
@@ -1,46 +1,55 @@
 # Post-Freeze Backlog
 
-These items are explicitly not blockers for framework freeze acceptance.
+Status: closed as of 2026-04-19.
+
+These items were not blockers for framework freeze acceptance. They were reviewed after freeze and either completed with code/tests or closed as already satisfied by the frozen architecture.
 
 ## TurnExecutor Third Cut
 
-- Current state: `prepareTurnExecution()`, `executePromptWithEventStream()`, and `handlePermissionAskedEvent()` reduce the first dense areas.
-- Why not a blocker: settle, fallback, and watchdog behavior remained intact during freeze, and the current shape is covered by the existing turn executor and integration tests.
-- Suggested trigger: first post-freeze runtime orchestration change or any bug that touches fallback/watchdog behavior.
+- Final state: closed.
+- Resolution: `TurnExecutionSettlement` now owns turn settlement, fallback timer cleanup, unsubscribe, watchdog cleanup, and resolver/reject plumbing.
+- Verification: `test/turn-executor.test.ts` covers the first-SSE fallback path with fake timers.
 
 ## Runtime Module Dependency Tightening
 
-- Current state: `createRuntimeModules()` accepts an outbound shape that is narrower at the type boundary than some knowledge-resource consumers need.
-- Why not a blocker: runtime guards and tests cover the current assembly path.
-- Suggested trigger: before adding another module that downloads or updates Feishu resources.
+- Final state: closed.
+- Resolution: `createRuntimeModules()` now requires a complete outbound resource port at the type boundary instead of accepting `Partial<KnowledgeResourcePort>` and narrowing later. `BridgeApp` adapts its outbound dependency into that complete port and fails early when resource-backed modules are enabled without required Feishu resource methods.
+- Verification: `test/runtime-modules.test.ts` assembles modules with a complete outbound resource stub, and flow tests cover the app-level adapter path.
 
 ## FeishuTransport Notice Convenience
 
-- Current state: `sendNotice()` is a known convenience that couples transport to notice-card construction.
-- Why not a blocker: it is intentionally Feishu-only and avoids repeated notice-send plumbing.
-- Suggested trigger: if another card-family convenience method is proposed.
+- Final state: closed.
+- Resolution: `sendNotice()` remains the only transport-level card-building convenience and is explicitly documented as a narrow exception.
+- Verification: no additional card-family convenience helpers were added.
 
 ## Contract Transport Call Style
 
-- Current state: contract and labor modules both use `FeishuTransport`, but their local call style is not perfectly identical.
-- Why not a blocker: behavior and ownership are correct; this is consistency cleanup.
-- Suggested trigger: next contract-assistant runtime-module edit.
+- Final state: closed.
+- Resolution: contract and labor modules both call `this.deps.transport.sendPayload()` / `updatePayload()` directly for runtime sends.
+- Verification: no contract-specific private transport wrapper remains.
 
 ## PersistedInteractionManager Error Semantics
 
-- Current state: `flush()` is designed to log persistence failures rather than throw them back into feature flows.
-- Why not a blocker: this preserves current runtime behavior and avoids failing user-facing flows on best-effort persistence writes.
-- Suggested trigger: if a caller needs hard durability acknowledgement.
+- Final state: closed.
+- Resolution: `flush()` is documented as non-throwing, and persist failures are logged by `schedulePersist()`.
+- Verification: `test/persisted-interaction-manager.test.ts` covers non-throwing `flush()` on persist failure.
 
 ## Expired Interaction Set Semantics
 
-- Current state: restored interactions are filtered for expiry; explicitly setting an already-expired interaction may schedule an immediate expiry.
-- Why not a blocker: current callers set future TTLs.
-- Suggested trigger: before exposing `PersistedInteractionManager` beyond pending runtime interactions.
+- Final state: closed.
+- Resolution: `set()` ignores already-expired interactions by deleting any existing entry and returning without scheduling an immediate timer.
+- Verification: `test/persisted-interaction-manager.test.ts` covers already-expired `set()` input.
 
 ## Contract Card Family Follow-Up
 
-- Current state: `contract-cards.ts` exists and business callers use family entrypoints.
-- Why not a blocker: formatter compatibility is preserved and tests cover contract cards.
-- Suggested trigger: when removing or shrinking the remaining compatibility surface in `formatter.ts`.
+- Final state: closed.
+- Resolution: `contract-cards.ts` is an independent card family, and `formatter.ts` is a compatibility re-export surface.
+- Verification: `test/formatter.test.ts` covers contract-family compatibility re-exports.
 
+## New Follow-Up Candidate
+
+### Module Resource Requirements
+
+- Current state: `BridgeApp` still knows which configured features require Feishu resource methods when adapting its outbound dependency for `createRuntimeModules()`.
+- Why not part of this closure: moving that requirement into module self-declaration would widen this cleanup into module metadata design.
+- Suggested trigger: before adding the next runtime module that needs Feishu resource download or Bitable access.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feishu-opencode-bridge",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feishu-opencode-bridge",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.42.0",
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feishu-opencode-bridge",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -215,7 +215,7 @@ export class BridgeApp {
     });
     const moduleAssembly = createRuntimeModules({
       config: this.config,
-      outbound: this.outbound as OutboundPort & Partial<KnowledgeResourcePort>,
+      outbound: this.getRuntimeModuleOutbound(),
       transport,
       logger: this.logger,
       opencode: this.opencode as OpenCodeClient,
@@ -747,6 +747,37 @@ export class BridgeApp {
       }
     }
     return null;
+  }
+
+  private getRuntimeModuleOutbound(): OutboundPort & KnowledgeResourcePort {
+    const resources = this.outbound as OutboundPort & Partial<KnowledgeResourcePort>;
+    const missing = [
+      "downloadMessageResource",
+      "createBitableRecord",
+      "listBitableRecords",
+      "updateBitableRecord",
+    ].filter((name) => typeof resources[name as keyof KnowledgeResourcePort] !== "function");
+    if (missing.length > 0 && this.hasResourceBackedFeatureEnabled()) {
+      throw new Error(`runtime modules require outbound resource methods: ${missing.join(", ")}`);
+    }
+    const missingResourceMethod = async (): Promise<never> => {
+      throw new Error("当前运行环境不支持飞书资源操作。");
+    };
+    return {
+      ...this.outbound,
+      downloadMessageResource: resources.downloadMessageResource ?? missingResourceMethod,
+      createBitableRecord: resources.createBitableRecord ?? missingResourceMethod,
+      listBitableRecords: resources.listBitableRecords ?? missingResourceMethod,
+      updateBitableRecord: resources.updateBitableRecord ?? missingResourceMethod,
+    };
+  }
+
+  private hasResourceBackedFeatureEnabled(): boolean {
+    return Boolean(
+      this.config.knowledgeBase.enabled
+      || this.config.contractAssistant?.enabled
+      || this.config.laborSkill?.enabled,
+    );
   }
 
   private async prepareFileForOpenCodeTurn(

--- a/src/runtime/runtime-modules.ts
+++ b/src/runtime/runtime-modules.ts
@@ -33,6 +33,8 @@ type KnowledgeResourcePort = {
   updateBitableRecord(appToken: string, tableId: string, recordId: string, fields: Record<string, unknown>): Promise<void>;
 };
 
+type RuntimeModuleOutboundPort = OutboundPort & KnowledgeResourcePort;
+
 export type RuntimeModuleAssemblyResult = {
   moduleManager: ModuleManager;
   knowledgeModule: KnowledgeRuntimeModule;
@@ -40,7 +42,7 @@ export type RuntimeModuleAssemblyResult = {
 
 export function createRuntimeModules(options: {
   config: AppConfig;
-  outbound: OutboundPort & Partial<KnowledgeResourcePort>;
+  outbound: RuntimeModuleOutboundPort;
   transport: FeishuTransport;
   logger: Logger;
   opencode: Pick<OpenCodeClient,
@@ -119,14 +121,13 @@ function createMemoryService(
 
 function createKnowledgeService(
   config: AppConfig,
-  outbound: OutboundPort & Partial<KnowledgeResourcePort>,
+  outbound: RuntimeModuleOutboundPort,
   opencode: OpenCodeClient,
   logger: Logger,
 ): KnowledgeBasePort | null {
   if (!config.knowledgeBase.enabled) {
     return null;
   }
-  assertKnowledgeResourcePort(outbound, "knowledge base");
   return new KnowledgeBaseService(
     config.knowledgeBase,
     outbound,
@@ -137,7 +138,7 @@ function createKnowledgeService(
 
 function createContractAssistantService(
   config: AppConfig,
-  outbound: OutboundPort & Partial<KnowledgeResourcePort>,
+  outbound: RuntimeModuleOutboundPort,
   opencode: OpenCodeClient,
   logger: Logger,
 ): ContractAssistantService | null {
@@ -145,7 +146,6 @@ function createContractAssistantService(
   if (!contractAssistantConfig.enabled) {
     return null;
   }
-  assertKnowledgeResourcePort(outbound, "contract assistant");
   return new ContractAssistantService(
     contractAssistantConfig,
     config.storage.dataDir,
@@ -157,7 +157,7 @@ function createContractAssistantService(
 
 function createLaborSkillService(
   config: AppConfig,
-  outbound: OutboundPort & Partial<KnowledgeResourcePort>,
+  outbound: RuntimeModuleOutboundPort,
   opencode: OpenCodeClient,
   logger: Logger,
   knowledge: KnowledgeBasePort | null,
@@ -166,7 +166,6 @@ function createLaborSkillService(
   if (!laborSkillConfig.enabled) {
     return null;
   }
-  assertKnowledgeResourcePort(outbound, "labor skill");
   return new LaborSkillService(
     laborSkillConfig,
     config.storage.dataDir,
@@ -175,22 +174,4 @@ function createLaborSkillService(
     logger,
     knowledge,
   );
-}
-
-function assertKnowledgeResourcePort(
-  outbound: OutboundPort & Partial<KnowledgeResourcePort>,
-  featureName: string,
-): asserts outbound is OutboundPort & KnowledgeResourcePort {
-  const missing = [
-    "downloadMessageResource",
-    "createBitableRecord",
-    "listBitableRecords",
-    "updateBitableRecord",
-  ].filter((name) => typeof outbound[name as keyof KnowledgeResourcePort] !== "function");
-
-  if (missing.length === 0) {
-    return;
-  }
-
-  throw new Error(`${featureName} requires outbound resource methods: ${missing.join(", ")}`);
 }

--- a/src/runtime/turn-executor.ts
+++ b/src/runtime/turn-executor.ts
@@ -34,6 +34,74 @@ import { cleanAssistantReply } from "./sanitize.js";
 const FIRST_SSE_FALLBACK_MS = 5_000;
 const PERMISSION_TTL_MS = 120_000;
 
+type TurnExecutionSettlementOptions = {
+  finalize: () => Promise<string>;
+  reject: (reason?: unknown) => void;
+  resolve: (value: string) => void;
+  unsubscribe: () => void;
+  watchdog: TurnWatchdog;
+};
+
+class TurnExecutionSettlement {
+  private settled = false;
+  private fallbackTimer: NodeJS.Timeout | null = null;
+  private seenSessionEvent = false;
+
+  constructor(private readonly options: TurnExecutionSettlementOptions) {}
+
+  startFallback(runFallback: () => void): void {
+    this.fallbackTimer = setTimeout(() => {
+      if (!this.seenSessionEvent) {
+        runFallback();
+      }
+    }, FIRST_SSE_FALLBACK_MS);
+  }
+
+  markSessionEvent(): void {
+    this.seenSessionEvent = true;
+    this.clearFallbackTimer();
+  }
+
+  markWatchdogEvent(nextWatchdogGapMs: number | null): void {
+    if (nextWatchdogGapMs !== null) {
+      this.options.watchdog.snoozeEventGap(nextWatchdogGapMs);
+      return;
+    }
+
+    this.options.watchdog.markEvent();
+  }
+
+  settleWithError(error: Error): void {
+    if (this.settled) return;
+    this.settled = true;
+    this.cleanup();
+    this.options.reject(error);
+  }
+
+  async settleWithText(): Promise<void> {
+    if (this.settled) return;
+    this.settled = true;
+    this.cleanup();
+    try {
+      this.options.resolve(await this.options.finalize());
+    } catch (error) {
+      this.options.reject(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
+  private cleanup(): void {
+    this.clearFallbackTimer();
+    this.options.unsubscribe();
+    this.options.watchdog.clear();
+  }
+
+  private clearFallbackTimer(): void {
+    if (!this.fallbackTimer) return;
+    clearTimeout(this.fallbackTimer);
+    this.fallbackTimer = null;
+  }
+}
+
 type RuntimeQueue = {
   peek(): BridgeTurn | null;
   replaceActive(turn: BridgeTurn): void;
@@ -237,46 +305,38 @@ export class TurnExecutor {
     return new Promise<string>((resolve, reject) => {
       let assistantMessageId: string | null = null;
       let finalText = "";
-      let settled = false;
-      let fallbackTimer: NodeJS.Timeout | null = null;
-      let seenSessionEvent = false;
       const ignoredTextPartIds = new Set<string>();
       const pendingTextEvents: Array<{ messageId: string; kind: "delta" | "set"; value: string }> = [];
 
-      const settleWithError = (error: Error): void => {
-        if (settled) return;
-        settled = true;
-        if (fallbackTimer) clearTimeout(fallbackTimer);
-        unsubscribe();
-        watchdog.clear();
-        reject(error);
-      };
+      let unsubscribe = (): void => {};
+      const settleWithError = (error: Error): void => { settlement.settleWithError(error); };
+      const watchdog = new TurnWatchdog(
+        {
+          firstEventTimeoutMs: this.context.config.bridge.firstEventTimeoutMs,
+          eventGapTimeoutMs: this.context.config.bridge.eventGapTimeoutMs,
+          totalTimeoutMs: this.context.config.bridge.totalTimeoutMs,
+        },
+        {
+          onFirstEventTimeout: () => settleWithError(new Error("处理超时，请重试或 /new 开新会话")),
+          onEventGapTimeout: () => settleWithError(new Error("处理超时，请重试或 /new 开新会话")),
+          onTotalTimeout: () => settleWithError(new Error("处理超时，请重试或 /new 开新会话")),
+        },
+      );
+      const settlement = new TurnExecutionSettlement({
+        finalize: () => this.finalizeAssistantReply(turn.sessionId, finalText, {
+          baselineAssistantId: baseline.baselineAssistantId,
+          baselineAssistantTimestamp: baseline.baselineAssistantTimestamp,
+          assistantMessageId,
+        }),
+        reject,
+        resolve,
+        unsubscribe: () => { unsubscribe(); },
+        watchdog,
+      });
 
-      const settleWithText = async (): Promise<void> => {
-        if (settled) return;
-        settled = true;
-        if (fallbackTimer) clearTimeout(fallbackTimer);
-        unsubscribe();
-        watchdog.clear();
-        try {
-          const text = await this.finalizeAssistantReply(turn.sessionId, finalText, {
-            baselineAssistantId: baseline.baselineAssistantId,
-            baselineAssistantTimestamp: baseline.baselineAssistantTimestamp,
-            assistantMessageId,
-          });
-          resolve(text);
-        } catch (error) {
-          reject(error instanceof Error ? error : new Error(String(error)));
-        }
-      };
-
-      const unsubscribe = this.context.eventStream.subscribe(async (event) => {
+      unsubscribe = this.context.eventStream.subscribe(async (event) => {
         if (getEventSessionId(event) !== turn.sessionId) return;
-        seenSessionEvent = true;
-        if (fallbackTimer) {
-          clearTimeout(fallbackTimer);
-          fallbackTimer = null;
-        }
+        settlement.markSessionEvent();
 
         try {
           let nextWatchdogGapMs: number | null = null;
@@ -309,56 +369,37 @@ export class TurnExecutor {
               finalText = value;
               await this.context.turnCardManager.scheduleStreamUpdate(turn.turnId, finalText);
             },
-            finish: settleWithText,
-            fail: settleWithError,
+            finish: () => settlement.settleWithText(),
+            fail: (error) => settlement.settleWithError(error),
             getFinalText: () => finalText,
             snoozeWatchdog: (timeoutMs) => { nextWatchdogGapMs = timeoutMs; },
           });
-          if (nextWatchdogGapMs !== null) {
-            watchdog.snoozeEventGap(nextWatchdogGapMs);
-          } else {
-            watchdog.markEvent();
-          }
+          settlement.markWatchdogEvent(nextWatchdogGapMs);
         } catch (error) {
           const detail = error instanceof Error ? error.message : String(error);
           this.context.logger.log("opencode/events", "event listener failed", { chatId: turn.chatId, conversationKey: turn.conversationKey, sessionId: turn.sessionId, detail, type: event.type }, "warn");
         }
       });
 
-      const watchdog = new TurnWatchdog(
-        {
-          firstEventTimeoutMs: this.context.config.bridge.firstEventTimeoutMs,
-          eventGapTimeoutMs: this.context.config.bridge.eventGapTimeoutMs,
-          totalTimeoutMs: this.context.config.bridge.totalTimeoutMs,
-        },
-        {
-          onFirstEventTimeout: () => settleWithError(new Error("处理超时，请重试或 /new 开新会话")),
-          onEventGapTimeout: () => settleWithError(new Error("处理超时，请重试或 /new 开新会话")),
-          onTotalTimeout: () => settleWithError(new Error("处理超时，请重试或 /new 开新会话")),
-        },
-      );
-
       watchdog.start();
       void this.context.opencode.promptAsync(turn.sessionId, buildPromptRequest(turn.text, systemPrompt))
         .then(() => {
           queue.replaceActive(transitionTurn(turn, "awaiting-sse"));
           void this.context.turnCardManager.updateTurnCard(turn.turnId, { status: "处理中", update: "请求已发送，等待事件流...", target: "step" });
-          fallbackTimer = setTimeout(() => {
-            if (!seenSessionEvent) {
-              void this.runFirstSseFallback(turn.sessionId, {
-                baselineAssistantId: baseline.baselineAssistantId,
-                baselineAssistantTimestamp: baseline.baselineAssistantTimestamp,
-                assistantMessageId: () => assistantMessageId,
-              }, {
-                updateText: async (text) => {
-                  finalText = text;
-                  await this.context.turnCardManager.scheduleStreamUpdate(turn.turnId, finalText);
-                },
-                finish: settleWithText,
-                fail: settleWithError,
-              });
-            }
-          }, FIRST_SSE_FALLBACK_MS);
+          settlement.startFallback(() => {
+            void this.runFirstSseFallback(turn.sessionId, {
+              baselineAssistantId: baseline.baselineAssistantId,
+              baselineAssistantTimestamp: baseline.baselineAssistantTimestamp,
+              assistantMessageId: () => assistantMessageId,
+            }, {
+              updateText: async (text) => {
+                finalText = text;
+                await this.context.turnCardManager.scheduleStreamUpdate(turn.turnId, finalText);
+              },
+              finish: () => settlement.settleWithText(),
+              fail: settleWithError,
+            });
+          });
         })
         .catch((error) => settleWithError(error instanceof Error ? error : new Error(String(error))));
     });

--- a/test/knowledge-flow.test.ts
+++ b/test/knowledge-flow.test.ts
@@ -993,6 +993,11 @@ function createOutbound() {
     sendMessage: vi.fn(async () => ({ messageId: "om_send" })),
     replyMessage: vi.fn(async () => ({ messageId: "om_reply" })),
     updateMessage: vi.fn(async () => ({ messageId: "om_update" })),
+    downloadMessageResource: vi.fn(async () => ({
+      fileName: "fixture.txt",
+      mimeType: "text/plain",
+      buffer: Buffer.from("fixture"),
+    })),
     createBitableRecord: vi.fn(async () => "rec_1"),
     listBitableRecords: vi.fn(async () => []),
     updateBitableRecord: vi.fn(async () => {}),

--- a/test/persisted-interaction-manager.test.ts
+++ b/test/persisted-interaction-manager.test.ts
@@ -135,4 +135,33 @@ describe("PersistedInteractionManager", () => {
     await manager.stop();
     await rm(tempDir, { recursive: true, force: true });
   });
+
+  it("logs persist failures and keeps flush non-throwing", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "persisted-interactions-"));
+    const logger = { log: vi.fn() };
+    const manager = new PersistedInteractionManager<TestInteraction>({
+      stateFilePath: tempDir,
+      logger: logger as never,
+      logScope: "test/persisted",
+      getKey: (interaction) => interaction.conversationKey,
+      getExpiresAt: (interaction) => interaction.expiresAt,
+    });
+
+    manager.set({
+      conversationKey: "active",
+      expiresAt: Date.now() + 60_000,
+      label: "saved",
+    });
+
+    await expect(manager.flush()).resolves.toBeUndefined();
+    expect(logger.log).toHaveBeenCalledWith(
+      "test/persisted",
+      "persist state failed",
+      expect.objectContaining({ detail: expect.any(String) }),
+      "warn",
+    );
+
+    await manager.stop();
+    await rm(tempDir, { recursive: true, force: true });
+  });
 });

--- a/test/runtime-modules.test.ts
+++ b/test/runtime-modules.test.ts
@@ -5,7 +5,7 @@ import { createRuntimeModules } from "../src/runtime/runtime-modules.js";
 import type { AppConfig } from "../src/config/schema.js";
 
 describe("createRuntimeModules", () => {
-  it("allows missing resource methods when resource-backed features are disabled", () => {
+  it("assembles modules with the complete outbound resource port", () => {
     expect(() => {
       createRuntimeModules({
         config: createConfig({ knowledgeEnabled: false, contractEnabled: false, laborEnabled: false }),
@@ -20,22 +20,6 @@ describe("createRuntimeModules", () => {
       });
     }).not.toThrow();
   });
-
-  it("throws a clear error when an enabled feature lacks resource methods", () => {
-    expect(() => {
-      createRuntimeModules({
-        config: createConfig({ knowledgeEnabled: true, contractEnabled: false, laborEnabled: false }),
-        outbound: createOutbound(),
-        transport: createTransport(),
-        logger: { log: vi.fn() } as never,
-        opencode: createOpenCode(),
-        whitelist: { bind: vi.fn(async () => {}) },
-        getSessionWindow: () => ({ mode: "single", interactionMode: "default", activeSessionId: null, sessions: [] }),
-        saveSessionWindow: vi.fn(async () => {}),
-        createAndBindSession: vi.fn(async () => ({ sessionId: "ses_1", label: "会话", createdAt: 1, lastUsedAt: 1 })),
-      });
-    }).toThrow("knowledge base requires outbound resource methods");
-  });
 });
 
 function createOutbound() {
@@ -43,6 +27,14 @@ function createOutbound() {
     sendMessage: vi.fn(async () => ({ messageId: "om_send" })),
     replyMessage: vi.fn(async () => ({ messageId: "om_reply" })),
     updateMessage: vi.fn(async () => ({ messageId: "om_update" })),
+    downloadMessageResource: vi.fn(async () => ({
+      fileName: "fixture.txt",
+      mimeType: "text/plain",
+      buffer: Buffer.from("fixture"),
+    })),
+    createBitableRecord: vi.fn(async () => "rec_1"),
+    listBitableRecords: vi.fn(async () => []),
+    updateBitableRecord: vi.fn(async () => {}),
   };
 }
 

--- a/test/turn-executor.test.ts
+++ b/test/turn-executor.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { TurnExecutor, type TurnExecutorContext } from "../src/runtime/turn-executor.js";
 
 describe("TurnExecutor text buffering", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("does not surface non-assistant text before the assistant message is confirmed", async () => {
     const executor = new TurnExecutor(createContext()) as unknown as {
       handleEvent: (turn: Record<string, unknown>, event: Record<string, unknown>, runtime: ReturnType<typeof createRuntime>) => Promise<void>;
@@ -146,6 +150,45 @@ describe("TurnExecutor text buffering", () => {
     await executor.runTurn("queue-1");
 
     expect(cleanupTurnResources).toHaveBeenCalledWith("turn_1");
+  });
+
+  it("falls back to the latest completed assistant message when SSE does not arrive", async () => {
+    vi.useFakeTimers();
+    const context = createContext();
+    const replaceActive = vi.fn();
+    const scheduleStreamUpdate = vi.fn(async () => {});
+    context.queues.get = () => ({
+      peek: () => createTurn(),
+      replaceActive,
+      current: () => createTurn(),
+      finishActive() {},
+    });
+    context.opencode.promptAsync = vi.fn(async () => ({}));
+    context.opencode.getSessionMessages = vi.fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([{
+        info: {
+          id: "msg_assistant",
+          role: "assistant",
+          sessionID: "ses_1",
+          finish: "stop",
+          time: { created: Date.now(), completed: Date.now() },
+        },
+        parts: [{ type: "text", text: "fallback 最终回复" }],
+      }]);
+    context.turnCardManager.scheduleStreamUpdate = scheduleStreamUpdate;
+    const executor = new TurnExecutor(context) as unknown as {
+      runTurn: (queueKey: string) => Promise<void>;
+    };
+
+    const run = executor.runTurn("queue-1");
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(5_000);
+    await run;
+
+    expect(scheduleStreamUpdate).toHaveBeenCalledWith("turn_1", "fallback 最终回复");
+    expect(replaceActive).toHaveBeenCalledWith(expect.objectContaining({ state: "done" }));
   });
 });
 


### PR DESCRIPTION
### 变更内容
- 收敛 TurnExecutor 结算逻辑，引入专门的结算 helper 管理 fallback timer、watchdog、unsubscribe 和最终 resolve/reject。
- 调整 runtime module outbound 资源端口，由 BridgeApp 统一适配完整资源能力后再装配模块。
- 清零冻结后的运行时打磨项，补充 post-freeze backlog 的完成状态和后续候选项。
- 补充 TurnExecutor fallback、runtime module 装配、持久化交互过期处理等回归测试。
- 更新版本到 0.1.26，并同步 CHANGELOG。

### 变更原因
- 冻结后的运行时核心已经具备拆分基础，需要把 turn 结算和模块资源边界进一步收紧，减少后续功能开发时的隐性耦合。
- post-freeze backlog 里的若干打磨项已经完成，需要把状态回写到文档和版本记录中。

### 影响
- TurnExecutor 的超时、fallback、最终回复结算路径更集中，后续维护风险更低。
- 资源型 runtime module 的依赖检查前置到 BridgeApp 适配层，模块装配边界更明确。
- 对外命令和用户可见行为保持兼容。

### 验证
- `npm test`
- `npm run typecheck`
- `npm run lint`