### PR TITLE
[codex] 打磨 README 展示结构

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The project follows Semantic Versioning.
 
+## 0.1.28 - 2026-04-19
+
+### Changed
+- Polished the Chinese and English README presentation with a stronger project intro, news section, capability overview, and clearer architecture/command sections.
+- Synchronized README formatting so both language entrypoints share the same public-facing structure.
+
 ## 0.1.27 - 2026-04-19
 
 ### Added

--- a/README.en.md
+++ b/README.en.md
@@ -3,103 +3,123 @@
 [![Node.js](https://img.shields.io/badge/Node.js-20%2B-339933)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6)](https://www.typescriptlang.org/)
 [![Feishu](https://img.shields.io/badge/Feishu-Bridge-0F6FFF)](https://open.feishu.cn/)
+[![Tests](https://img.shields.io/badge/tests-371%20passing-success)](#%EF%B8%8F-development-commands)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 [中文](README.md) | **English**
 
-Feishu OpenCode Bridge is a Feishu-native runtime adapter for OpenCode.
+> **Feishu OpenCode Bridge is not a normal Feishu bot.**
+> It is a **Feishu-native runtime adapter** that productizes the OpenCode runtime inside Feishu, giving private chats, group chats, and topic groups session windows, process cards, permission confirmation, a legal knowledge base, contract/labor modules, and long-term memory.
 
-It turns Feishu chats into session-aware OpenCode workspaces with process cards, permission confirmation, knowledge workflows, contract/labor modules, and optional long-term memory.
+## 📢 News
 
-## Status
+- **2026-04-19** · Post-freeze backlog cleared, the `TurnExecutor` settlement controller landed, and the project moved into regular maintenance
+- **2026-04-10** · Framework freeze accepted; [architecture baseline](docs/architecture-baseline.md) and [new feature checklist](docs/plans/new-feature-checklist.md) became PR entry gates
+- **2026-03** · Runtime Module abstraction completed; knowledge, contract, labor, and memory modules converged on a shared seam
+- **2026-02** · `FeishuTransport` became the single Feishu-side delivery boundary, and cards were split into family files
 
-- Version: `0.1.27`
-- Channel scope: Feishu only
-- Runtime backend: OpenCode
-- Framework freeze: completed
-- Test baseline: 52 test files, 371 tests
-- Architecture baseline: [docs/architecture-baseline.md](docs/architecture-baseline.md)
-- Feature checklist: [docs/plans/new-feature-checklist.md](docs/plans/new-feature-checklist.md)
+<details>
+<summary>Earlier milestones</summary>
 
-## Why This Is Not A Normal Bot
+- Formatter was split from one large file into five families: `shared-primitives`, `runtime-cards`, `knowledge-cards`, `labor-cards`, and `contract-cards`
+- OpenCode turn execution was split into `prepareTurnExecution` and `handlePermissionAskedEvent`
+- Contract assistant, labor analysis, knowledge CLI, and Bitable mirror capabilities shipped
+- Long-term memory integrated SQLite / FTS5 and Obsidian sync
 
-This project is not a generic chatbot.
+</details>
 
-The bridge owns the runtime control surface inside Feishu:
+## 💡 Core Capabilities
 
-- session windows for private chats, groups, and topic groups
-- bridge-owned commands such as `/new`, `/sessions`, `/switch`, and `/status`
-- in-place process cards for long-running OpenCode turns
-- Feishu button actions for permission requests
-- runtime modules for knowledge, contract assistant, labor analysis, and memory
-- OpenCode slash-command passthrough for commands not owned by the bridge
+- **Session windows**: bind, switch, close, delete, and rename sessions across private chats, group chats, and topic groups
+- **Process cards**: long-running OpenCode turns update Feishu cards with status, tool calls, and final replies
+- **Permission confirmation**: OpenCode permission requests can be handled through Feishu buttons, with text command fallback
+- **Group collaboration**: whitelist binding keeps group collaboration usable without repeated `@bot` mentions
+- **Knowledge base**: legal knowledge search, batch file ingestion, URL ingestion, and local CLI diagnostics
+- **Contract assistant**: contract drafting, case create/update flows, todos, and reminder management
+- **Labor analysis**: collect labor dispute materials and produce structured analysis output
+- **Long-term memory**: optional memory extraction, retrieval, SQLite / FTS5 storage, and Obsidian sync
+- **Startup diagnostics**: preflight checks config, Feishu, OpenCode, providers, and callback settings before startup
 
-## Architecture
+## 🧭 Why This Is Not A Normal Bot
+
+A normal bot usually receives messages and returns LLM replies. This project embeds OpenCode runtime capabilities into Feishu with stable operational boundaries:
+
+- The bridge owns runtime commands such as `/new`, `/sessions`, `/switch`, and `/status`
+- OpenCode-native commands continue to work through passthrough
+- Business capabilities live inside Runtime Modules instead of growing the `core` runtime
+- Feishu send, reply, update, and notice calls converge on `FeishuTransport` and card family entrypoints
+- New features must expand inside the frozen seams and must not bypass core boundaries casually
+
+## 🏗️ Architecture
+
+### Request Flow
 
 ```mermaid
 flowchart LR
-    user["Feishu users / groups"] --> ws["Feishu WebSocket<br/>src/feishu/ws.ts"]
+    user["Feishu users / groups / topic groups"] --> ws["Feishu WebSocket<br/>src/feishu/ws.ts"]
     user --> callback["Card Action Callback<br/>src/http/server.ts"]
 
     ws --> app["BridgeApp<br/>src/runtime/app.ts"]
     callback --> app
 
-    app --> command["CommandHandler"]
-    app --> executor["TurnExecutor"]
-    app --> modules["RuntimeModuleManager"]
+    app --> command["CommandHandler<br/>sessions / models / whitelist / permission commands"]
+    app --> executor["TurnExecutor<br/>OpenCode turn execution"]
+    app --> modules["RuntimeModuleManager<br/>src/runtime/runtime-modules.ts"]
 
-    executor <--> opencode["OpenCode Server API + SSE"]
+    executor <--> opencode["OpenCode Server API + SSE<br/>src/opencode/*"]
     modules --> services["Domain Services<br/>knowledge / contract / labor / memory"]
-    services --> stores["Stores / DB / Local Tools"]
+    services --> stores["Stores / DB / Local Tools<br/>JSON / SQLite / Bitable / Files"]
 
-    command --> transport["FeishuTransport"]
+    command --> transport["FeishuTransport<br/>send / reply / update / notice"]
     executor --> transport
     modules --> transport
-    transport --> cards["Feishu Cards / Posts"]
+    transport --> cards["Feishu Cards / Posts<br/>src/feishu/*-cards.ts"]
     cards --> user
 ```
 
-## Framework Structure
+### Layered View
 
 ```mermaid
 flowchart TB
-    config["Configuration<br/>schema + loader"]
+    config["Configuration<br/>src/config/schema.ts<br/>src/config/loader.ts"]
 
     subgraph feishu["Feishu Layer"]
       ws["WebSocket Ingress"]
       api["Feishu API Client"]
       transport["FeishuTransport"]
-      cards["Card Families"]
+      cardFamilies["Card Families<br/>shared / runtime / knowledge / labor / contract"]
     end
 
     subgraph core["Core Runtime"]
       app["BridgeApp"]
-      router["Router"]
+      router["Router<br/>src/bridge/router.ts"]
       command["CommandHandler"]
       executor["TurnExecutor"]
       permission["PermissionManager"]
       turnCards["TurnCardManager"]
+      resources["TurnOwnedResourceStore"]
     end
 
     subgraph modules["Runtime Modules"]
-      knowledgeModule["Knowledge"]
-      contractModule["Contract Assistant"]
-      laborModule["Labor"]
-      memoryModule["Memory"]
+      knowledgeModule["KnowledgeRuntimeModule"]
+      contractModule["ContractAssistantRuntimeModule"]
+      laborModule["LaborRuntimeModule"]
+      memoryModule["MemoryRuntimeModule"]
     end
 
-    subgraph services["Domain Services"]
+    subgraph services["Domain Services / Workflows"]
       knowledge["KnowledgeBaseService"]
       contract["ContractAssistantService"]
       labor["LaborSkillService"]
       memory["MemoryService"]
+      workflow["Evidence / Python / Local CLI"]
     end
 
     subgraph persistence["Persistence / External APIs"]
-      json["JSON Stores"]
+      json["JSON Stores<br/>mappings / whitelist / active ingests"]
       sqlite["SQLite / FTS / embeddings"]
       bitable["Feishu Bitable"]
-      files["Local files"]
+      files["Temp files / local workspace"]
       opencode["OpenCode Server"]
     end
 
@@ -110,44 +130,100 @@ flowchart TB
     app --> executor
     app --> permission
     app --> turnCards
+    app --> resources
     app --> modules
+
     command --> transport
     executor --> opencode
     executor --> transport
     modules --> transport
     transport --> api
-    transport --> cards
-    modules --> services
-    services --> persistence
+    transport --> cardFamilies
+
+    modules --> knowledge
+    modules --> contract
+    modules --> labor
+    modules --> memory
+    services --> json
+    services --> sqlite
+    services --> bitable
+    services --> files
+    services --> opencode
+    contract --> workflow
 ```
 
-## Quick Start
+## ✨ Capability Showcase
+
+| Session Windows | Process Cards | Permission Confirmation | Knowledge Ingestion |
+| :-- | :-- | :-- | :-- |
+| Private chats, group chats, and topic groups bind independently, and switching does not lose context | Cards update in place, tool calls unfold progressively, and final replies land where the work happened | Sensitive actions ask through buttons first, while `/allow` and `/deny` remain available as text fallback | Drop files into chat, paste URLs, or batch ingest documents with visible progress cards |
+| `/new` · `/switch` · `/sessions` | Live tool calls + final reply | Buttons / `/allow` / `/deny` | Files · URLs · batch |
+
+| Contract Assistant | Labor Analysis | Long-Term Memory | Startup Diagnostics |
+| :-- | :-- | :-- | :-- |
+| From contract drafting to case tracking, todos and reminders can be pushed by schedule | Collect salary, attendance, and agreement materials, then generate dispute analysis | Retrieve by conversation or topic, with optional Obsidian sync | Check Feishu, OpenCode, and callbacks before runtime starts, and fail loudly when something is missing |
+| Drafting · cases · todos · reminders | Material collection + analysis output | SQLite + FTS5 + Obsidian | `npm run doctor` |
+
+> Screenshots and GIFs are still being added. For now, run `npm run dev` and send the example commands in Feishu to reproduce the card experience.
+
+## 🚀 Quick Start
 
 ```bash
+# 1. Install dependencies
 npm install
+
+# 2. Prepare config
 cp config.example.json config.json
+
+# 3. Start OpenCode
 opencode serve
+
+# 4. Start the bridge
 npm run dev
-```
 
-Run diagnostics:
-
-```bash
+# 5. Run diagnostics
 npm run doctor
 ```
 
-## Common Commands
+At minimum, configure `feishu.appId`, `feishu.appSecret`, `opencode.baseUrl`, `opencode.directory`, and `storage.dataDir`.
+If Feishu card buttons are enabled, also configure `server.publicBaseUrl` and `feishu.cardActions`.
 
-Runtime:
+## 📖 Common Commands
 
-- `/new`
-- `/status`
-- `/sessions`
-- `/switch <index>`
-- `/rename <title>`
-- `/models`
+Quick reference:
 
-Knowledge:
+- `/new` · `/status` · `/sessions` · `/switch <index>` — session control
+- `/allow once` · `/allow always` · `/deny` — permission confirmation
+- `/法律咨询 <question>` · `/kb-query <question>` — knowledge base query
+- `/合同起草开始` · `/案件录入 <case info>` — contract assistant
+- `/劳动分析` — labor dispute analysis
+
+<details>
+<summary>Show all commands</summary>
+
+### Runtime Control
+
+- `/new`: create a new session
+- `/status`: show the current window status
+- `/sessions`: list sessions
+- `/switch <index>`: switch sessions
+- `/rename <title>`: rename the current session
+- `/close`, `/delete`: close or delete sessions
+- `/abort`: abort the current turn
+- `/models`, `/models <provider>`: list available models
+
+### Group Collaboration
+
+- `/who`: show the current group binding state
+- `/leave`: remove the current user's group binding
+
+### Permission Confirmation
+
+- `/allow once`
+- `/allow always`
+- `/deny`
+
+### Knowledge Base
 
 - `/法律咨询开始`
 - `/法律咨询结束`
@@ -157,18 +233,53 @@ Knowledge:
 - `/kb-ingest-start`
 - `/kb-ingest-end`
 
-Contract and labor:
+### Contract And Case
 
 - `/合同起草开始`
 - `/合同起草结束`
 - `/案件录入 <case info>`
 - `/案件更新 <update>`
+- `/案件待办`
+- `/案件提醒`
+- `/添加案件提醒 <reminder>`
+
+### Labor Analysis
+
 - `/劳动分析`
 - `/劳动分析结束`
 
-OpenCode-native slash commands that the bridge does not own are passed through to OpenCode.
+Slash commands not owned by the bridge are passed through to OpenCode, for example `/model use ...`, `/model reset`, `/review`, and `/init`.
 
-## Development
+</details>
+
+## 🧰 Knowledge Base CLI
+
+The local knowledge base provides fast CLI paths:
+
+```bash
+npm run --silent kb -- query --question "What is the maximum probation period?"
+npm run --silent kb -- ingest file --path "/absolute/path/to/file.pdf"
+npm run --silent kb -- ingest url --url "https://example.com/article"
+npm run --silent kb -- doctor
+```
+
+## ⚙️ Configuration
+
+Use [config.example.json](config.example.json) as the template. Main config sections:
+
+| Section | Purpose |
+| :-- | :-- |
+| `feishu` | Feishu app, bot identity, WebSocket, card callbacks, and behavior flags |
+| `server` | HTTP listen address, health check, and public callback URL |
+| `opencode` | OpenCode service URL and working directory |
+| `storage` | Session mappings, whitelist, logs, and business state directories |
+| `bridge` | Queueing, session mode, timeout, and system state injection |
+| `memory` | Long-term memory switches, storage, and sync settings |
+| `knowledgeBase` | Knowledge base switches, ingestion, retrieval, local DB, and Bitable settings |
+| `contractAssistant` | Contract, case, invoice, and reminder capabilities |
+| `laborSkill` | Labor analysis material collection and output settings |
+
+## 🛠️ Development Commands
 
 ```bash
 npm run typecheck
@@ -176,34 +287,70 @@ npm run lint
 npm test
 npm run build
 npm run dev
+npm run dev:once
 ```
 
-## Project Layout
+Current full verification baseline: **52 test files · 371 tests passing**
+
+## 📂 Project Layout
 
 ```text
 src/
-  bridge/              # routing, queues, turn state, module interface
-  config/              # schema and loader
+  bridge/              # router, queue, turn state, watchdog, module interface
+  config/              # zod schema and config loader
   feishu/              # Feishu API, WebSocket ingress, card families
   http/                # healthz and card action callback server
-  runtime/             # BridgeApp, command handler, turn executor, transport
-  knowledge/           # legal knowledge base and parser
-  contract-assistant/  # contract drafting and case workflows
-  labor/               # labor analysis workflows
-  memory/              # long-term memory
+  runtime/             # BridgeApp, command handler, turn executor, transport, preflight
+  knowledge/           # legal knowledge base, parser, local CLI, SQLite mirror
+  contract-assistant/  # contract drafting, case updates, reminders
+  labor/               # labor dispute material collection and analysis
+  memory/              # long-term memory, retrievers, embeddings, Obsidian sync
   opencode/            # OpenCode client and event stream
-  store/               # JSON stores
+  store/               # JSON stores for mappings, whitelist, active ingests
+  workflows/           # workflow helpers
 scripts/               # doctor, onboard, knowledge CLI wrappers
-docs/                  # architecture, deployment, plans
-test/                  # Vitest tests
+docs/                  # architecture, deployment, plans, archived demo docs
+test/                  # Vitest unit and integration tests
 ```
 
-## Documentation
+## 📚 Documentation
 
 - [Architecture baseline](docs/architecture-baseline.md)
 - [New feature checklist](docs/plans/new-feature-checklist.md)
 - [Feishu Markdown rules](docs/feishu-markdown.md)
 - [Deployment](docs/deploy.md)
+- [Formatter migration record](docs/plans/formatter-migration.md)
+- [Framework freeze acceptance](docs/plans/freeze-acceptance.md)
+
+## 🚢 Deployment
+
+Single-host topology:
+
+```text
+Feishu <-> HTTPS / Caddy <-> Bridge HTTP + WebSocket <-> OpenCode Server
+```
+
+References:
+
+- [docs/deploy.md](docs/deploy.md)
+- [ops/Caddyfile](ops/Caddyfile)
+- [.env.example](.env.example)
+
+Health check `GET /healthz` · default card callback path `/webhook/card`
+
+## 🤝 Contributing
+
+The framework has been frozen. Future feature work should follow these rules:
+
+- Prefer adding features inside Runtime Module / Service / Transport seams
+- Do not add business-specific branches to `src/runtime/app.ts`, `src/runtime/turn-executor.ts`, or `src/bridge/router.ts` unless the architecture baseline is updated first
+- Add new cards through `src/feishu/*-cards.ts` family entrypoints instead of growing `formatter.ts`
+- Reuse shared state persistence infrastructure instead of copying timer + JSON persist logic
+- Include the [new-feature-checklist](docs/plans/new-feature-checklist.md) self-check in PR descriptions
+
+## ⭐ Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=Clukay-Fun/feishu-opencode-bridge&type=Date)](https://star-history.com/#Clukay-Fun/feishu-opencode-bridge&Date)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -3,48 +3,56 @@
 [![Node.js](https://img.shields.io/badge/Node.js-20%2B-339933)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6)](https://www.typescriptlang.org/)
 [![Feishu](https://img.shields.io/badge/Feishu-Bridge-0F6FFF)](https://open.feishu.cn/)
+[![Tests](https://img.shields.io/badge/tests-371%20passing-success)](#%EF%B8%8F-开发命令)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 **中文** | [English](README.en.md)
 
-Feishu OpenCode Bridge 是一个把 OpenCode 运行时产品化到飞书里的桥接层。
+> **Feishu OpenCode Bridge 不是一个普通的飞书机器人。**
+> 它是把 OpenCode 运行时产品化到飞书里的 **Feishu-native runtime adapter**——让私聊、群聊、话题群都拥有会话窗口、过程卡片、权限确认、知识库、合同/劳动业务模块和长期记忆，真正成为 OpenCode 的工作入口。
 
-它不是普通聊天机器人，而是一个 Feishu-native runtime adapter：把飞书私聊、群聊、话题群变成有会话窗口、过程卡片、权限确认、知识库、合同/劳动业务模块和长期记忆能力的 OpenCode 工作入口。
+## 📢 News
 
-## 项目状态
+- **2026-04-19** · 冻结后 backlog 全部清零，`TurnExecutor` settlement 控制器落地，进入日常维护节奏
+- **2026-04-10** · 框架冻结验收通过，[架构基线](docs/architecture-baseline.md) 与 [新功能自检清单](docs/plans/new-feature-checklist.md) 成为 PR 准入标准
+- **2026-03** · Runtime Module 抽象完成，知识 / 合同 / 劳动 / 记忆四大模块全部收敛到统一 seam
+- **2026-02** · `FeishuTransport` 成为飞书侧唯一出口，卡片拆分为独立 family 文件
 
-- 当前版本：`0.1.27`
-- 当前阶段：框架冻结已完成，进入 feature expansion / 日常维护节奏
-- 当前渠道：仅支持飞书，不做多渠道抽象
-- 测试基线：52 个测试文件，371 个测试通过
-- 架构约束：[docs/architecture-baseline.md](docs/architecture-baseline.md)
-- 新功能自检：[docs/plans/new-feature-checklist.md](docs/plans/new-feature-checklist.md)
+<details>
+<summary>更早的里程碑</summary>
 
-## 核心能力
+- Formatter 从单体文件拆分为 `shared-primitives` + `runtime-cards` + `knowledge-cards` + `labor-cards` + `contract-cards` 五个家族
+- OpenCode turn 执行链抽象出 `prepareTurnExecution` / `handlePermissionAskedEvent`
+- 合同助手、劳动分析、知识库 CLI 与 Bitable 镜像能力上线
+- 长期记忆接入 SQLite / FTS5 + Obsidian 同步
 
-- **会话窗口**：支持私聊、群聊、话题群的 session 绑定、切换、关闭、重命名。
-- **过程卡片**：运行中的 OpenCode turn 会通过飞书卡片持续更新状态、工具调用和最终回复。
-- **权限确认**：OpenCode 权限请求可通过飞书按钮处理，也保留文本命令 fallback。
-- **群聊协作**：通过白名单绑定支持群内免重复 `@bot` 的协作流。
-- **知识库**：支持法律知识查询、批量文件入库、URL 入库和本地 CLI 诊断。
-- **合同助手**：支持合同起草、案件录入/更新、待办和提醒管理。
-- **劳动分析**：支持劳动争议材料收集、整理和分析输出。
-- **长期记忆**：支持可选的记忆提取、检索、SQLite/FTS5 存储和 Obsidian 同步。
-- **启动前诊断**：preflight 会在启动时检查配置、Feishu、OpenCode、provider 和 callback 设置。
+</details>
 
-## 为什么不是普通机器人
+## 💡 核心能力
 
-普通机器人通常只做消息收发和 LLM 回复。
+- **会话窗口**：支持私聊、群聊、话题群的 session 绑定、切换、关闭、重命名
+- **过程卡片**：运行中的 OpenCode turn 通过飞书卡片持续更新状态、工具调用和最终回复
+- **权限确认**：OpenCode 权限请求可通过飞书按钮处理，也保留文本命令 fallback
+- **群聊协作**：通过白名单绑定支持群内免重复 `@bot` 的协作流
+- **知识库**：支持法律知识查询、批量文件入库、URL 入库和本地 CLI 诊断
+- **合同助手**：支持合同起草、案件录入/更新、待办和提醒管理
+- **劳动分析**：支持劳动争议材料收集、整理和分析输出
+- **长期记忆**：可选的记忆提取、检索、SQLite / FTS5 存储和 Obsidian 同步
+- **启动前诊断**：preflight 会在启动时检查配置、Feishu、OpenCode、provider 和 callback 设置
 
-本项目的核心价值是把 OpenCode 的运行时能力稳定地嵌入飞书：
+## 🧭 为什么不是普通机器人
 
-- bridge 自己拥有 `/new`、`/sessions`、`/switch`、`/status` 等运行时控制面。
-- OpenCode 原生命令继续通过 passthrough 工作。
-- 业务能力放在 Runtime Module 内部，而不是继续把 `core` 写成巨型分支。
-- 飞书发送、回复、更新、notice 收敛到 `FeishuTransport` 和卡片 family 入口。
-- 新功能必须在冻结后的 seam 内扩展，不能随意绕过核心边界。
+普通机器人通常只做消息收发和 LLM 回复。本项目的核心价值是把 OpenCode 的运行时能力稳定地嵌入飞书：
 
-## 架构总览
+- bridge 自己拥有 `/new`、`/sessions`、`/switch`、`/status` 等运行时控制面
+- OpenCode 原生命令继续通过 passthrough 工作
+- 业务能力放在 Runtime Module 内部，而不是继续把 `core` 写成巨型分支
+- 飞书发送、回复、更新、notice 收敛到 `FeishuTransport` 和卡片 family 入口
+- 新功能必须在冻结后的 seam 内扩展，不能随意绕过核心边界
+
+## 🏗️ 架构
+
+### 请求流
 
 ```mermaid
 flowchart LR
@@ -69,7 +77,7 @@ flowchart LR
     cards --> user
 ```
 
-## 框架结构
+### 分层视图
 
 ```mermaid
 flowchart TB
@@ -144,49 +152,54 @@ flowchart TB
     contract --> workflow
 ```
 
-## 快速开始
+## ✨ 能力展示
 
-### 1. 安装依赖
+| 会话窗口 | 过程卡片 | 权限确认 | 知识入库 |
+| :-- | :-- | :-- | :-- |
+| 私聊 / 群聊 / 话题群各自独立绑定，切换不丢上下文 | 卡片原地滚动更新，工具调用逐步展开，最终回复就地落地 | 敏感操作先弹按钮，再保留 `/allow` `/deny` 文本 fallback | 拖文件进聊天、粘 URL 或批量入库，进度卡片全程可见 |
+| `/new` · `/switch` · `/sessions` | 实时工具调用 + 最终回复 | 按钮 / `/allow` / `/deny` | 文件 · URL · 批量 |
+
+| 合同助手 | 劳动分析 | 长期记忆 | 启动诊断 |
+| :-- | :-- | :-- | :-- |
+| 从合同起草到案件追踪，待办与提醒按日推送 | 收齐工资 / 考勤 / 协议，一键产出争议分析 | 按会话 / 主题检索，支持与 Obsidian 双向同步 | 启动前自检飞书 / OpenCode / 回调，缺什么报什么 |
+| 起草 · 案件 · 待办 · 提醒 | 材料收集 + 分析输出 | SQLite + FTS5 + Obsidian | `npm run doctor` |
+
+> 截图与 GIF 正在补充中。当前版本运行 `npm run dev` 并在飞书侧发送示例命令即可复现上述卡片体验。
+
+## 🚀 快速开始
 
 ```bash
+# 1. 安装依赖
 npm install
-```
 
-### 2. 准备配置
-
-```bash
+# 2. 准备配置
 cp config.example.json config.json
-```
 
-至少需要配置：
-
-- `feishu.appId`
-- `feishu.appSecret`
-- `opencode.baseUrl`
-- `opencode.directory`
-- `storage.dataDir`
-
-如果启用飞书卡片按钮，还需要配置 `server.publicBaseUrl` 和 `feishu.cardActions`。
-
-### 3. 启动 OpenCode
-
-```bash
+# 3. 启动 OpenCode
 opencode serve
-```
 
-### 4. 启动 Bridge
-
-```bash
+# 4. 启动 Bridge
 npm run dev
-```
 
-### 5. 运行诊断
-
-```bash
+# 5. 运行诊断
 npm run doctor
 ```
 
-## 常用命令
+至少需要配置 `feishu.appId`、`feishu.appSecret`、`opencode.baseUrl`、`opencode.directory`、`storage.dataDir`。
+如果启用飞书卡片按钮，还需要配置 `server.publicBaseUrl` 和 `feishu.cardActions`。
+
+## 📖 常用命令
+
+速查：
+
+- `/new` · `/status` · `/sessions` · `/switch <编号>` — 会话控制
+- `/allow once` · `/allow always` · `/deny` — 权限确认
+- `/法律咨询 <问题>` · `/kb-query <问题>` — 知识库查询
+- `/合同起草开始` · `/案件录入 <案件信息>` — 合同助手
+- `/劳动分析` — 劳动争议分析
+
+<details>
+<summary>展开全部命令</summary>
 
 ### 运行时控制
 
@@ -237,9 +250,11 @@ npm run doctor
 
 未被 bridge 接管的 slash 命令会透传给 OpenCode，例如 `/model use ...`、`/model reset`、`/review`、`/init`。
 
-## 知识库 CLI
+</details>
 
-本地知识库也提供 CLI 快速路径：
+## 🧰 知识库 CLI
+
+本地知识库提供 CLI 快速路径：
 
 ```bash
 npm run --silent kb -- query --question "员工试用期最长多久？"
@@ -248,23 +263,23 @@ npm run --silent kb -- ingest url --url "https://example.com/article"
 npm run --silent kb -- doctor
 ```
 
-## 配置说明
+## ⚙️ 配置说明
 
-配置文件以 [config.example.json](config.example.json) 为模板。
+配置文件以 [config.example.json](config.example.json) 为模板。主要配置块：
 
-主要配置块：
+| 配置块 | 作用 |
+| :-- | :-- |
+| `feishu` | 飞书应用、机器人身份、WebSocket、卡片回调和行为开关 |
+| `server` | HTTP 服务监听地址、健康检查和公网回调地址 |
+| `opencode` | OpenCode 服务地址和工作目录 |
+| `storage` | 会话映射、白名单、日志和业务状态目录 |
+| `bridge` | 队列、会话模式、超时和系统状态注入 |
+| `memory` | 长期记忆开关、存储和同步设置 |
+| `knowledgeBase` | 知识库开关、入库、检索、本地数据库和多维表格配置 |
+| `contractAssistant` | 合同、案件、发票和提醒能力配置 |
+| `laborSkill` | 劳动分析材料收集和输出配置 |
 
-- `feishu`：飞书应用、机器人身份、WebSocket、卡片回调和行为开关。
-- `server`：HTTP 服务监听地址、健康检查和公网回调地址。
-- `opencode`：OpenCode 服务地址和工作目录。
-- `storage`：会话映射、白名单、日志和业务状态目录。
-- `bridge`：队列、会话模式、超时和系统状态注入。
-- `memory`：长期记忆开关、存储和同步设置。
-- `knowledgeBase`：知识库开关、入库、检索、本地数据库和多维表格配置。
-- `contractAssistant`：合同、案件、发票和提醒能力配置。
-- `laborSkill`：劳动分析材料收集和输出配置。
-
-## 开发命令
+## 🛠️ 开发命令
 
 ```bash
 npm run typecheck
@@ -275,14 +290,9 @@ npm run dev
 npm run dev:once
 ```
 
-当前完整验证基线：
+当前完整验证基线：**52 test files · 371 tests passing**
 
-```text
-52 test files
-371 tests
-```
-
-## 项目目录
+## 📂 项目目录
 
 ```text
 src/
@@ -303,7 +313,7 @@ docs/                  # architecture, deployment, plans, archived demo docs
 test/                  # Vitest unit and integration tests
 ```
 
-## 文档入口
+## 📚 文档入口
 
 - [架构基线](docs/architecture-baseline.md)
 - [新功能自检清单](docs/plans/new-feature-checklist.md)
@@ -312,9 +322,9 @@ test/                  # Vitest unit and integration tests
 - [Formatter 迁移记录](docs/plans/formatter-migration.md)
 - [框架冻结验收](docs/plans/freeze-acceptance.md)
 
-## 部署
+## 🚢 部署
 
-单机部署建议：
+单机部署拓扑：
 
 ```text
 Feishu <-> HTTPS / Caddy <-> Bridge HTTP + WebSocket <-> OpenCode Server
@@ -326,27 +336,21 @@ Feishu <-> HTTPS / Caddy <-> Bridge HTTP + WebSocket <-> OpenCode Server
 - [ops/Caddyfile](ops/Caddyfile)
 - [.env.example](.env.example)
 
-健康检查：
+健康检查 `GET /healthz` · 默认卡片回调路径 `/webhook/card`
 
-```text
-GET /healthz
-```
-
-默认卡片回调路径：
-
-```text
-/webhook/card
-```
-
-## 贡献与开发约束
+## 🤝 贡献与开发约束
 
 本项目已经完成框架冻结。后续功能开发请遵守：
 
-- 新功能优先落在 Runtime Module / Service / Transport seam 内。
-- 不要在 `src/runtime/app.ts`、`src/runtime/turn-executor.ts`、`src/bridge/router.ts` 里新增业务特定分支，除非同步更新架构基线。
-- 新卡片走 `src/feishu/*-cards.ts` family entrypoint，不要继续扩张 `formatter.ts`。
-- 模块状态持久化复用共享基础设施，不复制 timer + JSON persist 逻辑。
-- PR 描述里建议附上 [new-feature-checklist](docs/plans/new-feature-checklist.md) 自检结果。
+- 新功能优先落在 Runtime Module / Service / Transport seam 内
+- 不要在 `src/runtime/app.ts`、`src/runtime/turn-executor.ts`、`src/bridge/router.ts` 里新增业务特定分支，除非同步更新架构基线
+- 新卡片走 `src/feishu/*-cards.ts` family entrypoint，不要继续扩张 `formatter.ts`
+- 模块状态持久化复用共享基础设施，不复制 timer + JSON persist 逻辑
+- PR 描述里建议附上 [new-feature-checklist](docs/plans/new-feature-checklist.md) 自检结果
+
+## ⭐ Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=Clukay-Fun/feishu-opencode-bridge&type=Date)](https://star-history.com/#Clukay-Fun/feishu-opencode-bridge&Date)
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feishu-opencode-bridge",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feishu-opencode-bridge",
-      "version": "0.1.27",
+      "version": "0.1.28",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.42.0",
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feishu-opencode-bridge",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
### 变更内容
- 同步英文 README 的展示结构，补充更完整的项目定位、能力说明、架构图、安装配置和命令说明。
- 打磨中文 README 首页，加入 News、能力展示、速查命令、配置表格和更清晰的文档入口。
- 更新版本到 0.1.28，并同步 CHANGELOG。

### 变更原因
- README 已经拆成中英文入口，需要继续统一信息架构和对外展示口径。
- 框架冻结和运行时收敛完成后，首页需要更清楚地表达项目状态、能力边界和使用方式。

### 影响
- 仅影响 README、版本号和 CHANGELOG，不改变运行时代码行为。
- 对外阅读入口更清晰，中文和英文文档结构更一致。

### 验证
- `npm test`
- `npm run typecheck`
- `npm run lint`