### PR TITLE
[codex] 建立运行时可观测性事件链

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The project follows Semantic Versioning.
 
+## 0.1.30 - 2026-04-19
+
+### Added
+- Added the first observability event schema for bridge runtime logs.
+- Added structured logger context propagation, JSON log output, message logging policies, and event helpers.
+
+### Changed
+- Threaded correlation and turn context through Feishu ingress, HTTP callbacks, runtime modules, permission handling, turn cards, and turn execution.
+- Updated architecture documentation to describe the observability boundary and stable event vocabulary.
+
 ## 0.1.29 - 2026-04-19
 
 ### Changed

--- a/docs/architecture-baseline.md
+++ b/docs/architecture-baseline.md
@@ -115,7 +115,7 @@ Stable responsibilities:
 - normalize callback inputs
 - handle Feishu markdown and card payload rules
 - encapsulate delivery details such as reply vs thread reply
-- emit logs and transcripts through the shared logger pipeline using stable scope naming
+- emit logs and transcripts through the shared logger pipeline using stable scope naming and the observability event schema
 
 Must not own:
 
@@ -145,6 +145,7 @@ Stable responsibilities:
 - own bridge command surface such as `/new`, `/sessions`, `/status`, `/close`, `/delete`
 - own queueing, turn execution, watchdog, process-card lifecycle, and final reply delivery
 - own session-window state and interaction mode state
+- emit turn, permission, and module lifecycle events using the observability event schema
 
 Must not own:
 

--- a/docs/observability/event-schema.md
+++ b/docs/observability/event-schema.md
@@ -1,0 +1,288 @@
+# Observability Event Schema
+
+> Last updated: 2026-04-19
+>
+> This document defines the first stable event vocabulary for bridge runtime logs.
+> It is documentation-first on purpose: code should migrate toward these names instead of inventing new text per call site.
+
+## Goal
+
+Make one bridge turn traceable from ingress to final delivery with stable event names and predictable fields.
+
+The runtime already has a shared logger. The next observability phase should add request context propagation, JSON line output, and event helpers without replacing that logger wholesale.
+
+## Common Envelope
+
+Every structured bridge event should use this envelope:
+
+- `ts`: ISO timestamp emitted by the logger
+- `level`: `debug`, `info`, `warn`, or `error`
+- `scope`: stable logger scope, such as `bridge/queue` or `feishu/reply`
+- `event`: one of the event names in this document
+- `msg`: short human-readable message for local debugging
+- `correlationId`: id shared by one inbound Feishu event and all work it triggers
+- `turnId`: bridge turn id, when a turn exists
+- `sessionId`: OpenCode session id, when available
+- `chatId`: Feishu chat id, when available
+- `userId`: Feishu sender id, when available
+- `messageId`: Feishu message id, when available
+
+Field rules:
+
+- Event-specific fields may be added, but must use stable names.
+- Raw user message content must not be logged by default.
+- Message previews must follow the configured message logging policy.
+- Transcript files remain separate from structured bridge events.
+
+## Event Names
+
+### `turn.started`
+
+Emitted when a queued turn begins execution.
+
+Required fields:
+
+- `turnId`
+- `sessionId`
+- `chatId`
+- `conversationKey`
+
+Trigger point:
+
+- `TurnExecutor` after the turn enters active execution.
+
+### `turn.completed`
+
+Emitted when a turn finishes successfully.
+
+Required fields:
+
+- `turnId`
+- `sessionId`
+- `durationMs`
+
+Optional fields:
+
+- `replyLength`
+- `processMessageId`
+- `finalMessageId`
+
+Trigger point:
+
+- `TurnExecutor` after final reply delivery and cleanup.
+
+### `turn.failed`
+
+Emitted when a turn fails before normal completion.
+
+Required fields:
+
+- `turnId`
+- `chatId`
+- `conversationKey`
+- `errorKind`
+- `detail`
+
+Optional fields:
+
+- `sessionId`
+- `durationMs`
+
+Trigger point:
+
+- `TurnExecutor` catch path around turn execution.
+
+### `turn.fallback_triggered`
+
+Emitted when the bridge falls back to a degraded turn behavior.
+
+Required fields:
+
+- `turnId`
+- `fallbackKind`
+- `reason`
+
+Optional fields:
+
+- `sessionId`
+- `chatId`
+
+Trigger point:
+
+- Runtime fallback branches, such as degraded reply or process-card fallback.
+
+### `permission.asked`
+
+Emitted when the bridge asks the user to approve or deny a runtime permission request.
+
+Required fields:
+
+- `turnId`
+- `permissionId`
+- `permissionKind`
+- `chatId`
+
+Optional fields:
+
+- `sessionId`
+- `toolName`
+
+Trigger point:
+
+- `PermissionManager` after sending the permission card.
+
+### `permission.decided`
+
+Emitted when the user or timeout path decides a permission request.
+
+Required fields:
+
+- `turnId`
+- `permissionId`
+- `decision`
+- `decisionSource`
+
+Optional fields:
+
+- `sessionId`
+- `chatId`
+- `durationMs`
+
+Allowed values:
+
+- `decision`: `approved`, `denied`
+- `decisionSource`: `user`, `timeout`, `system`
+
+Trigger point:
+
+- `PermissionManager` card action and auto-deny paths.
+
+### `module.invoked`
+
+Emitted when a runtime module claims or processes a message or hook.
+
+Required fields:
+
+- `moduleId`
+- `hook`
+- `result`
+
+Optional fields:
+
+- `turnId`
+- `chatId`
+- `conversationKey`
+- `durationMs`
+
+Allowed values:
+
+- `hook`: `handleMessage`, `beforeTurn`, `afterTurn`, `stop`
+- `result`: `claimed`, `ignored`, `completed`
+
+Trigger point:
+
+- `RuntimeModuleManager` around module hook dispatch.
+
+### `module.failed`
+
+Emitted when a runtime module hook throws or returns an invalid result.
+
+Required fields:
+
+- `moduleId`
+- `hook`
+- `errorKind`
+- `detail`
+
+Optional fields:
+
+- `turnId`
+- `chatId`
+- `conversationKey`
+
+Trigger point:
+
+- `RuntimeModuleManager` error handling around module hook dispatch.
+
+### `transport.sent`
+
+Emitted when the Feishu transport successfully sends or updates a bridge-owned message.
+
+Required fields:
+
+- `chatId`
+- `messageId`
+- `transportAction`
+- `payloadKind`
+
+Optional fields:
+
+- `turnId`
+- `textPreview`
+- `len`
+
+Allowed values:
+
+- `transportAction`: `send`, `update`, `reply`, `thread_reply`
+- `payloadKind`: `card`, `post`, `text`, `markdown`
+
+Trigger point:
+
+- Feishu transport and turn card manager send/update success paths.
+
+### `transport.failed`
+
+Emitted when the Feishu transport fails to send or update a bridge-owned message.
+
+Required fields:
+
+- `transportAction`
+- `payloadKind`
+- `errorKind`
+- `detail`
+
+Optional fields:
+
+- `turnId`
+- `chatId`
+- `messageId`
+
+Trigger point:
+
+- Feishu transport and turn card manager send/update failure paths.
+
+## Privacy Policy
+
+Structured logs should default to operational metadata, not content.
+
+Default redaction list:
+
+- `feishu.appSecret`
+- `opencode.apiKey`
+- raw inbound user message content
+- raw OpenCode reply content
+- file contents and attachment contents
+
+Recommended message policies:
+
+- `none`: do not log message content or preview
+- `hash`: log only a deterministic hash
+- `preview`: log a short normalized preview
+- `full`: log full content only for local diagnosis
+
+The default production policy should be `preview` or stricter.
+
+## Migration Order
+
+1. Add request context propagation so `correlationId` and `turnId` are automatic.
+2. Add JSON line output while keeping pretty local output configurable.
+3. Add `logger.event(event, fields)` with the event names above.
+4. Migrate seam files one group at a time.
+
+Initial seam groups:
+
+- ingress: `src/feishu/ws.ts`, `src/http/server.ts`
+- turn runtime: `src/runtime/turn-executor.ts`
+- permissions: `src/runtime/permission-manager.ts`
+- modules: `src/runtime/runtime-modules.ts`
+- transport: `src/runtime/feishu-transport.ts`, `src/runtime/turn-card-manager.ts`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feishu-opencode-bridge",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feishu-opencode-bridge",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.42.0",
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feishu-opencode-bridge",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/bridge/module.ts
+++ b/src/bridge/module.ts
@@ -3,6 +3,7 @@ import type { RoutedText } from "./router.js";
 import type { BridgeTurn } from "./turn.js";
 import type { SessionWindowRecord } from "../store/mappings.js";
 import type { PendingInteraction } from "./state.js";
+import { logEvent, type Logger } from "../logging/logger.js";
 
 export type RuntimeModuleHandleResult =
   | { claimed: true }
@@ -38,6 +39,8 @@ export interface RuntimeModule {
 export class ModuleManager {
   private readonly modules: RuntimeModule[] = [];
 
+  constructor(private readonly logger?: Pick<Logger, "log" | "event">) {}
+
   register(module: RuntimeModule): void {
     this.modules.push(module);
     this.modules.sort((left, right) => left.priority - right.priority);
@@ -61,8 +64,16 @@ export class ModuleManager {
 
   async handleMessage(context: RuntimeModuleMessageContext): Promise<RuntimeModuleHandleResult> {
     for (const module of this.modules) {
-      const result = await module.handleMessage?.(context);
+      const startedAt = Date.now();
+      let result: RuntimeModuleHandleResult | undefined;
+      try {
+        result = await module.handleMessage?.(context);
+      } catch (error) {
+        this.logModuleFailed(module, "handleMessage", error);
+        throw error;
+      }
       if (result?.claimed) {
+        this.logModuleInvoked(module, "handleMessage", "claimed", startedAt);
         return result;
       }
     }
@@ -72,7 +83,17 @@ export class ModuleManager {
   async collectBeforeTurnBlocks(context: RuntimeModuleBeforeTurnContext): Promise<string[]> {
     const blocks: string[] = [];
     for (const module of this.modules) {
-      const result = await module.beforeTurn?.(context);
+      const startedAt = Date.now();
+      let result: { systemBlocks?: string[] } | void;
+      try {
+        result = await module.beforeTurn?.(context);
+      } catch (error) {
+        this.logModuleFailed(module, "beforeTurn", error);
+        throw error;
+      }
+      if (module.beforeTurn) {
+        this.logModuleInvoked(module, "beforeTurn", "completed", startedAt);
+      }
       if (!result?.systemBlocks) {
         continue;
       }
@@ -88,7 +109,50 @@ export class ModuleManager {
 
   async runAfterTurnHooks(context: RuntimeModuleAfterTurnContext): Promise<void> {
     for (const module of this.modules) {
-      await module.afterTurn?.(context);
+      if (!module.afterTurn) {
+        continue;
+      }
+      const startedAt = Date.now();
+      try {
+        await module.afterTurn(context);
+      } catch (error) {
+        this.logModuleFailed(module, "afterTurn", error);
+        throw error;
+      }
+      this.logModuleInvoked(module, "afterTurn", "completed", startedAt);
     }
+  }
+
+  private logModuleInvoked(
+    module: RuntimeModule,
+    hook: "handleMessage" | "beforeTurn" | "afterTurn" | "stop",
+    result: "claimed" | "completed",
+    startedAt: number,
+  ): void {
+    if (!this.logger) {
+      return;
+    }
+    logEvent(this.logger, "runtime/modules", "module.invoked", {
+      moduleId: module.name,
+      hook,
+      result,
+      durationMs: Date.now() - startedAt,
+    });
+  }
+
+  private logModuleFailed(
+    module: RuntimeModule,
+    hook: "handleMessage" | "beforeTurn" | "afterTurn" | "stop",
+    error: unknown,
+  ): void {
+    if (!this.logger) {
+      return;
+    }
+    logEvent(this.logger, "runtime/modules", "module.failed", {
+      moduleId: module.name,
+      hook,
+      errorKind: error instanceof Error ? error.name : "unknown",
+      detail: error instanceof Error ? error.message : String(error),
+    }, "warn");
   }
 }

--- a/src/bridge/turn.ts
+++ b/src/bridge/turn.ts
@@ -1,3 +1,5 @@
+import type { LogContext } from "../logging/logger.js";
+
 export type BridgeTurn = {
   turnId: string;
   chatId: string;
@@ -13,6 +15,7 @@ export type BridgeTurn = {
   finalMessageId?: string;
   state?: "queued" | "running" | "awaiting-sse" | "done" | "timeout" | "aborted";
   startedAt?: number;
+  logContext?: LogContext;
 };
 
 export type QueueNotice = {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -92,6 +92,9 @@ export async function loadConfig(configPath?: string): Promise<AppConfig> {
       enableConsole: parsed.logging.enableConsole,
       enableColor: parsed.logging.enableColor,
       rotateDaily: parsed.logging.rotateDaily,
+      format: parsed.logging.format,
+      messagePolicy: parsed.logging.messagePolicy,
+      redactFields: parsed.logging.redactFields,
     },
     memory: {
       enabled: parsed.memory.enabled,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -243,6 +243,16 @@ export const ConfigSchema = z.object({
     enableConsole: z.boolean().default(true),
     enableColor: z.boolean().default(true),
     rotateDaily: z.boolean().default(true),
+    format: z.enum(["pretty", "json"]).default("pretty"),
+    messagePolicy: z.enum(["full", "preview", "hash", "none"]).default("preview"),
+    redactFields: z.array(z.string().min(1)).default([
+      "feishu.appSecret",
+      "opencode.apiKey",
+      "appSecret",
+      "apiKey",
+      "plainText",
+      "content",
+    ]),
   }).default({}),
   memory: MemoryConfigSchema.default({}),
   knowledgeBase: KnowledgeBaseConfigSchema,
@@ -408,6 +418,9 @@ export type AppConfig = {
     enableConsole: boolean;
     enableColor: boolean;
     rotateDaily: boolean;
+    format?: "pretty" | "json" | undefined;
+    messagePolicy?: "full" | "preview" | "hash" | "none" | undefined;
+    redactFields?: string[] | undefined;
   };
   memory: {
     enabled: boolean;

--- a/src/feishu/ws.ts
+++ b/src/feishu/ws.ts
@@ -1,7 +1,10 @@
+import { randomUUID } from "node:crypto";
+
 import * as lark from "@larksuiteoapi/node-sdk";
 
 import { routeIncomingText } from "../bridge/router.js";
 import type { AppConfig } from "../config/schema.js";
+import { runWithLogContext } from "../logging/logger.js";
 import type { IncomingChatMessage } from "../runtime/app.js";
 import type { ChatWhitelist } from "../store/whitelist.js";
 
@@ -143,6 +146,17 @@ export class FeishuWsClient {
   }
 
   private async handleEvent(payload: FeishuReceiveEvent): Promise<void> {
+    await runWithLogContext({
+      correlationId: randomUUID(),
+      chatId: payload.message?.chat_id,
+      messageId: payload.message?.message_id,
+      userId: payload.sender?.sender_id?.open_id,
+    }, async () => {
+      await this.handleEventWithContext(payload);
+    });
+  }
+
+  private async handleEventWithContext(payload: FeishuReceiveEvent): Promise<void> {
     const duplicateMessageId = this.markMessageSeen(payload.message?.message_id);
     if (duplicateMessageId) {
       this.logger.log("feishu/ws", "duplicate message skipped", { messageId: duplicateMessageId }, "warn");

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -1,6 +1,8 @@
+import { randomUUID } from "node:crypto";
 import http from "node:http";
 
 import type { AppConfig } from "../config/schema.js";
+import { runWithLogContext } from "../logging/logger.js";
 import { APP_VERSION } from "../version.js";
 
 type LoggerLike = {
@@ -85,18 +87,23 @@ export async function startBridgeHttpServer(
           const openMessageId = extractOpenMessageId(event);
           const actionValue = event.action?.value ?? {};
 
-          logger.log("http/server", "callback event parsed", {
-            actorOpenId,
-            openMessageId,
-            actionValueKind: typeof actionValue.kind === "string" ? actionValue.kind : "",
-            ...flattenScalarFields("callback", event),
-          });
+          return await runWithLogContext({
+            userId: actorOpenId,
+            messageId: openMessageId,
+          }, async () => {
+            logger.log("http/server", "callback event parsed", {
+              actorOpenId,
+              openMessageId,
+              actionValueKind: typeof actionValue.kind === "string" ? actionValue.kind : "",
+              ...flattenScalarFields("callback", event),
+            });
 
-          return actions.handlePermissionCardAction(
-            actorOpenId,
-            openMessageId,
-            actionValue,
-          );
+            return await actions.handlePermissionCardAction(
+              actorOpenId,
+              openMessageId,
+              actionValue,
+            );
+          });
         },
       ),
       { autoChallenge: true },
@@ -122,13 +129,15 @@ export async function startBridgeHttpServer(
     }
 
     if (adapter && url.pathname === config.feishu.cardActions.path) {
-      logger.log("http/card-action", "callback received", {
-        method: req.method ?? "UNKNOWN",
-        path: url.pathname,
-        userAgent: req.headers["user-agent"] ?? "",
-        contentType: req.headers["content-type"] ?? "",
+      await runWithLogContext({ correlationId: randomUUID() }, async () => {
+        logger.log("http/card-action", "callback received", {
+          method: req.method ?? "UNKNOWN",
+          path: url.pathname,
+          userAgent: req.headers["user-agent"] ?? "",
+          contentType: req.headers["content-type"] ?? "",
+        });
+        await adapter(req, res);
       });
-      await adapter(req, res);
       return;
     }
 

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -1,19 +1,51 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { createHash } from "node:crypto";
 import { appendFile, mkdir } from "node:fs/promises";
 import path from "node:path";
 
 export type TranscriptType = "inbound" | "outbound-process" | "outbound-final" | "opencode-reply" | "reasoning-raw";
+export type LogLevel = "debug" | "info" | "warn" | "error";
+export type LogFormat = "pretty" | "json";
+export type LogMessagePolicy = "full" | "preview" | "hash" | "none";
+export type BridgeEventName =
+  | "turn.started"
+  | "turn.completed"
+  | "turn.failed"
+  | "turn.fallback_triggered"
+  | "permission.asked"
+  | "permission.decided"
+  | "module.invoked"
+  | "module.failed"
+  | "transport.sent"
+  | "transport.failed";
+
+export type LogContext = {
+  correlationId?: string | undefined;
+  turnId?: string | undefined;
+  userId?: string | undefined;
+  chatId?: string | undefined;
+  messageId?: string | undefined;
+  sessionId?: string | undefined;
+};
 
 export type Logger = {
-  log: (scope: string, message: string, fields?: Record<string, unknown>, level?: "debug" | "info" | "warn" | "error") => void;
+  log: (scope: string, message: string, fields?: Record<string, unknown>, level?: LogLevel) => void;
+  event?: (scope: string, event: BridgeEventName, fields?: Record<string, unknown>, level?: LogLevel) => void;
   logTranscript: (type: TranscriptType, fields: Record<string, unknown>, content: string) => void;
 };
 
 export type LoggerOptions = {
-  level: "debug" | "info" | "warn" | "error";
+  level: LogLevel;
   enableTranscript: boolean;
   enableConsole: boolean;
   enableColor: boolean;
   rotateDaily: boolean;
+  format: LogFormat;
+  messagePolicy: LogMessagePolicy;
+  redactFields: string[];
+};
+export type LoggerInputOptions = {
+  [Key in keyof LoggerOptions]?: LoggerOptions[Key] | undefined;
 };
 
 const TRANSCRIPT_LABELS: Record<TranscriptType, string> = {
@@ -30,20 +62,63 @@ const DEFAULT_LOGGER_OPTIONS: LoggerOptions = {
   enableConsole: true,
   enableColor: true,
   rotateDaily: true,
+  format: "pretty",
+  messagePolicy: "preview",
+  redactFields: [
+    "feishu.appSecret",
+    "opencode.apiKey",
+    "appSecret",
+    "apiKey",
+    "plainText",
+    "content",
+  ],
 };
 
-const LEVEL_PRIORITY: Record<LoggerOptions["level"], number> = {
+const LEVEL_PRIORITY: Record<LogLevel, number> = {
   debug: 10,
   info: 20,
   warn: 30,
   error: 40,
 };
 
-export async function createLogger(loggingDir: string, options: Partial<LoggerOptions> = {}): Promise<Logger> {
+const logContextStorage = new AsyncLocalStorage<LogContext>();
+
+export async function runWithLogContext<T>(context: LogContext, callback: () => Promise<T>): Promise<T> {
+  const parent = logContextStorage.getStore() ?? {};
+  return await logContextStorage.run({ ...parent, ...compactContext(context) }, callback);
+}
+
+export function getLogContext(): LogContext {
+  return logContextStorage.getStore() ?? {};
+}
+
+export function logEvent(
+  logger: Pick<Logger, "log" | "event">,
+  scope: string,
+  event: BridgeEventName,
+  fields: Record<string, unknown> = {},
+  level: LogLevel = "info",
+): void {
+  if (logger.event) {
+    logger.event(scope, event, fields, level);
+    return;
+  }
+  logger.log(scope, event, { event, ...fields }, level);
+}
+
+export async function createLogger(loggingDir: string, options: LoggerInputOptions = {}): Promise<Logger> {
   await mkdir(loggingDir, { recursive: true });
-  const resolvedOptions = {
+  const resolvedOptions: LoggerOptions = {
     ...DEFAULT_LOGGER_OPTIONS,
     ...options,
+    level: options.level ?? DEFAULT_LOGGER_OPTIONS.level,
+    enableTranscript: options.enableTranscript ?? DEFAULT_LOGGER_OPTIONS.enableTranscript,
+    enableConsole: options.enableConsole ?? DEFAULT_LOGGER_OPTIONS.enableConsole,
+    enableColor: options.enableColor ?? DEFAULT_LOGGER_OPTIONS.enableColor,
+    rotateDaily: options.rotateDaily ?? DEFAULT_LOGGER_OPTIONS.rotateDaily,
+    format: options.format ?? DEFAULT_LOGGER_OPTIONS.format,
+    messagePolicy: options.messagePolicy ?? DEFAULT_LOGGER_OPTIONS.messagePolicy,
+    redactFields: options.redactFields ?? DEFAULT_LOGGER_OPTIONS.redactFields,
   };
 
   return {
@@ -51,17 +126,19 @@ export async function createLogger(loggingDir: string, options: Partial<LoggerOp
       if (!shouldLog(level, resolvedOptions.level)) {
         return;
       }
-      const line = `${timeStamp()} [${scope}] ${message} ${formatFields(fields)}`.trimEnd();
-      void appendFile(resolveLogPath(loggingDir, "bridge", resolvedOptions.rotateDaily), `${line}\n`, "utf8");
-      if (resolvedOptions.enableConsole) {
-        console.log(resolvedOptions.enableColor ? colorizeLine(line, level) : line);
+      writeBridgeLog(loggingDir, resolvedOptions, scope, message, fields, level);
+    },
+    event(scope, event, fields = {}, level = "info") {
+      if (!shouldLog(level, resolvedOptions.level)) {
+        return;
       }
+      writeBridgeLog(loggingDir, resolvedOptions, scope, event, { event, ...fields }, level);
     },
     logTranscript(type, fields, content) {
       if (!resolvedOptions.enableTranscript) {
         return;
       }
-      const header = `[${TRANSCRIPT_LABELS[type]}] ${formatFields(fields)}`.trimEnd();
+      const header = `[${TRANSCRIPT_LABELS[type]}] ${formatFields(prepareFields(fields, resolvedOptions))}`.trimEnd();
       const block = `${header}\n内容: ${content}\n---\n`;
       void appendFile(resolveLogPath(loggingDir, "transcript", resolvedOptions.rotateDaily), block, "utf8");
     },
@@ -93,11 +170,11 @@ function formatLocalDay(value: Date): string {
   return `${year}-${month}-${day}`;
 }
 
-function shouldLog(level: LoggerOptions["level"], configuredLevel: LoggerOptions["level"]): boolean {
+function shouldLog(level: LogLevel, configuredLevel: LogLevel): boolean {
   return LEVEL_PRIORITY[level] >= LEVEL_PRIORITY[configuredLevel];
 }
 
-function colorizeLine(line: string, level: LoggerOptions["level"]): string {
+function colorizeLine(line: string, level: LogLevel): string {
   switch (level) {
     case "debug": return `\u001b[90m${line}\u001b[0m`;
     case "warn": return `\u001b[33m${line}\u001b[0m`;
@@ -115,4 +192,89 @@ function formatFields(fields: Record<string, unknown>): string {
   }
 
   return `{ ${entries.map(([key, value]) => `${key}=${JSON.stringify(value)}`).join(" ")} }`;
+}
+
+function writeBridgeLog(
+  loggingDir: string,
+  options: LoggerOptions,
+  scope: string,
+  message: string,
+  fields: Record<string, unknown>,
+  level: LogLevel,
+): void {
+  const preparedFields = prepareFields(fields, options);
+  const line = options.format === "json"
+    ? formatJsonLine(scope, message, preparedFields, level)
+    : `${timeStamp()} [${scope}] ${message} ${formatFields(preparedFields)}`.trimEnd();
+  void appendFile(resolveLogPath(loggingDir, "bridge", options.rotateDaily), `${line}\n`, "utf8");
+  if (options.enableConsole) {
+    console.log(options.enableColor && options.format === "pretty" ? colorizeLine(line, level) : line);
+  }
+}
+
+function prepareFields(fields: Record<string, unknown>, options: LoggerOptions): Record<string, unknown> {
+  return applyMessagePolicy(redactFields({
+    ...getLogContext(),
+    ...fields,
+  }, new Set(options.redactFields)), options.messagePolicy);
+}
+
+function formatJsonLine(
+  scope: string,
+  message: string,
+  fields: Record<string, unknown>,
+  level: LogLevel,
+): string {
+  return JSON.stringify({
+    ts: new Date().toISOString(),
+    level,
+    scope,
+    msg: message,
+    ...fields,
+  });
+}
+
+function redactFields(fields: Record<string, unknown>, redactedKeys: Set<string>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(fields).map(([key, value]) => {
+    if (redactedKeys.has(key)) {
+      return [key, "[REDACTED]"];
+    }
+    return [key, value];
+  }));
+}
+
+function applyMessagePolicy(fields: Record<string, unknown>, policy: LogMessagePolicy): Record<string, unknown> {
+  if (!Object.prototype.hasOwnProperty.call(fields, "textPreview")) {
+    return fields;
+  }
+
+  const value = fields.textPreview;
+  if (typeof value !== "string") {
+    return fields;
+  }
+
+  if (policy === "full" || policy === "preview") {
+    return policy === "preview"
+      ? { ...fields, textPreview: createTextPreview(value) }
+      : fields;
+  }
+
+  if (policy === "hash") {
+    return {
+      ...fields,
+      textPreviewHash: createHash("sha256").update(value).digest("hex"),
+      textPreview: "[HASHED]",
+    };
+  }
+
+  return {
+    ...fields,
+    textPreview: "[REDACTED]",
+  };
+}
+
+function compactContext(context: LogContext): LogContext {
+  return Object.fromEntries(
+    Object.entries(context).filter(([, value]) => typeof value === "string" && value.length > 0),
+  ) as LogContext;
 }

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -14,7 +14,7 @@ import {
   toInteractiveCardContent,
   type FeishuPostPayload,
 } from "../feishu/shared-primitives.js";
-import { createTextPreview, type Logger, type TranscriptType } from "../logging/logger.js";
+import { createTextPreview, getLogContext, logEvent, type LogContext, type Logger, type TranscriptType } from "../logging/logger.js";
 import {
   type KnowledgeBasePort,
 } from "../knowledge/index.js";
@@ -416,8 +416,9 @@ export class BridgeApp {
     const sessionId = await this.ensureSession(message);
     const executionKey = this.buildExecutionKey(message.conversationKey, sessionId);
     const queue = this.queues.get(executionKey);
+    const turnId = crypto.randomUUID();
     const turn: BridgeTurn = {
-      turnId: crypto.randomUUID(),
+      turnId,
       chatId: message.chatId,
       conversationKey: message.conversationKey,
       threadKey: message.threadKey,
@@ -427,6 +428,7 @@ export class BridgeApp {
       plainText: message.plainText,
       text: toOpencodePromptText(message),
       sessionId,
+      logContext: this.buildTurnLogContext(message, turnId, sessionId),
     };
 
     const result = queue.enqueue(turn);
@@ -645,6 +647,7 @@ export class BridgeApp {
       plainText: `${instruction}\n\n[文件] ${pending.file.fileName}`,
       text: processed.prompt,
       sessionId,
+      logContext: this.buildTurnLogContext(message, turnId, sessionId),
     };
     const result = queue.enqueue(turn);
     if (!result.accepted) {
@@ -1220,14 +1223,38 @@ export class BridgeApp {
     options: { event: string; transcriptType: TranscriptType; textPreview: string; len: number },
     delivery?: { replyToMessageId: string; replyInThread?: boolean },
   ): Promise<{ messageId: string }> {
-    const result = delivery?.replyToMessageId && delivery.replyInThread !== undefined
-      ? await this.outbound.replyMessage(delivery.replyToMessageId, payload, { replyInThread: delivery.replyInThread })
-      : this.config.feishu.behavior.replyInThread && delivery?.replyToMessageId
-        ? await this.outbound.replyMessage(delivery.replyToMessageId, payload)
-        : await this.outbound.sendMessage(chatId, payload);
-    this.logger.log("feishu/reply", options.event, { chatId, messageId: result.messageId, textPreview: options.textPreview, len: options.len });
-    this.logger.logTranscript(options.transcriptType, { chatId, messageId: result.messageId }, prettyPrintPayload(payload));
-    return result;
+    const transportAction = delivery?.replyToMessageId
+      ? "reply"
+      : "send";
+    try {
+      const result = delivery?.replyToMessageId && delivery.replyInThread !== undefined
+        ? await this.outbound.replyMessage(delivery.replyToMessageId, payload, { replyInThread: delivery.replyInThread })
+        : this.config.feishu.behavior.replyInThread && delivery?.replyToMessageId
+          ? await this.outbound.replyMessage(delivery.replyToMessageId, payload)
+          : await this.outbound.sendMessage(chatId, payload);
+      logEvent(this.logger, "feishu/reply", "transport.sent", {
+        chatId,
+        messageId: result.messageId,
+        transportAction,
+        payloadKind: payload.msg_type === "interactive" ? "card" : "post",
+        legacyEvent: options.event,
+        textPreview: options.textPreview,
+        len: options.len,
+      });
+      this.logger.logTranscript(options.transcriptType, { chatId, messageId: result.messageId }, prettyPrintPayload(payload));
+      return result;
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      logEvent(this.logger, "feishu/reply", "transport.failed", {
+        chatId,
+        transportAction,
+        payloadKind: payload.msg_type === "interactive" ? "card" : "post",
+        legacyEvent: options.event,
+        errorKind: error instanceof Error ? error.name : "unknown",
+        detail,
+      }, "warn");
+      throw error;
+    }
   }
 
   private async updatePayload(
@@ -1236,10 +1263,47 @@ export class BridgeApp {
     payload: FeishuPostPayload,
     options: { event: string; transcriptType: TranscriptType; textPreview: string; len: number },
   ): Promise<{ messageId: string }> {
-    const result = await this.outbound.updateMessage(messageId, payload);
-    this.logger.log("feishu/reply", options.event, { chatId, messageId: result.messageId, textPreview: options.textPreview, len: options.len });
-    this.logger.logTranscript(options.transcriptType, { chatId, messageId: result.messageId }, prettyPrintPayload(payload));
-    return result;
+    try {
+      const result = await this.outbound.updateMessage(messageId, payload);
+      logEvent(this.logger, "feishu/reply", "transport.sent", {
+        chatId,
+        messageId: result.messageId,
+        transportAction: "update",
+        payloadKind: payload.msg_type === "interactive" ? "card" : "post",
+        legacyEvent: options.event,
+        textPreview: options.textPreview,
+        len: options.len,
+      });
+      this.logger.logTranscript(options.transcriptType, { chatId, messageId: result.messageId }, prettyPrintPayload(payload));
+      return result;
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      logEvent(this.logger, "feishu/reply", "transport.failed", {
+        chatId,
+        messageId,
+        transportAction: "update",
+        payloadKind: payload.msg_type === "interactive" ? "card" : "post",
+        legacyEvent: options.event,
+        errorKind: error instanceof Error ? error.name : "unknown",
+        detail,
+      }, "warn");
+      throw error;
+    }
+  }
+
+  private buildTurnLogContext(
+    message: Pick<IncomingChatMessage, "chatId" | "senderOpenId" | "messageId">,
+    turnId: string,
+    sessionId?: string,
+  ): LogContext {
+    return {
+      ...getLogContext(),
+      turnId,
+      chatId: message.chatId,
+      userId: message.senderOpenId,
+      messageId: message.messageId,
+      sessionId,
+    };
   }
 }
 

--- a/src/runtime/permission-manager.ts
+++ b/src/runtime/permission-manager.ts
@@ -1,6 +1,6 @@
 import type { PendingPermissionInteraction } from "../bridge/state.js";
 import { buildNoticeCardPayload, type FeishuPostPayload } from "../feishu/shared-primitives.js";
-import type { Logger, TranscriptType } from "../logging/logger.js";
+import { logEvent, type Logger, type TranscriptType } from "../logging/logger.js";
 import type { PermissionPolicy } from "../opencode/client.js";
 import type { PermissionCardActionValue } from "./app.js";
 import { isPermissionCardActionValue } from "./app-helpers.js";
@@ -143,6 +143,14 @@ export class PermissionManager {
         status: "处理中",
         update: resolution === "timeout" ? "权限请求已超时，已默认拒绝" : `已处理权限请求：${interaction.permissionName}`,
         target: "step",
+      });
+      logEvent(this.logger, "bridge/permission", "permission.decided", {
+        turnId: interaction.turnId,
+        sessionId: interaction.sessionId,
+        chatId: interaction.chatId,
+        permissionId: interaction.permissionId,
+        decision: resolution === "deny" || resolution === "timeout" ? "denied" : "approved",
+        decisionSource: resolution === "timeout" ? "timeout" : "user",
       });
     } finally {
       this.processing.delete(interaction.permissionVersion);

--- a/src/runtime/runtime-modules.ts
+++ b/src/runtime/runtime-modules.ts
@@ -67,7 +67,7 @@ export function createRuntimeModules(options: {
   const contractAssistant = createContractAssistantService(options.config, options.outbound, options.opencode as OpenCodeClient, options.logger);
   const laborSkill = createLaborSkillService(options.config, options.outbound, options.opencode as OpenCodeClient, options.logger, knowledge);
 
-  const moduleManager = new RuntimeModuleManager();
+  const moduleManager = new RuntimeModuleManager(options.logger);
   const knowledgeModule = new KnowledgeRuntimeModule({
     config: options.config,
     logger: options.logger,

--- a/src/runtime/turn-card-manager.ts
+++ b/src/runtime/turn-card-manager.ts
@@ -1,6 +1,6 @@
 import { type FeishuPostPayload, type OutputView, type ToolUpdateView } from "../feishu/shared-primitives.js";
 import { buildTurnStatusCardPayload, type TurnStatusCardView } from "../feishu/runtime-cards.js";
-import { createTextPreview, type Logger, type TranscriptType } from "../logging/logger.js";
+import { createTextPreview, logEvent, type Logger, type TranscriptType } from "../logging/logger.js";
 import {
   appendProgressUpdate,
   formatDuration,
@@ -83,7 +83,15 @@ export class TurnCardManager {
       return { messageId: result.messageId };
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
-      this.logger.log("feishu/reply", "process card send failed", { chatId, turnId, detail }, "warn");
+      logEvent(this.logger, "feishu/reply", "transport.failed", {
+        chatId,
+        turnId,
+        transportAction: this.replyInThread ? "reply" : "send",
+        payloadKind: "card",
+        legacyEvent: "process card send failed",
+        errorKind: error instanceof Error ? error.name : "unknown",
+        detail,
+      }, "warn");
       return null;
     }
   }
@@ -149,16 +157,27 @@ export class TurnCardManager {
     try {
       const payload = buildTurnStatusCardPayload(this.toTurnCardView(card));
       const result = await this.outbound.updateMessage(card.messageId, payload);
-      this.logger.log("feishu/reply", "process message updated", {
+      logEvent(this.logger, "feishu/reply", "transport.sent", {
         messageId: result.messageId,
         turnId,
+        transportAction: "update",
+        payloadKind: "card",
+        legacyEvent: "process message updated",
         textPreview: createTextPreview([...card.progressUpdates, ...card.toolUpdates.map((item) => item.view.label)].join(" | ")),
         len: [...card.progressUpdates, ...card.toolUpdates.map((item) => item.view.label)].join("\n").length,
       });
       this.logger.logTranscript("outbound-process", { messageId: result.messageId }, prettyPrintPayload(payload));
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
-      this.logger.log("feishu/reply", "process card update failed", { messageId: card.messageId, turnId, detail }, "warn");
+      logEvent(this.logger, "feishu/reply", "transport.failed", {
+        messageId: card.messageId,
+        turnId,
+        transportAction: "update",
+        payloadKind: "card",
+        legacyEvent: "process card update failed",
+        errorKind: error instanceof Error ? error.name : "unknown",
+        detail,
+      }, "warn");
     }
   }
 
@@ -189,7 +208,15 @@ export class TurnCardManager {
     const result = this.replyInThread && delivery?.replyToMessageId
       ? await this.outbound.replyMessage(delivery.replyToMessageId, payload)
       : await this.outbound.sendMessage(chatId, payload);
-    this.logger.log("feishu/reply", options.event, { chatId, messageId: result.messageId, textPreview: options.textPreview, len: options.len });
+    logEvent(this.logger, "feishu/reply", "transport.sent", {
+      chatId,
+      messageId: result.messageId,
+      transportAction: this.replyInThread && delivery?.replyToMessageId ? "reply" : "send",
+      payloadKind: payload.msg_type === "interactive" ? "card" : "post",
+      legacyEvent: options.event,
+      textPreview: options.textPreview,
+      len: options.len,
+    });
     this.logger.logTranscript(options.transcriptType, { chatId, messageId: result.messageId }, prettyPrintPayload(payload));
     return result;
   }

--- a/src/runtime/turn-executor.ts
+++ b/src/runtime/turn-executor.ts
@@ -7,7 +7,7 @@ import { TurnWatchdog } from "../bridge/watchdog.js";
 import type { BridgeTurn } from "../bridge/turn.js";
 import { buildPermissionRequestCardPayload } from "../feishu/runtime-cards.js";
 import { buildPostMarkdownPayload, type FeishuPostPayload } from "../feishu/shared-primitives.js";
-import { createTextPreview, type Logger, type TranscriptType } from "../logging/logger.js";
+import { createTextPreview, logEvent, runWithLogContext, type Logger, type TranscriptType } from "../logging/logger.js";
 import { type OpenCodeMessage, type OpenCodeSessionStatus } from "../opencode/client.js";
 import { getEventSessionId, type OpenCodeEvent } from "../opencode/events.js";
 import { type SessionWindowRecord } from "../store/mappings.js";
@@ -203,15 +203,28 @@ export class TurnExecutor {
     const active = queue.peek();
     if (!active) return;
 
+    await runWithLogContext(active.logContext ?? {
+      turnId: active.turnId,
+      chatId: active.chatId,
+      userId: active.senderOpenId,
+      messageId: active.inboundMessageId,
+      sessionId: active.sessionId,
+    }, async () => {
+      await this.runTurnWithContext(queueKey, active);
+    });
+  }
+
+  private async runTurnWithContext(queueKey: string, active: BridgeTurn): Promise<void> {
+    const queue = this.context.queues.get(queueKey);
     let turn = transitionTurn(active, "running");
     queue.replaceActive(turn);
     let hasProcessCard = false;
 
     try {
       const sessionId = turn.sessionId ?? await this.context.ensureSession(turn);
-      turn = { ...turn, sessionId };
+      turn = { ...turn, sessionId, logContext: { ...(turn.logContext ?? {}), sessionId } };
       queue.replaceActive(turn);
-      this.context.logger.log("bridge/queue", "turn started", { turnId: turn.turnId, sessionId, chatId: turn.chatId, conversationKey: turn.conversationKey });
+      logEvent(this.context.logger, "bridge/queue", "turn.started", { turnId: turn.turnId, sessionId, chatId: turn.chatId, conversationKey: turn.conversationKey });
 
       const card = await this.context.turnCardManager.createTurnCard(turn.chatId, turn.turnId, sessionId, turn.inboundMessageId);
       if (card) {
@@ -237,11 +250,31 @@ export class TurnExecutor {
       await this.context.turnCardManager.flushStreamUpdate(turn.turnId, reply, true);
       await this.context.turnCardManager.updateTurnCard(turn.turnId, { status: "已完成", update: `最终回复已生成（${reply.length} 字）`, target: "step" });
       queue.replaceActive(transitionTurn({ ...turn, sessionId }, "done"));
-      this.context.logger.log("bridge/queue", "turn completed", { turnId: turn.turnId, duration: Date.now() - (turn.startedAt ?? Date.now()) });
+      logEvent(this.context.logger, "bridge/queue", "turn.completed", {
+        turnId: turn.turnId,
+        sessionId,
+        durationMs: Date.now() - (turn.startedAt ?? Date.now()),
+        replyLength: reply.length,
+        processMessageId: turn.processMessageId,
+      });
     } catch (error) {
       const detail = normalizeTurnFailureDetail(error);
-      this.context.logger.log("bridge/queue", "run turn failed", { chatId: turn.chatId, conversationKey: turn.conversationKey, turnId: turn.turnId, detail }, "error");
+      logEvent(this.context.logger, "bridge/queue", "turn.failed", {
+        chatId: turn.chatId,
+        conversationKey: turn.conversationKey,
+        turnId: turn.turnId,
+        sessionId: turn.sessionId,
+        errorKind: error instanceof Error ? error.name : "unknown",
+        detail,
+      }, "error");
       if (!hasProcessCard) {
+        logEvent(this.context.logger, "bridge/queue", "turn.fallback_triggered", {
+          turnId: turn.turnId,
+          sessionId: turn.sessionId,
+          chatId: turn.chatId,
+          fallbackKind: "failure-markdown",
+          reason: detail,
+        }, "warn");
         await this.sendTurnFallbackMarkdown(turn.chatId, `处理失败：${escapeMarkdownText(detail)}`, turn.inboundMessageId);
       }
       await this.context.turnCardManager.updateTurnCard(turn.turnId, { status: detail.includes("超时") ? "已超时" : "处理失败", update: detail, target: "step" });
@@ -587,6 +620,14 @@ export class TurnExecutor {
       len: permissionName.length + 16,
     }, { replyToMessageId: turn.inboundMessageId });
     interaction.permissionMessageId = sent.messageId;
+    logEvent(this.context.logger, "bridge/permission", "permission.asked", {
+      turnId: turn.turnId,
+      sessionId: turn.sessionId,
+      permissionId,
+      permissionKind: permissionName,
+      chatId: turn.chatId,
+      messageId: sent.messageId,
+    });
   }
 
   private async runFirstSseFallback(

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { createLogger, createTextPreview } from "../src/logging/logger.js";
+import { createLogger, createTextPreview, runWithLogContext } from "../src/logging/logger.js";
 
 describe("logger", () => {
   afterEach(() => {
@@ -134,6 +134,43 @@ describe("logger", () => {
     const content = await readFile(path.join(dir, "bridge-2026-04-12.log"), "utf8");
     expect(content).toContain("scope");
     expect(content).toContain("message");
+  });
+
+  it("adds async log context to bridge logs", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-logger-"));
+    const logger = await createLogger(dir, { enableConsole: false });
+    await runWithLogContext({ correlationId: "corr-1", turnId: "turn-1" }, async () => {
+      logger.log("scope", "message", { ok: true });
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const content = await readFile(path.join(dir, `bridge-${localDay()}.log`), "utf8");
+    expect(content).toContain("correlationId=\"corr-1\"");
+    expect(content).toContain("turnId=\"turn-1\"");
+  });
+
+  it("writes json bridge logs and redacts configured fields", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-logger-"));
+    const logger = await createLogger(dir, {
+      enableConsole: false,
+      format: "json",
+      redactFields: ["secret"],
+    });
+
+    logger.event?.("scope", "turn.started", {
+      turnId: "turn-1",
+      sessionId: "session-1",
+      chatId: "chat-1",
+      conversationKey: "conversation-1",
+      secret: "hidden",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const content = await readFile(path.join(dir, `bridge-${localDay()}.log`), "utf8");
+    const line = JSON.parse(content) as Record<string, unknown>;
+    expect(line.event).toBe("turn.started");
+    expect(line.turnId).toBe("turn-1");
+    expect(line.secret).toBe("[REDACTED]");
   });
 });
 


### PR DESCRIPTION
### 变更内容
- 新增运行时可观测性事件 schema 文档，定义 turn、permission、module、transport 等稳定事件名和字段约定。
- 扩展 logger，支持结构化 JSON 输出、messagePolicy、字段脱敏、AsyncLocalStorage 日志上下文和 event helper。
- 在飞书 WebSocket、HTTP callback、BridgeApp、RuntimeModule、PermissionManager、TurnCardManager、TurnExecutor 等路径贯通 correlation/turn/session/message 上下文。
- 更新架构基线，补充 observability seam 说明。
- 更新版本到 0.1.30，并补充 logger 回归测试。

### 变更原因
- PR-A 已建立新功能自检自动化后，PR-B 需要把运行时观测边界落到代码和文档，减少后续排查 turn、权限、模块调用和发送失败时的信息断点。
- 结构化日志和稳定事件名可以让后续 JSONL、监控、告警或 trace 汇总有明确接入点。

### 影响
- 默认日志仍保持 pretty/preview 行为，兼容现有本地调试体验。
- 开启 JSON 格式或 hash/none messagePolicy 后，可以降低日志敏感内容暴露风险。
- 不改变用户可见命令行为。

### 验证
- `npm run lint`
- `npm run typecheck`
- `npm run lint:deps`
- `npm run check:formatter-exports`
- `npm run check:docs-diff`
- `npm test`
- `npm run build`