### PR TITLE
[codex] 支持图片资源与权限默认策略

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -56,6 +56,9 @@
       "totalTurn": 300000
     }
   },
+  "permissions": {
+    "defaultPolicy": "ask"
+  },
   "embeddings": {
     "provider": {
       "baseUrl": "https://api.openai.com/v1/",

--- a/src/bridge/router.ts
+++ b/src/bridge/router.ts
@@ -30,6 +30,7 @@ export type RoutedText =
       | { kind: "delete"; index?: number | undefined; sessionId?: string | undefined; range?: { start: number; end: number } | undefined; all?: boolean | undefined; confirm: boolean }
       | { kind: "allow"; policy: "once" | "always" }
       | { kind: "deny" }
+      | { kind: "help-file" }
       | { kind: "passthrough"; name: string; arguments: string[] };
   }
   | { kind: "message"; text: string };
@@ -268,6 +269,10 @@ export function routeIncomingText(text: string): RoutedText {
 
   if (rawCommand === "deny" && args.length === 0) {
     return { kind: "command", command: { kind: "deny" } };
+  }
+
+  if (rawCommand === "help-file" && args.length === 0) {
+    return { kind: "command", command: { kind: "help-file" } };
   }
 
   return {

--- a/src/bridge/state.ts
+++ b/src/bridge/state.ts
@@ -81,6 +81,8 @@ export type PendingFileInstructionInteraction = {
     fileName: string;
     size?: number | undefined;
   };
+  /** 区分普通文件与图片资源，下载时传给飞书 API。缺失时默认 "file"。 */
+  resourceType?: "file" | "image" | undefined;
 };
 
 export type PendingInteraction =

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -110,6 +110,10 @@ export const ConfigSchema = z.object({
       totalTurn: z.number().int().positive().default(300_000),
     }).default({}),
   }),
+  permissions: z.object({
+    /** ask: 每次都询问; allow: 只读权限自动放行; deny: 只读权限自动拒绝 */
+    defaultPolicy: z.enum(["ask", "allow", "deny"]).default("ask"),
+  }).default({}),
   embeddings: EmbeddingsConfigSchema,
   logging: z.object({
     dir: z.string().min(1).default("./logs"),
@@ -209,6 +213,9 @@ export type AppConfig = {
     eventGapTimeoutMs: number;
     totalTimeoutMs: number;
   };
+  permissions?: {
+    defaultPolicy: "ask" | "allow" | "deny";
+  } | undefined;
   embeddings?: {
     provider?: {
       baseUrl: URL;

--- a/src/extension-api/index.ts
+++ b/src/extension-api/index.ts
@@ -64,7 +64,7 @@ export type ExtensionOutboundPort = {
   sendMessage(chatId: string, payload: ExtensionOutboundPayload): Promise<{ messageId: string }>;
   replyMessage(messageId: string, payload: ExtensionOutboundPayload, options?: { replyInThread?: boolean }): Promise<{ messageId: string }>;
   updateMessage(messageId: string, payload: ExtensionOutboundPayload): Promise<{ messageId: string }>;
-  downloadMessageResource(messageId: string, fileKey: string, type: "file"): Promise<{
+  downloadMessageResource(messageId: string, fileKey: string, type: "file" | "image"): Promise<{
     fileName: string;
     mimeType: string;
     buffer: Buffer;
@@ -129,12 +129,14 @@ export type ExtensionIncomingMessage = {
   parentId?: string | undefined;
   threadKey: string;
   conversationKey: string;
-  messageType: "text" | "post" | "file";
+  messageType: "text" | "post" | "file" | "image";
   file?: {
     fileKey: string;
     fileName: string;
     size?: number | undefined;
   } | undefined;
+  /** 区分普通文件与图片资源，缺失时默认 "file"。 */
+  resourceType?: "file" | "image" | undefined;
 };
 
 export type ExtensionRoutedText =

--- a/src/feishu/runtime-cards.ts
+++ b/src/feishu/runtime-cards.ts
@@ -44,6 +44,8 @@ export type SessionListCardView = {
     current?: boolean;
     archived?: boolean;
     meta?: string;
+    /** 短会话 ID（前 12 位），用于显示和匹配。 */
+    shortId?: string;
   }>;
   footer: string;
   emptyText?: string;
@@ -555,13 +557,14 @@ function buildSessionListItemBlock(item: SessionListCardView["items"][number]): 
 
 function formatSessionListTitle(item: SessionListCardView["items"][number]): string {
   const title = escapeText(item.title);
+  const shortIdSuffix = item.shortId ? ` \`${escapeText(item.shortId)}\`` : "";
   if (item.archived) {
-    return `~~${title}~~`;
+    return `~~${title}~~${shortIdSuffix}`;
   }
   if (item.current) {
-    return `**${title}**`;
+    return `**${title}**${shortIdSuffix}`;
   }
-  return title;
+  return `${title}${shortIdSuffix}`;
 }
 
 function buildEmptyStateBlock(text: string): Record<string, unknown> {

--- a/src/feishu/ws.ts
+++ b/src/feishu/ws.ts
@@ -76,6 +76,8 @@ type TextParseResult = {
     fileName: string;
     size?: number | undefined;
   } | undefined;
+  /** 区分普通文件与图片资源，下载时传给飞书 API。 */
+  resourceType?: "file" | "image" | undefined;
 };
 
 type IncomingMessageInspection =
@@ -100,7 +102,7 @@ type IncomingMessageInspection =
     fields?: Record<string, unknown>;
   };
 
-const SUPPORTED_MESSAGE_TYPES = new Set(["text", "post", "file"]);
+const SUPPORTED_MESSAGE_TYPES = new Set(["text", "post", "file", "image"]);
 const RECENT_MESSAGE_TTL_MS = 24 * 60 * 60 * 1000;
 
 type FeishuIngressOptions = {
@@ -225,10 +227,12 @@ export class FeishuWsClient {
       messageId: incoming.messageId,
       senderId: incoming.senderOpenId,
       messageType: incoming.messageType,
+      resourceType: "resourceType" in incoming ? incoming.resourceType : undefined,
+      hasFilePayload: "file" in incoming && Boolean(incoming.file),
       textPreview: incoming.plainText,
       len: incoming.plainText.length,
       ...(inspection.fields ?? {}),
-    });
+    }, "debug");
 
     if (
       incoming.chatType !== "p2p"
@@ -499,10 +503,17 @@ function parseIncomingMessage(payload: FeishuReceiveEvent, options: FeishuIngres
 
   return {
     accepted: true,
-    incoming: parsed.file ? { ...common, messageType: "file", file: parsed.file } : {
-      ...common,
-      messageType: messageType as "text" | "post",
-    },
+    incoming: parsed.file
+      ? {
+        ...common,
+        messageType: parsed.resourceType === "image" ? "image" : "file",
+        file: parsed.file,
+        ...(parsed.resourceType ? { resourceType: parsed.resourceType } : {}),
+      }
+      : {
+        ...common,
+        messageType: messageType as "text" | "post",
+      },
     hasAnyMention: parsed.hasAnyMention,
     hasExactBotMention: parsed.hasExactBotMention,
     fields: {
@@ -575,6 +586,10 @@ function parseMessageContent(
 
   if (messageType === "file") {
     return parseFileMessage(rawContent);
+  }
+
+  if (messageType === "image") {
+    return parseImageMessage(rawContent);
   }
 
   return null;
@@ -684,6 +699,26 @@ function parseFileMessage(rawContent: string): TextParseResult {
       hasAnyMention: false,
       hasExactBotMention: false,
     };
+  }
+}
+
+/** 解析 image 消息，提取 image_key 并复用 file-like payload。 */
+function parseImageMessage(rawContent: string): TextParseResult {
+  try {
+    const parsed = JSON.parse(rawContent) as Record<string, unknown>;
+    const imageKey = nonEmptyStringFromKeys(parsed, ["image_key", "imageKey", "key"]);
+    if (!imageKey) {
+      return { plainText: "", hasAnyMention: false, hasExactBotMention: false };
+    }
+    return {
+      plainText: "[图片]",
+      hasAnyMention: false,
+      hasExactBotMention: false,
+      file: { fileKey: imageKey, fileName: `${imageKey}.png` },
+      resourceType: "image",
+    };
+  } catch {
+    return { plainText: "", hasAnyMention: false, hasExactBotMention: false };
   }
 }
 

--- a/src/knowledge/factory.ts
+++ b/src/knowledge/factory.ts
@@ -22,7 +22,7 @@ import {
 } from "./index.js";
 
 type KnowledgeResourcePort = {
-  downloadMessageResource(messageId: string, fileKey: string, type: "file"): Promise<{
+  downloadMessageResource(messageId: string, fileKey: string, type: "file" | "image"): Promise<{
     fileName: string;
     mimeType: string;
     buffer: Buffer;

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -122,7 +122,7 @@ export interface KnowledgeBasePort {
 type OpenCodePort = Pick<OpenCodeClient, "createSession" | "postMessageSync" | "deleteSession">;
 
 type KnowledgeResourcePort = {
-  downloadMessageResource(messageId: string, fileKey: string, type: "file"): Promise<{
+  downloadMessageResource(messageId: string, fileKey: string, type: "file" | "image"): Promise<{
     fileName: string;
     mimeType: string;
     buffer: Buffer;

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -88,12 +88,14 @@ export type IncomingTextMessage = IncomingChatMessageBase & {
 };
 
 export type IncomingFileMessage = IncomingChatMessageBase & {
-  messageType: "file";
+  messageType: "file" | "image";
   file: {
     fileKey: string;
     fileName: string;
     size?: number | undefined;
   };
+  /** 区分普通文件与图片资源，下载时传给飞书 API。缺失时默认 "file"。 */
+  resourceType?: "file" | "image" | undefined;
 };
 
 export type IncomingChatMessage = IncomingTextMessage | IncomingFileMessage;
@@ -105,7 +107,7 @@ type OutboundPort = {
 };
 
 type KnowledgeResourcePort = {
-  downloadMessageResource(messageId: string, fileKey: string, type: "file"): Promise<{
+  downloadMessageResource(messageId: string, fileKey: string, type: "file" | "image"): Promise<{
     fileName: string;
     mimeType: string;
     buffer: Buffer;
@@ -226,7 +228,7 @@ export class BridgeApp {
         return await this.sendPayload(chatId, payload, options, delivery);
       },
       toCardContent: (payload) => this.toCardContent(payload),
-    });
+    }, this.config.permissions?.defaultPolicy ?? "ask");
     const transport = createFeishuTransport({
       sendPayload: async (chatId, payload, options, delivery) => await this.sendPayload(chatId, payload, options, delivery),
       updatePayload: async (chatId, messageId, payload, options) => await this.updatePayload(chatId, messageId, payload, options),
@@ -363,7 +365,7 @@ export class BridgeApp {
     }, message.plainText);
     this.messageContextStore.rememberInbound(message);
 
-    const routed = message.messageType === "file"
+    const routed = message.messageType === "file" || message.messageType === "image"
       ? null
       : routeIncomingText(message.plainText);
     if (routed?.kind === "command") {
@@ -401,7 +403,7 @@ export class BridgeApp {
       }
     }
 
-    if (message.messageType === "file") {
+    if (message.messageType === "file" || message.messageType === "image") {
       try {
         this.validateRegularFileInput(message.file.fileName, message.file.size);
       } catch (error) {
@@ -422,6 +424,7 @@ export class BridgeApp {
         }, { replyToMessageId: message.messageId });
         return;
       }
+      const resourceType = message.resourceType ?? (message.messageType === "image" ? "image" : "file");
       this.setPendingInteraction(message.conversationKey, {
         kind: "file-await-instruction",
         chatId: message.chatId,
@@ -434,6 +437,7 @@ export class BridgeApp {
           fileName: message.file.fileName,
           size: message.file.size,
         },
+        resourceType,
       });
       await this.sendPayload(message.chatId, buildNoticeCardPayload({
         title: "已收到文件",
@@ -442,8 +446,7 @@ export class BridgeApp {
         message: [
           `文件：${message.file.fileName}`,
           "",
-          "如果只处理这个文件，可直接回复例如：`总结这个文件` 或 `把这个文件入库`。",
-          "如果要连续批量入库，请发送 `/kb-ingest-start` 后重新上传文件。",
+          "发送指令处理，或 `/help-file` 查看示例",
         ].join("\n"),
         messageIconToken: "file-link-docx_outlined",
         messageIconColor: "blue",
@@ -634,7 +637,7 @@ export class BridgeApp {
    */
   private async handlePendingInteraction(message: IncomingChatMessage, pending: PendingInteraction): Promise<boolean> {
     if (pending.kind === "question") {
-      if (message.messageType === "file") {
+      if (message.messageType === "file" || message.messageType === "image") {
         await this.sendMarkdown(message.chatId, "当前正在等待文本回答，请直接发送文字内容。", message.messageId);
         return true;
       }
@@ -690,7 +693,7 @@ export class BridgeApp {
       await this.sendMarkdown(message.chatId, "当前文件处理仅允许文件发送者继续说明需求。", message.messageId);
       return true;
     }
-    if (message.messageType === "file") {
+    if (message.messageType === "file" || message.messageType === "image") {
       await this.sendMarkdown(message.chatId, "已收到上一个文件，请先发送文字说明你希望我如何处理；如需入库，请发送 `/kb-ingest-start`。", message.messageId);
       return true;
     }
@@ -939,7 +942,7 @@ export class BridgeApp {
     if (!resources.downloadMessageResource) {
       throw new Error("当前运行环境不支持下载飞书文件。");
     }
-    const downloaded = await resources.downloadMessageResource(pending.file.messageId, pending.file.fileKey, "file");
+    const downloaded = await resources.downloadMessageResource(pending.file.messageId, pending.file.fileKey, pending.resourceType ?? "file");
     this.validateRegularFileInput(downloaded.fileName, downloaded.buffer.byteLength);
     const localPath = await this.saveUploadedFileForTurn(turnId, downloaded.fileName, downloaded.buffer);
     return {

--- a/src/runtime/command-handler.ts
+++ b/src/runtime/command-handler.ts
@@ -44,7 +44,7 @@ const SESSION_SELECTION_TTL_MS = 180_000;
 const SESSION_DELETE_CONFIRM_TTL_MS = 30_000;
 const SESSIONS_ALL_PAGE_SIZE = 20;
 
-type CommandMessage = Pick<IncomingChatMessage, "chatId" | "chatType" | "messageId" | "conversationKey" | "threadKey" | "senderOpenId">;
+type CommandMessage = Pick<IncomingChatMessage, "chatId" | "chatType" | "messageId" | "conversationKey" | "threadKey" | "senderOpenId" | "rootId" | "parentId">;
 type CommandRouted = Extract<RoutedText, { kind: "command" }>;
 type PermissionResolution = "once" | "always" | "deny" | "timeout";
 type SessionSelectionOption = PendingSessionSelectionInteraction["options"][number];
@@ -133,8 +133,70 @@ const BRIDGE_OWNED_COMMAND_KINDS = new Set<Extract<RoutedText, { kind: "command"
   "delete",
   "allow",
   "deny",
+  "help-file",
   "passthrough",
 ]);
+
+/**
+ * 统一查找挂起的权限交互。
+ * 查找链: conversationKey -> rootId/parentId 匹配 permissionMessageId -> chatId+requester -> 唯一 active。
+ */
+function resolvePendingPermission(
+  pendingInteractions: Map<string, PendingInteraction>,
+  message: CommandMessage,
+): PendingPermissionInteraction | null {
+  const now = Date.now();
+  const isValid = (p: PendingPermissionInteraction) => !p.resolvedAt && p.expiresAt > now;
+
+  // 1. 按 conversationKey 精确查找
+  const direct = pendingInteractions.get(message.conversationKey);
+  if (direct?.kind === "permission" && isValid(direct)) {
+    return direct;
+  }
+
+  // 2. 按 rootId/parentId 匹配 permissionMessageId（卡片线程回复）
+  const threadCandidates = new Set([message.rootId, message.parentId].filter(Boolean));
+  if (threadCandidates.size > 0) {
+    for (const pending of pendingInteractions.values()) {
+      if (pending.kind !== "permission" || !isValid(pending)) continue;
+      if (pending.chatId === message.chatId && pending.permissionMessageId && threadCandidates.has(pending.permissionMessageId)) {
+        return pending;
+      }
+    }
+  }
+
+  // 3. 按 chatId + requester 查找
+  const candidates: PendingPermissionInteraction[] = [];
+  for (const pending of pendingInteractions.values()) {
+    if (pending.kind !== "permission" || !isValid(pending)) continue;
+    if (pending.chatId === message.chatId && pending.requesterOpenId === message.senderOpenId) {
+      candidates.push(pending);
+    }
+  }
+  if (candidates.length === 1) {
+    return candidates[0] ?? null;
+  }
+
+  // 4. 多 pending 时返回 null
+  return null;
+}
+
+/** 判断是否有多个挂起的权限请求（用于提示用户点击卡片）。 */
+function hasMultiplePendingPermissions(
+  pendingInteractions: Map<string, PendingInteraction>,
+  message: CommandMessage,
+): boolean {
+  const now = Date.now();
+  let count = 0;
+  for (const pending of pendingInteractions.values()) {
+    if (pending.kind !== "permission" || pending.resolvedAt || pending.expiresAt <= now) continue;
+    if (pending.chatId === message.chatId && pending.requesterOpenId === message.senderOpenId) {
+      count++;
+      if (count > 1) return true;
+    }
+  }
+  return false;
+}
 
 /** 判断命令是否由 bridge 核心层而不是业务模块处理。 */
 export function isBridgeOwnedCommand(command: Extract<RoutedText, { kind: "command" }>["command"]): boolean {
@@ -702,19 +764,40 @@ export class CommandHandler {
     }
 
     if (command.kind === "allow" || command.kind === "deny") {
-      const pending = this.context.pendingInteractions.get(message.conversationKey);
-      if (!pending || pending.kind !== "permission") {
+      const pending = resolvePendingPermission(this.context.pendingInteractions, message);
+      if (!pending) {
+        const multiple = hasMultiplePendingPermissions(this.context.pendingInteractions, message);
         await this.sendNotice(message, {
           title: "信息提示",
           template: "blue",
           icon: "info_outlined",
-          message: "当前没有待确认的权限请求。",
+          message: multiple
+            ? "检测到多个待确认的权限请求，请点击对应卡片按钮操作。"
+            : "当前没有待确认的权限请求。",
         });
         return;
       }
       const resolution: PermissionResolution = command.kind === "deny" ? "deny" : command.policy;
       await this.context.permissionManager.resolveInteraction(pending, resolution);
       await this.context.sendPayload(message.chatId, this.context.permissionManager.buildResolutionPayload(resolution), { event: "final message sent", transcriptType: "outbound-final", textPreview: resolution === "deny" ? "已拒绝权限请求。" : "已确认权限请求。", len: 8 }, { replyToMessageId: message.messageId });
+      return;
+    }
+
+    if (command.kind === "help-file") {
+      const helpText = [
+        "**文件处理示例**",
+        "",
+        "直接回复文件消息，输入以下指令：",
+        "",
+        "- `总结这个文件`",
+        "- `提取文件中的关键信息`",
+        "- `把这个文件入库`",
+        "- `分析这个 PDF 的内容`",
+        "- `识别这张图片中的文字`",
+        "",
+        "批量入库请发送 `/kb-ingest-start` 后重新上传文件。",
+      ].join("\n");
+      await this.context.sendMarkdown(message.chatId, helpText, message.messageId);
       return;
     }
 
@@ -740,45 +823,38 @@ export class CommandHandler {
   private async switchSessionByName(message: CommandMessage, window: SessionWindowRecord, rawQuery: string): Promise<void> {
     const query = normalizeSessionLookupText(rawQuery);
     if (!query) {
-      await this.context.sendMarkdown(message.chatId, "请在 `/switch` 后输入会话名称。", message.messageId);
+      await this.context.sendMarkdown(message.chatId, "请在 `/switch` 后输入会话名称或短 ID。", message.messageId);
       return;
     }
 
-    const openCodeSessions = await this.context.listOpenCodeSessionsById();
-    const candidateMap = new Map<string, SessionSelectionOption>();
-    for (const session of window.sessions) {
-      candidateMap.set(session.sessionId, {
-        index: candidateMap.size + 1,
-        sessionId: session.sessionId,
-        title: session.label,
-        current: session.sessionId === window.activeSessionId,
-        inWindow: true,
-      });
-    }
-    for (const session of openCodeSessions.values()) {
-      if (candidateMap.has(session.id)) {
-        continue;
-      }
-      candidateMap.set(session.id, {
-        index: candidateMap.size + 1,
-        sessionId: session.id,
-        title: resolveDisplayLabel(session, session.title ?? session.slug ?? session.id, session.id),
-        current: session.id === window.activeSessionId,
-        inWindow: false,
-      });
-    }
+    // 只在窗口可见 sessions 中匹配
+    const SHORT_ID_LENGTH = 12;
+    const candidates: SessionSelectionOption[] = window.sessions.map((session, index) => ({
+      index: index + 1,
+      sessionId: session.sessionId,
+      title: session.label,
+      current: session.sessionId === window.activeSessionId,
+      inWindow: true,
+    }));
 
-    const candidates = [...candidateMap.values()];
+    // 精确匹配: 标题或完整 sessionId
     const exactMatches = candidates.filter((candidate) => (
       normalizeSessionLookupText(candidate.title) === query
       || normalizeSessionLookupText(candidate.sessionId) === query
     ));
-    const matches = exactMatches.length > 0
+
+    // 前缀匹配: sessionId 前 12 位
+    const prefixMatches = exactMatches.length > 0
       ? exactMatches
-      : candidates.filter((candidate) => normalizeSessionLookupText(candidate.title).includes(query));
+      : candidates.filter((candidate) => {
+        const shortId = candidate.sessionId.slice(0, SHORT_ID_LENGTH).toLowerCase();
+        return shortId.startsWith(query) || normalizeSessionLookupText(candidate.title).includes(query);
+      });
+
+    const matches = exactMatches.length > 0 ? exactMatches : prefixMatches;
 
     if (matches.length === 0) {
-      await this.context.sendMarkdown(message.chatId, "未找到匹配的会话，请发送 `/sessions all` 查看完整列表。", message.messageId);
+      await this.context.sendMarkdown(message.chatId, "未找到匹配的会话，请发送 `/sessions` 查看列表。", message.messageId);
       return;
     }
 
@@ -790,15 +866,15 @@ export class CommandHandler {
           index: option.index,
           title: option.title,
           current: Boolean(option.current),
-          archived: !option.inWindow,
-          meta: option.current ? "当前" : option.inWindow ? "窗口中" : "已隐藏",
+          meta: option.current ? "当前" : "窗口中",
+          shortId: option.sessionId.slice(0, SHORT_ID_LENGTH),
         })),
         footer: "匹配到多个会话 · 发送 `/switch <编号>` 切换 · 3 分钟内有效",
       }), { event: "final message sent", transcriptType: "outbound-final", textPreview: "匹配会话", len: 4 }, { replyToMessageId: message.messageId });
       return;
     }
 
-    await this.switchToSession(message, window, matches[0] as SessionSelectionOption, { clearPending: false, openCodeSessions });
+    await this.switchToSession(message, window, matches[0] as SessionSelectionOption, { clearPending: false });
   }
 
   private async resolveDeleteSessionById(

--- a/src/runtime/external-extension-adapter.ts
+++ b/src/runtime/external-extension-adapter.ts
@@ -136,7 +136,9 @@ function toIncomingMessageView(message: IncomingChatMessage): ExtensionIncomingM
     threadKey: message.threadKey,
     conversationKey: message.conversationKey,
     messageType: message.messageType,
-    ...(message.messageType === "file" ? { file: { ...message.file } } : {}),
+    ...(message.messageType === "file" || message.messageType === "image"
+      ? { file: { ...message.file }, resourceType: message.resourceType }
+      : {}),
   };
 }
 

--- a/src/runtime/permission-manager.ts
+++ b/src/runtime/permission-manager.ts
@@ -45,13 +45,38 @@ export class PermissionManager {
     private readonly opencode: OpenCodePermissionPort,
     private readonly logger: Logger,
     private readonly callbacks: PermissionManagerCallbacks,
+    private readonly defaultPolicy: "ask" | "allow" | "deny" = "ask",
   ) {}
 
   // #region 对外入口
 
-  /** 注册一条新的权限请求。 */
-  registerInteraction(interaction: PendingPermissionInteraction): void {
+  /** 注册一条新的权限请求。若 defaultPolicy 自动决策成功则返回 true。 */
+  async registerInteraction(interaction: PendingPermissionInteraction): Promise<boolean> {
+    // 如果 defaultPolicy 不是 ask，尝试自动决策
+    if (this.defaultPolicy !== "ask" && this.isReadOnlyPermission(interaction.permissionName)) {
+      const resolution = this.defaultPolicy === "allow" ? "once" : "deny";
+      this.logger.log("bridge/permission", "auto decision by defaultPolicy", {
+        permissionId: interaction.permissionId,
+        permissionName: interaction.permissionName,
+        defaultPolicy: this.defaultPolicy,
+        resolution,
+      }, "warn");
+      try {
+        await this.resolveInteraction(interaction, resolution);
+        return true;
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        this.logger.log("bridge/permission", "auto decision failed, falling back to manual approval", {
+          permissionId: interaction.permissionId,
+          detail,
+        }, "warn");
+        // 自动决策失败，注册 pending 让人工审批卡兜底
+        this.interactions.set(interaction.permissionVersion, interaction);
+        return false;
+      }
+    }
     this.interactions.set(interaction.permissionVersion, interaction);
+    return false;
   }
 
   /** 处理来自飞书卡片的权限审批动作。 */
@@ -260,6 +285,19 @@ export class PermissionManager {
       messageIconToken: iconToken,
       messageIconColor: template,
     });
+  }
+
+  /** 判断权限是否为只读类（可被 defaultPolicy=allow 自动放行）。 */
+  private isReadOnlyPermission(permissionName: string): boolean {
+    // 明确拒绝的危险权限
+    const deniedPermissions = ["bash", "edit", "write", "delete", "remove", "execute", "run", "install", "uninstall"];
+    const normalizedName = permissionName.toLowerCase().trim();
+    if (deniedPermissions.some((p) => normalizedName === p || normalizedName.endsWith(`.${p}`))) {
+      return false;
+    }
+    // 明确允许的只读权限（包括 OpenCode 常见权限）
+    const allowedPermissions = ["external_directory", "read", "list", "get", "search", "query", "find", "view", "show", "export"];
+    return allowedPermissions.some((p) => normalizedName === p || normalizedName.startsWith(`${p}.`) || normalizedName.startsWith(`${p}_`) || normalizedName.includes(`.${p}`));
   }
 
   // #endregion

--- a/src/runtime/turn-executor.ts
+++ b/src/runtime/turn-executor.ts
@@ -157,7 +157,7 @@ export type TurnExecutorContext = {
     cleanup(turnId: string): void;
   };
   permissionManager: {
-    registerInteraction(interaction: PendingPermissionInteraction): void;
+    registerInteraction(interaction: PendingPermissionInteraction): Promise<boolean>;
     buildActionButtons(interaction: PendingPermissionInteraction): Array<{
       label: string;
       type: "default" | "primary" | "danger";
@@ -624,7 +624,16 @@ export class TurnExecutor {
       turnId: turn.turnId,
       expiresAt: Date.now() + PERMISSION_TTL_MS,
     };
-    this.context.permissionManager.registerInteraction(interaction);
+    const autoDecided = await this.context.permissionManager.registerInteraction(interaction);
+    if (autoDecided) {
+      runtime.snoozeWatchdog(PERMISSION_TTL_MS + 5_000);
+      await this.context.turnCardManager.updateTurnCard(turn.turnId, {
+        status: "处理中",
+        update: `权限 \`${escapeMarkdownText(permissionName)}\` 已由策略自动处理`,
+        target: "step",
+      });
+      return;
+    }
     this.context.setPendingInteraction(turn.conversationKey, interaction);
     runtime.snoozeWatchdog(PERMISSION_TTL_MS + 5_000);
     await this.context.turnCardManager.updateTurnCard(turn.turnId, {

--- a/src/workflows/evidence-extract.ts
+++ b/src/workflows/evidence-extract.ts
@@ -27,7 +27,7 @@ export type EvidenceFileRef = {
 };
 
 export type EvidenceExtractResourcePort = {
-  downloadMessageResource(messageId: string, fileKey: string, type: "file"): Promise<{
+  downloadMessageResource(messageId: string, fileKey: string, type: "file" | "image"): Promise<{
     fileName: string;
     mimeType: string;
     buffer: Buffer;

--- a/test/app-command-surface.test.ts
+++ b/test/app-command-surface.test.ts
@@ -178,6 +178,7 @@ describe("BridgeApp command surface", () => {
       activeSessionId: "ses_1",
       sessions: [
         { sessionId: "ses_1", label: "劳动争议分析", createdAt: 1, lastUsedAt: 3 },
+        { sessionId: "ses_2", label: "劳动合同审查", createdAt: 1, lastUsedAt: 2 },
       ],
     };
 

--- a/test/group-chat.test.ts
+++ b/test/group-chat.test.ts
@@ -20,6 +20,7 @@ vi.mock("@larksuiteoapi/node-sdk", () => {
 });
 
 import { FeishuWsClient, buildConversationKey, computeThreadKey, createFeishuIngressOptions, normalizeIncomingMessage } from "../src/feishu/ws.js";
+import type { IncomingChatMessage } from "../src/runtime/app.js";
 import { toOpencodePromptText } from "../src/runtime/app-helpers.js";
 import type { ChatWhitelist } from "../src/store/whitelist.js";
 
@@ -877,5 +878,44 @@ describe("group chat support", () => {
       senderOpenId: "ou_123",
     }));
     expect(lastCall?.[3]).toBe("warn");
+  });
+
+  it("accepts image messages and parses image_key as file payload", async () => {
+    const handler = vi.fn(async (message: IncomingChatMessage) => {
+      void message;
+    });
+    const logger = { log: vi.fn() };
+    const client = new FeishuWsClient(
+      "app",
+      "secret",
+      makeOptions({ enableP2p: true }),
+      createWhitelist(),
+      handler,
+      logger,
+    );
+
+    await (client as unknown as { handleEvent(payload: unknown): Promise<void> }).handleEvent({
+      message: {
+        chat_id: "oc_p2p_img_1",
+        chat_type: "p2p",
+        message_id: "om_img_1",
+        message_type: "image",
+        content: JSON.stringify({ image_key: "img_v3_abc123" }),
+      },
+      sender: { sender_id: { open_id: "ou_123" } },
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const passedMessage = handler.mock.calls[0]?.[0] as IncomingChatMessage;
+    expect(passedMessage.messageType).toBe("image");
+    if (passedMessage.messageType !== "image") {
+      throw new Error("expected image message");
+    }
+    expect(passedMessage.file).toEqual(expect.objectContaining({
+      fileKey: "img_v3_abc123",
+      fileName: "img_v3_abc123.png",
+    }));
+    expect(passedMessage.resourceType).toBe("image");
+    expect(passedMessage.plainText).toBe("[图片]");
   });
 });

--- a/test/knowledge-flow.test.ts
+++ b/test/knowledge-flow.test.ts
@@ -204,7 +204,7 @@ describe("knowledge base bridge flow", () => {
     const replyPayloads = (outbound.replyMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
     const updatePayloads = (outbound.updateMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
     expect(JSON.stringify(replyPayloads)).toContain("已收到文件");
-    expect(JSON.stringify(replyPayloads)).toContain("把这个文件入库");
+    expect(JSON.stringify(replyPayloads)).toContain("/help-file");
     expect(outbound.downloadMessageResource).toHaveBeenCalledWith("om_file_plain", "file_plain", "file");
     const request = promptAsync.mock.calls[0]?.[1];
     expect(request).toBeDefined();

--- a/test/turn-executor.test.ts
+++ b/test/turn-executor.test.ts
@@ -281,7 +281,7 @@ function createContext(): TurnExecutorContext {
       cleanup() {},
     },
     permissionManager: {
-      registerInteraction() {},
+      async registerInteraction() { return false; },
       buildActionButtons() { return []; },
     },
     moduleManager: {


### PR DESCRIPTION
## 变更内容
- 支持飞书 image 消息进入文件处理链路，并按 image 类型下载消息资源。
- 扩展 extension-api / knowledge / evidence 资源端口类型，允许 downloadMessageResource 传入 file 或 image。
- 增加 permissions.defaultPolicy 配置，支持只读权限按 ask / allow / deny 策略处理。
- 补充 /help-file 文件处理提示，并恢复会话短 ID 展示与切换匹配。

## 变更原因
图片消息和普通文件在飞书下载资源时需要不同 type 参数；同时权限默认策略和文件帮助提示可以减少常见交互阻塞。

## 影响
extension-api 的 downloadMessageResource 新增 "image" 类型支持，旧 "file" 调用保持兼容。

本次变更触及 router、runtime app、turn executor 等 seam 文件；check:docs-diff 已给出提醒，本轮属于既有运行时边界内的行为扩展，未扩大核心架构契约。

## 验证
- `npm run typecheck`
- `npm run lint`
- `npm run lint:deps`
- `npm run check:formatter-exports`
- `npm run check:docs-diff`（仅 seam 提醒，无失败）
- `npm test`
- `npm run build`