### PR TITLE
[codex] 支持司法文书类案入库

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -156,7 +156,13 @@
         "sessionIdleMs": 1800000,
         "concurrency": 3,
         "maxExtractChunks": 30,
-        "maxExtractQas": 500
+        "maxExtractQas": 0
+      },
+      "judicialIngest": {
+        "enabled": true,
+        "batchEnabled": false,
+        "sources": ["manual"],
+        "batchSize": 20
       },
       "parser": {
         "externalApiEnabled": false,

--- a/docs/backlog/judicial-document-ingest.md
+++ b/docs/backlog/judicial-document-ingest.md
@@ -93,6 +93,23 @@ type CaseDigestEntry = {
 - **caseNumber 是去重 key**：同一争议在同一案号下只能有一条
 - **statutes.valid 字段**：与现行法条对照后标注，便于检索时降权过期判决
 
+### 3.1 V1 落库映射
+
+V1 不新增独立 case 表，复用现有 `knowledge_entries`：
+
+| case_digest 字段 | knowledge_entries 映射 |
+|---|---|
+| `type` | `entry_type = "case_digest"` |
+| `issue` | `question` |
+| `rule + outcome + reasoning` | `answer` |
+| `cause + issue tags` | `tags_json` |
+| `statutes[]` | `statute` 合并文本 |
+| `caseNumber + issueHash` | `dedup_key = case_digest:{caseNumber}:{issueHash}` |
+| 司法文书专属字段 | `fields_json` |
+| 原文件名 / 飞书来源 | `source_file`，不得替换成案号 |
+
+写入前先查 `dedup_key`；命中则跳过，避免同案同争议焦点重复堆积。
+
 ---
 
 ## 4. 提取管线（6 步）
@@ -111,6 +128,18 @@ type CaseDigestEntry = {
 [校验通过的条目]
   ↓ ⑥ 入库（embedding + bitable + sqlite）
 ```
+
+实际接入顺序：
+
+```
+parseKnowledgeFile()
+  ↓
+detectJudicialDocument()
+  ├─ 命中：case_digest extractor
+  └─ 未命中：现有结构化 QA / 通用 extractQa 流程
+```
+
+司法文书 detector 必须在通用 QA 抽取前执行，否则判决书仍会被当成说明性材料而抽取 0 条。
 
 ### 4.1 步骤 ② 结构化分段
 
@@ -191,11 +220,12 @@ type CaseDigestEntry = {
 
 - `case_digest` 与 `article` 共用同一张 KB 表，通过 `type` 字段区分
 - embedding 用 `issue + rule + reasoning 前 100 字` 拼接（避免长文本稀释向量）
-- bitable 同步：在多维表格的「源文件」字段填 `caseNumber`，便于人工核查
+- bitable 同步：多维表格「源文件」字段继续保留真实文件名或来源链接，案号写入 `fields_json.caseNumber`
 
 ### 5.2 检索
 
 - 默认情况下 `case_digest` 与 `article` 一起返回，但**视觉上必须区隔**
+- 法律问答卡片中，普通知识 / 法条结果进入“答案”区；`case_digest` 进入“类案参考”区，不作为同级法律依据
 - 案件工作台分析时，按争议焦点**主动检索类案**：
   ```
   for each issue in 争议焦点:
@@ -217,6 +247,8 @@ type CaseDigestEntry = {
 | `statutes[].valid` | 任一为 false | 标注「⚠️ 引用法条已修订」+ 附现行版本对照 |
 | `consensusLevel` | low | 标注「裁判口径不一」+ 附其他法院相反观点示例 |
 | `weight` | reference | 排序降权 |
+
+V1 沿用现有 `effective_status` 字段，取值先使用 `current / unknown / expired`。自动识别一案多审级改判不在 V1 范围内，无法确认时统一写 `unknown`。
 
 ### 6.2 一案多审级关联
 
@@ -273,7 +305,16 @@ P0 提取管线上线前必须达到：
 - **复用** `src/knowledge/` 的 ingest 管线、embedding、bitable 同步——不改框架
 - **新增** `src/knowledge/extractors/case-digest.ts`：判决书专用抽取器
 - **复用** 已接入的 pkulaw（`config.extensions.knowledge-base.authoritySources.pkulaw`）做法条有效性校验和 R3 数据来源
-- **配置位**：`config.extensions.knowledge-base.judicialIngest.{enabled, sources, batchSize}`，默认关闭
+- **配置位**：配置可写在 `extensions["knowledge-base"].judicialIngest`，运行时归一化为 `knowledgeBase.judicialIngest`
+- **默认行为**：手动知识入库遇到明确司法文书会自动走 detector；批量外部来源入库默认关闭
+
+### 10.1 V1 非目标
+
+- 不做裁判文书网爬虫
+- 不做 pkulaw 批量抓取
+- 不做一案多审级自动关联
+- 不做类案采纳率统计
+- 不做案件工作台主动类案 UI 改造
 
 ---
 

--- a/src/feishu/knowledge-cards.ts
+++ b/src/feishu/knowledge-cards.ts
@@ -61,7 +61,18 @@ export type KnowledgeIngestCompletedCardView = {
 /** 构建知识查询命中结果卡。 */
 export function buildKnowledgeQueryPayload(view: KnowledgeQueryResult): FeishuPostPayload {
   const results = view.results.slice(0, Math.max(1, view.results.length));
+  const answerResults = results.filter((result) => result.entryType !== "case_digest");
+  const caseResults = results.filter((result) => result.entryType === "case_digest");
   const tags = uniqueKnowledgeTags(results).slice(0, 2);
+  const bodyElements: Record<string, unknown>[] = [
+    questionBlock(view.question),
+    { tag: "hr", margin: "0px 0px 0px 0px" },
+    ...answerResults.flatMap((result, index) => answerBlock(result, index, index < answerResults.length - 1 || caseResults.length > 0)),
+  ];
+  if (caseResults.length > 0) {
+    bodyElements.push(sectionTitle("类案参考"));
+    bodyElements.push(...caseResults.flatMap((result, index) => caseDigestBlock(result, index, index < caseResults.length - 1)));
+  }
   const card = {
     schema: "2.0",
     config: {
@@ -82,11 +93,7 @@ export function buildKnowledgeQueryPayload(view: KnowledgeQueryResult): FeishuPo
       vertical_spacing: "8px",
       horizontal_align: "left",
       vertical_align: "top",
-      elements: [
-        questionBlock(view.question),
-        { tag: "hr", margin: "0px 0px 0px 0px" },
-        ...results.flatMap((result, index) => answerBlock(result, index, index < results.length - 1)),
-      ],
+      elements: bodyElements,
     },
     header: {
       title: {
@@ -102,10 +109,20 @@ export function buildKnowledgeQueryPayload(view: KnowledgeQueryResult): FeishuPo
           tag: "text_tag",
           text: {
             tag: "plain_text",
-            content: `${results.length} 条答案`,
+            content: `${answerResults.length} 条答案`,
           },
           color: "purple",
         },
+        ...(caseResults.length > 0
+          ? [{
+            tag: "text_tag",
+            text: {
+              tag: "plain_text",
+              content: `${caseResults.length} 条类案`,
+            },
+            color: "blue",
+          }]
+          : []),
         ...tags.map((tag) => ({
           tag: "text_tag",
           text: {
@@ -411,6 +428,58 @@ function answerBlock(result: KnowledgeQueryAnswer, index: number, withDivider: b
   ];
 }
 
+function caseDigestBlock(result: KnowledgeQueryAnswer, index: number, withDivider: boolean): Record<string, unknown>[] {
+  const meta = parseCaseDigestMeta(result.fieldsJson);
+  const title = [
+    meta.caseNumber,
+    meta.court,
+    meta.judgmentDate,
+  ].filter(Boolean).join(" · ") || result.sourceFile;
+  const sourceText = [result.sourceFile, result.pageSection].filter(Boolean).join(" · ") || "知识库记录";
+  const source = result.sourceUrl ? markdownLink(sourceText, result.sourceUrl) : sourceText;
+  const statutes = result.statute
+    ? result.statuteUrl ? markdownLink(result.statute, result.statuteUrl) : result.statute
+    : "未标注";
+  return [{
+    tag: "column_set",
+    flex_mode: "stretch",
+    horizontal_spacing: "12px",
+    horizontal_align: "left",
+    columns: [{
+      tag: "column",
+      width: "weighted",
+      elements: [
+        caseDigestLabel(index),
+        {
+          tag: "markdown",
+          content: [
+            `**${title}**`,
+            meta.issue ? `争议焦点：${meta.issue}` : "",
+            meta.rule ? `裁判规则：${meta.rule}` : formatAnswerParagraphs(result.answer),
+            meta.outcome ? `裁判结果：${meta.outcome}` : "",
+            "> 类案参考：仅供说理思路参考，非法律依据。",
+            `> 来源：${source}`,
+            `> 法条：${statutes}`,
+          ].filter(Boolean).join("\n\n"),
+          text_align: "left",
+          text_size: "normal_v2",
+          margin: "8px 0px 8px 0px",
+        },
+        ...(withDivider ? [{ tag: "hr", margin: "0px 0px 0px 0px" }] : []),
+      ],
+      padding: "0px 0px 0px 0px",
+      direction: "vertical",
+      horizontal_spacing: "8px",
+      vertical_spacing: "4px",
+      horizontal_align: "left",
+      vertical_align: "top",
+      margin: "0px 0px 0px 0px",
+      weight: 1,
+    }],
+    margin: "4px 0px 0px 0px",
+  }];
+}
+
 function answerLabel(index: number): Record<string, unknown> {
   return {
     tag: "column_set",
@@ -437,6 +506,60 @@ function answerLabel(index: number): Record<string, unknown> {
     }],
     margin: "0px 0px 0px 0px",
   };
+}
+
+function caseDigestLabel(index: number): Record<string, unknown> {
+  return {
+    tag: "column_set",
+    horizontal_spacing: "8px",
+    horizontal_align: "left",
+    columns: [{
+      tag: "column",
+      width: "auto",
+      background_style: "grey-50",
+      elements: [{
+        tag: "markdown",
+        content: `类案 ${index + 1}`,
+        text_align: "left",
+        text_size: "notation",
+        margin: "0px 0px 0px 0px",
+      }],
+      padding: "4px 8px 4px 8px",
+      direction: "vertical",
+      horizontal_spacing: "8px",
+      vertical_spacing: "8px",
+      horizontal_align: "left",
+      vertical_align: "top",
+      margin: "0px 0px 0px 0px",
+    }],
+    margin: "0px 0px 0px 0px",
+  };
+}
+
+function parseCaseDigestMeta(fieldsJson: string | undefined): {
+  caseNumber?: string | undefined;
+  court?: string | undefined;
+  judgmentDate?: string | undefined;
+  issue?: string | undefined;
+  rule?: string | undefined;
+  outcome?: string | undefined;
+} {
+  if (!fieldsJson) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(fieldsJson) as Record<string, unknown>;
+    return {
+      caseNumber: typeof parsed.caseNumber === "string" ? parsed.caseNumber : undefined,
+      court: typeof parsed.court === "string" ? parsed.court : undefined,
+      judgmentDate: typeof parsed.judgmentDate === "string" ? parsed.judgmentDate : undefined,
+      issue: typeof parsed.issue === "string" ? parsed.issue : undefined,
+      rule: typeof parsed.rule === "string" ? parsed.rule : undefined,
+      outcome: typeof parsed.outcome === "string" ? parsed.outcome : undefined,
+    };
+  } catch {
+    return {};
+  }
 }
 
 function formatKnowledgeReference(result: KnowledgeQueryAnswer): string {

--- a/src/feishu/runtime-cards.ts
+++ b/src/feishu/runtime-cards.ts
@@ -5,7 +5,7 @@
  * - 为桥接层的过程消息与系统通知提供一致的 UI 结构。
  */
 import { column, columnSet, markdown, standardIcon } from "./card-builder.js";
-import { buildDesignerCardPayload, setDesignerButtonValue } from "./designer-card-renderer.js";
+import { buildDesignerCardPayload, cloneDesignerCard, setDesignerButtonValue, type DesignerCard } from "./designer-card-renderer.js";
 import {
   buildDivider,
   buildFooterTipBlock,
@@ -160,9 +160,6 @@ export function buildStatusCommandCardPayload(view: StatusCommandCardView): Feis
 
 /** 构建 `/cost` 成本摘要卡。 */
 export function buildCostCommandCardPayload(view: CostCommandCardView): FeishuPostPayload {
-  const todayCost = view.todayCostCny === undefined ? "未配置价格" : `≈¥${view.todayCostCny.toFixed(4)}`;
-  const monthCost = view.monthCostCny === undefined ? "未配置价格" : `≈¥${view.monthCostCny.toFixed(4)}`;
-
   return buildInteractivePayload({
     title: "AI 成本摘要",
     template: "orange",
@@ -170,19 +167,15 @@ export function buildCostCommandCardPayload(view: CostCommandCardView): FeishuPo
     bodyElements: [
       columnSet([
         column([
-          markdown(`**今日**\n${view.todayTokens} tokens\n${todayCost}`, { icon: { token: "calendar_outlined", color: "orange" } }),
+          markdown(`**今日**\n${view.todayTokens} tokens`, { icon: { token: "calendar_outlined", color: "orange" } }),
         ], { bg: "orange-50", weight: 1 }),
         column([
-          markdown(`**本月**\n${view.monthTokens} tokens\n${monthCost}`, { icon: { token: "insert-chart_outlined", color: "blue" } }),
+          markdown(`**本月**\n${view.monthTokens} tokens`, { icon: { token: "insert-chart_outlined", color: "blue" } }),
         ], { bg: "wathet-50", weight: 1 }),
       ]),
       buildDivider(),
       buildCostLimitBlock(view),
-      buildDivider(),
-      buildRuntimeActionBlock([
-        runtimeCommandButton("查看完整账单", "/cost detail", "default", "send-message"),
-      ]),
-      buildFooterTipBlock("金额是本地估算，provider 账单以服务商为准。终端运行 `bridge cost` 查看更多。", "info-hollow_filled", "grey", "notation"),
+      buildFooterTipBlock("本页只展示本地 token 记录。终端运行 `bridge cost` 查看更多。", "info-hollow_filled", "grey", "notation"),
     ],
   });
 }
@@ -250,15 +243,9 @@ function buildSessionReviewBlock(review: NonNullable<SessionTransitionCardView["
 
 /** 构建模型列表卡。 */
 export function buildModelListCardPayload(view: ModelListCardView): FeishuPostPayload {
-  const firstProvider = view.providers[0];
-  const secondProvider = view.providers[1];
-  return buildDesignerCardPayload("可用模型", [
-    { from: "OpenAI", to: firstProvider?.name ?? "OpenAI" },
-    { from: "gpt-5.4", to: firstProvider?.models[0]?.id ?? view.currentModelLabel },
-    { from: "OpenCode Zen", to: secondProvider?.name ?? "OpenCode Zen" },
-    { from: "MiniMax-M2.7", to: secondProvider?.models[0]?.id ?? "MiniMax-M2.7" },
-    { from: "发送 `/model use <provider>/model` 切换模型。", to: view.footer },
-  ]);
+  return buildDesignerCardPayload("可用模型", [], (card) => {
+    applyModelListTemplateData(card, view);
+  });
 }
 
 /** 构建权限请求卡。 */
@@ -270,6 +257,157 @@ export function buildPermissionRequestCardPayload(view: PermissionRequestCardVie
       setDesignerButtonValue(card, resolvePermissionDesignerButtonLabel(button.label), button.value);
     }
   });
+}
+
+function applyModelListTemplateData(card: DesignerCard, view: ModelListCardView): void {
+  const header = getRuntimeDesignerRecord(card.header);
+  const subtitle = getRuntimeDesignerRecord(header?.subtitle);
+  if (subtitle) {
+    subtitle.content = `当前：${view.currentModelLabel}`;
+  }
+
+  const body = getRuntimeDesignerRecord(card.body);
+  const elements = Array.isArray(body?.elements) ? body.elements : [];
+  const providerRows = elements.filter((element) => isProviderModelRow(element));
+  const footer = elements.find((element) => getRuntimeDesignerRecord(element)?.tag === "markdown"
+    && typeof getRuntimeDesignerRecord(element)?.content === "string"
+    && (getRuntimeDesignerRecord(element)?.content as string).includes("/model use"));
+
+  const templateRow = providerRows[0] ? cloneDesignerCard(providerRows[0]) : null;
+  while (providerRows.length < view.providers.length && templateRow) {
+    const cloned = cloneDesignerCard(templateRow);
+    const insertAt = footer ? elements.indexOf(footer) : elements.length;
+    elements.splice(insertAt, 0, cloned);
+    providerRows.push(cloned);
+  }
+
+  providerRows.forEach((row, index) => {
+    const provider = view.providers[index];
+    if (!provider) {
+      const rowIndex = elements.indexOf(row);
+      if (rowIndex >= 0) elements.splice(rowIndex, 1);
+      return;
+    }
+    applyProviderModelRow(row, provider);
+  });
+
+  const footerRecord = getRuntimeDesignerRecord(footer);
+  if (footerRecord && typeof footerRecord.content === "string") {
+    footerRecord.content = view.footer;
+  }
+}
+
+function applyProviderModelRow(row: unknown, provider: ModelListCardView["providers"][number]): void {
+  const title = findFirstRuntimeMarkdown(row, (content) => /^(\*\*)?.+模型/.test(content));
+  if (title) {
+    title.content = `**${escapeText(provider.name)} 模型**`;
+  }
+
+  const modelColumnSet = findModelChipColumnSet(row);
+  if (modelColumnSet) {
+    const templateColumn = Array.isArray(modelColumnSet.columns) && modelColumnSet.columns[0]
+      ? cloneDesignerCard(modelColumnSet.columns[0])
+      : null;
+    modelColumnSet.columns = provider.models.length > 0 && templateColumn
+      ? provider.models.slice(0, 5).map((model) => buildModelChipColumn(templateColumn, model.id, Boolean(model.current)))
+      : [buildModelEmptyColumn(templateColumn)];
+  }
+
+  const example = findFirstRuntimeMarkdown(row, (content) => content.includes("切换示例"));
+  if (example) {
+    const sample = provider.models[0]?.id;
+    example.content = sample ? `>切换示例：${escapeText(sample)}` : ">暂无可切换模型";
+  }
+}
+
+function buildModelChipColumn(templateColumn: DesignerCard, label: string, current: boolean): DesignerCard {
+  const column = cloneDesignerCard(templateColumn);
+  column.background_style = current ? "blue-50" : "grey-50";
+  const markdownNode = findFirstRuntimeMarkdown(column);
+  if (markdownNode) {
+    markdownNode.content = escapeText(label);
+  }
+  return column;
+}
+
+function buildModelEmptyColumn(templateColumn: DesignerCard | null): DesignerCard {
+  const column = templateColumn ? cloneDesignerCard(templateColumn) : {
+    tag: "column",
+    width: "auto",
+    background_style: "grey-50",
+    elements: [{ tag: "markdown", content: "暂无模型", text_align: "left", text_size: "normal" }],
+    padding: "4px 8px 4px 8px",
+  };
+  const markdownNode = findFirstRuntimeMarkdown(column);
+  if (markdownNode) {
+    markdownNode.content = "暂无模型";
+  }
+  return column;
+}
+
+function isProviderModelRow(input: unknown): boolean {
+  const record = getRuntimeDesignerRecord(input);
+  if (!record || record.tag !== "column_set") {
+    return false;
+  }
+  return Boolean(findFirstRuntimeMarkdown(record, (content) => content.includes("模型"))
+    && findFirstRuntimeMarkdown(record, (content) => content.includes("切换示例")));
+}
+
+function findModelChipColumnSet(input: unknown): Record<string, unknown> | null {
+  if (Array.isArray(input)) {
+    for (const item of input) {
+      const found = findModelChipColumnSet(item);
+      if (found) return found;
+    }
+    return null;
+  }
+  const record = getRuntimeDesignerRecord(input);
+  if (!record) {
+    return null;
+  }
+  if (record.tag === "column_set"
+    && record.flex_mode === "stretch"
+    && Array.isArray(record.columns)
+    && record.columns.some((column) => Boolean(findFirstRuntimeMarkdown(column, (content) => !content.includes("模型") && !content.includes("切换示例"))))) {
+    return record;
+  }
+  for (const value of Object.values(record)) {
+    const found = findModelChipColumnSet(value);
+    if (found) return found;
+  }
+  return null;
+}
+
+function findFirstRuntimeMarkdown(
+  input: unknown,
+  predicate: (content: string) => boolean = () => true,
+): Record<string, unknown> | null {
+  if (Array.isArray(input)) {
+    for (const item of input) {
+      const found = findFirstRuntimeMarkdown(item, predicate);
+      if (found) return found;
+    }
+    return null;
+  }
+  const record = getRuntimeDesignerRecord(input);
+  if (!record) {
+    return null;
+  }
+  if (record.tag === "markdown" && typeof record.content === "string" && predicate(record.content)) {
+    return record;
+  }
+  for (const value of Object.values(record)) {
+    const found = findFirstRuntimeMarkdown(value, predicate);
+    if (found) return found;
+  }
+  return null;
+}
+
+function getRuntimeDesignerRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
 }
 
 function resolvePermissionDesignerButtonLabel(label: string): string {
@@ -528,27 +666,29 @@ function buildCostTableHeader(): Record<string, unknown> {
     ...columnSet([
       column([markdown("模型", { size: "notation" })], { bg: "grey-100", weight: 2 }),
       column([markdown("Tokens", { size: "notation" })], { bg: "grey-100", weight: 1 }),
-      column([markdown("费用", { size: "notation" })], { bg: "grey-100", weight: 1 }),
-      column([markdown("来源", { size: "notation" })], { bg: "grey-100", weight: 1 }),
     ]),
     flex_mode: "stretch",
   };
 }
 
 function buildCostTableRow(entry: CostCommandCardView["recent"][number]): Record<string, unknown> {
-  const cost = entry.estimatedCostCny === undefined ? "未配置" : `¥${entry.estimatedCostCny.toFixed(4)}`;
-  const source = entry.source === "external-call"
-    ? `${entry.tool ?? entry.model}/${entry.operation ?? "call"}`
-    : (entry.source === "provider" ? "provider" : "估算");
   return {
     ...columnSet([
-      column([markdown(`${escapeText(entry.provider)}/${escapeText(entry.model)}`, { size: "notation" })], { bg: "bg-white", weight: 2 }),
+      column([markdown(formatCostModelLabel(entry), { size: "notation" })], { bg: "bg-white", weight: 2 }),
       column([markdown(String(entry.totalTokens), { size: "notation" })], { bg: "bg-white", weight: 1 }),
-      column([markdown(cost, { size: "notation" })], { bg: "bg-white", weight: 1 }),
-      column([markdown(escapeText(source), { size: "notation" })], { bg: "bg-white", weight: 1 }),
     ]),
     flex_mode: "stretch",
   };
+}
+
+function formatCostModelLabel(entry: CostCommandCardView["recent"][number]): string {
+  if (entry.source === "external-call") {
+    return escapeText(`${entry.provider}/${entry.tool ?? entry.model}`);
+  }
+  if (entry.provider === "opencode-default" && entry.model === "default") {
+    return "OpenCode 默认模型";
+  }
+  return `${escapeText(entry.provider)}/${escapeText(entry.model)}`;
 }
 
 function buildStatusChip(text: string, backgroundStyle: string): Record<string, unknown> {

--- a/src/knowledge/config.ts
+++ b/src/knowledge/config.ts
@@ -64,7 +64,14 @@ const KnowledgeBaseIngestSchema = z.object({
   sessionIdleMs: z.number().int().positive().default(1_800_000),
   concurrency: z.number().int().positive().max(10).default(3),
   maxExtractChunks: z.number().int().positive().default(30),
-  maxExtractQas: z.number().int().positive().default(500),
+  maxExtractQas: z.number().int().min(0).default(500),
+}).default({});
+
+const KnowledgeBaseJudicialIngestSchema = z.object({
+  enabled: z.boolean().default(true),
+  batchEnabled: z.boolean().default(false),
+  sources: z.array(z.enum(["manual", "pkulaw", "court-publication"])).default(["manual"]),
+  batchSize: z.number().int().positive().default(20),
 }).default({});
 
 const DocumentParserProviderSchema = z.enum(["mineru-agent", "paddleocr-vl", "paddleocr-vl-aistudio", "pymupdf4llm", "docling", "pdf-parse", "tesseract"]);
@@ -173,6 +180,7 @@ const KnowledgeBaseConfigSchema = z.object({
   embeddingProvider: EmbeddingProviderSchema.optional(),
   models: KnowledgeBaseModelsSchema,
   ingest: KnowledgeBaseIngestSchema,
+  judicialIngest: KnowledgeBaseJudicialIngestSchema,
   parser: KnowledgeBaseParserSchema,
   obsidian: KnowledgeBaseObsidianSchema,
   authoritySources: KnowledgeBaseAuthoritySourcesSchema,
@@ -238,6 +246,12 @@ export type KnowledgeBaseConfig = {
     maxExtractChunks: number;
     maxExtractQas: number;
   };
+  judicialIngest?: {
+    enabled: boolean;
+    batchEnabled: boolean;
+    sources: Array<"manual" | "pkulaw" | "court-publication">;
+    batchSize: number;
+  } | undefined;
   parser?: {
     externalApiEnabled: boolean;
     pdfProviderOrder: Array<"mineru-agent" | "paddleocr-vl" | "paddleocr-vl-aistudio" | "pymupdf4llm" | "docling" | "pdf-parse" | "tesseract">;
@@ -416,6 +430,12 @@ function normalizeKnowledgeBaseConfig(
       concurrency: parsed.ingest.concurrency,
       maxExtractChunks: parsed.ingest.maxExtractChunks,
       maxExtractQas: parsed.ingest.maxExtractQas,
+    },
+    judicialIngest: {
+      enabled: parsed.judicialIngest.enabled,
+      batchEnabled: parsed.judicialIngest.batchEnabled,
+      sources: parsed.judicialIngest.sources,
+      batchSize: parsed.judicialIngest.batchSize,
     },
     parser: {
       externalApiEnabled: parsed.parser.externalApiEnabled,

--- a/src/knowledge/db.ts
+++ b/src/knowledge/db.ts
@@ -25,6 +25,7 @@ export type KnowledgeDocumentRecord = {
   checksum: string;
   status: string;
   bitableRecordId?: string | undefined;
+  obsidianPath?: string | undefined;
   createdAt: number;
 };
 
@@ -106,6 +107,7 @@ type KnowledgeDocumentRow = {
   checksum: string;
   status: string;
   bitable_record_id: string | null;
+  obsidian_path: string | null;
   created_at: number;
 };
 
@@ -189,6 +191,7 @@ export class KnowledgeDb {
         checksum,
         status,
         bitable_record_id AS bitableRecordId,
+        obsidian_path AS obsidianPath,
         created_at AS createdAt
       FROM knowledge_documents
       WHERE checksum = @checksum
@@ -337,6 +340,15 @@ export class KnowledgeDb {
     `).run({ id, status });
   }
 
+  /** 记录知识库文档导出的 Obsidian 笔记路径，便于远端删除后同步清理。 */
+  updateDocumentObsidianPath(id: number, obsidianPath: string): void {
+    this.db.prepare(`
+      UPDATE knowledge_documents
+      SET obsidian_path = @obsidianPath
+      WHERE id = @id
+    `).run({ id, obsidianPath });
+  }
+
   // List all mirrored Bitable record ids that already exist in the local entry table.
   listEntryBitableRecordIds(): string[] {
     const rows = this.db.prepare(`
@@ -360,6 +372,74 @@ export class KnowledgeDb {
     const result = this.db.prepare(`
       DELETE FROM knowledge_entries
       WHERE bitable_record_id IN (${placeholders})
+    `).run(params);
+    return result.changes;
+  }
+
+  /** 按 Bitable record id 找到受影响的本地文档。 */
+  listDocumentsByEntryBitableRecordIds(recordIds: string[]): KnowledgeDocumentRecord[] {
+    const normalized = [...new Set(recordIds.filter((value) => value.length > 0))];
+    if (normalized.length === 0) {
+      return [];
+    }
+    const placeholders = normalized.map((_, index) => `@recordId${index}`).join(", ");
+    const params = Object.fromEntries(normalized.map((recordId, index) => [`recordId${index}`, recordId]));
+    const rows = this.db.prepare(`
+      SELECT DISTINCT d.*
+      FROM knowledge_documents d
+      JOIN knowledge_entries e ON e.document_id = d.id
+      WHERE e.bitable_record_id IN (${placeholders})
+    `).all(params) as KnowledgeDocumentRow[];
+    return rows.map((row) => toDocumentRecord(row));
+  }
+
+  /** 找出指定文档中已经没有条目和提取缓存的孤儿文档。 */
+  listOrphanDocumentsByIds(documentIds: number[]): KnowledgeDocumentRecord[] {
+    const normalized = [...new Set(documentIds.filter((value) => Number.isInteger(value) && value > 0))];
+    if (normalized.length === 0) {
+      return [];
+    }
+    const placeholders = normalized.map((_, index) => `@documentId${index}`).join(", ");
+    const params = Object.fromEntries(normalized.map((documentId, index) => [`documentId${index}`, documentId]));
+    const rows = this.db.prepare(`
+      SELECT *
+      FROM knowledge_documents
+      WHERE id IN (${placeholders})
+        AND NOT EXISTS (
+          SELECT 1
+          FROM knowledge_entries e
+          WHERE e.document_id = knowledge_documents.id
+        )
+        AND NOT EXISTS (
+          SELECT 1
+          FROM knowledge_extract_chunks c
+          WHERE c.document_id = knowledge_documents.id
+        )
+    `).all(params) as KnowledgeDocumentRow[];
+    return rows.map((row) => toDocumentRecord(row));
+  }
+
+  /** 删除指定范围内已经确认没有条目和缓存的孤儿文档。 */
+  deleteOrphanDocumentsByIds(documentIds: number[]): number {
+    const normalized = [...new Set(documentIds.filter((value) => Number.isInteger(value) && value > 0))];
+    if (normalized.length === 0) {
+      return 0;
+    }
+    const placeholders = normalized.map((_, index) => `@documentId${index}`).join(", ");
+    const params = Object.fromEntries(normalized.map((documentId, index) => [`documentId${index}`, documentId]));
+    const result = this.db.prepare(`
+      DELETE FROM knowledge_documents
+      WHERE id IN (${placeholders})
+        AND NOT EXISTS (
+          SELECT 1
+          FROM knowledge_entries e
+          WHERE e.document_id = knowledge_documents.id
+        )
+        AND NOT EXISTS (
+          SELECT 1
+          FROM knowledge_extract_chunks c
+          WHERE c.document_id = knowledge_documents.id
+        )
     `).run(params);
     return result.changes;
   }
@@ -665,6 +745,7 @@ export class KnowledgeDb {
         checksum TEXT NOT NULL UNIQUE,
         status TEXT NOT NULL,
         bitable_record_id TEXT,
+        obsidian_path TEXT,
         created_at INTEGER NOT NULL
       );
 
@@ -741,13 +822,22 @@ export class KnowledgeDb {
   }
 
   private migrateKnowledgeEntriesSchema(): void {
-    const columns = new Set(
+    const entryColumns = new Set(
       (this.db.prepare("PRAGMA table_info(knowledge_entries)").all() as Array<{ name: string }>).map((column) => column.name),
     );
+    const documentColumns = new Set(
+      (this.db.prepare("PRAGMA table_info(knowledge_documents)").all() as Array<{ name: string }>).map((column) => column.name),
+    );
     const addColumn = (name: string, ddl: string): void => {
-      if (!columns.has(name)) {
+      if (!entryColumns.has(name)) {
         this.db.exec(`ALTER TABLE knowledge_entries ADD COLUMN ${ddl}`);
-        columns.add(name);
+        entryColumns.add(name);
+      }
+    };
+    const addDocumentColumn = (name: string, ddl: string): void => {
+      if (!documentColumns.has(name)) {
+        this.db.exec(`ALTER TABLE knowledge_documents ADD COLUMN ${ddl}`);
+        documentColumns.add(name);
       }
     };
 
@@ -761,6 +851,7 @@ export class KnowledgeDb {
     addColumn("fields_json", "fields_json TEXT");
     addColumn("source_url", "source_url TEXT");
     addColumn("statute_url", "statute_url TEXT");
+    addDocumentColumn("obsidian_path", "obsidian_path TEXT");
 
     this.db.exec(`
       CREATE INDEX IF NOT EXISTS idx_knowledge_entries_dedup_key
@@ -877,6 +968,7 @@ function toDocumentRecord(row: KnowledgeDocumentRow): KnowledgeDocumentRecord {
     checksum: row.checksum,
     status: row.status,
     bitableRecordId: row.bitable_record_id ?? undefined,
+    obsidianPath: row.obsidian_path ?? undefined,
     createdAt: row.created_at,
   };
 }

--- a/src/knowledge/detector.ts
+++ b/src/knowledge/detector.ts
@@ -68,6 +68,17 @@ const LEGAL_KEYWORDS = [
 ];
 
 const QUESTION_MARKERS = ["吗", "么", "如何", "怎么", "怎么办", "是否", "能否", "可以", "多久", "多长", "合法么"];
+const LEGAL_QUERY_FORCE_PATTERN = /^\/?法律问答(?:\s+|[：:])/;
+const META_DOCUMENT_PATTERNS = [
+  /演示视频脚本|视频脚本|最终版|分镜|画面说明|时长[:：]|第[一二三四五六七八九十]+幕/,
+  /AI\s*回复|用户(?:打开|把|说|输入)|语音[:：]|命令示例|示例[:：]/i,
+  /测试用例|验收清单|开发计划|修复计划|需求文档|方案|脚本/,
+];
+const META_STRUCTURE_PATTERNS = [
+  /^#{1,6}\s+/m,
+  /\n---\n/,
+  />\s*["“]?[^"\n“”]*(?:法律问答|劳动合同|竞业限制|解除劳动合同)[^"\n“”]*["”]?/,
+];
 const MATERIAL_INGEST_NEGATIVE_PATTERN = /不要入库|别入库|不用入库|不入库|先别入库|不要写入知识库|不要保存到知识库/;
 const MATERIAL_INGEST_TARGET_PATTERN = /知识库|知识|库/;
 const MATERIAL_INGEST_ACTION_PATTERN = /入库|导入|收录|收入|整理|保存|写入|同步|加入|添加|放进|放到|归档/;
@@ -78,6 +89,9 @@ export function detectLegalQuestion(text: string): KnowledgeAutoDetectResult {
   const normalized = text.replace(/\s+/g, " ").trim().toLowerCase();
   if (!normalized) {
     return { matched: false, confidence: 0, reasons: [] };
+  }
+  if (isMetaDocumentWithEmbeddedLegalExample(text)) {
+    return { matched: false, confidence: 0, reasons: ["meta-document"] };
   }
 
   const reasons: string[] = [];
@@ -108,6 +122,23 @@ export function detectLegalQuestion(text: string): KnowledgeAutoDetectResult {
     confidence: bounded,
     reasons,
   };
+}
+
+/** 避免把演示稿、测试方案等长文本里的法律问题示例误判成真实咨询。 */
+function isMetaDocumentWithEmbeddedLegalExample(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed || LEGAL_QUERY_FORCE_PATTERN.test(trimmed)) {
+    return false;
+  }
+
+  const metaHits = META_DOCUMENT_PATTERNS.filter((pattern) => pattern.test(trimmed)).length;
+  const structureHits = META_STRUCTURE_PATTERNS.filter((pattern) => pattern.test(trimmed)).length;
+  if (trimmed.length < 120 || metaHits < 1 || structureHits < 1) {
+    return false;
+  }
+
+  const legalExampleCount = (trimmed.match(/法律问答|劳动合同|竞业限制|解除劳动合同|法条|诉讼|仲裁/g) ?? []).length;
+  return legalExampleCount >= 2;
 }
 
 /** 检测消息中是否包含网页入库意图与 URL。 */

--- a/src/knowledge/extractors/case-digest.ts
+++ b/src/knowledge/extractors/case-digest.ts
@@ -1,0 +1,386 @@
+/**
+ * 职责: 识别司法文书并把类案要旨规整为知识库 case_digest 条目。
+ * 关注点:
+ * - 在通用问答抽取前分流判决书、裁定书和仲裁裁决书。
+ * - 校验司法文书结构、案号、脱敏和法院说理原文回指。
+ * - 输出兼容 knowledge_entries 的 question/answer/tags/statute/fieldsJson 映射。
+ */
+import crypto from "node:crypto";
+
+import type { ParsedKnowledgeSection } from "../parser.js";
+
+export type JudicialDocumentKind = "judgment" | "ruling" | "arbitration_award";
+
+export type JudicialDocumentDetection = {
+  matched: boolean;
+  kind?: JudicialDocumentKind | undefined;
+  caseNumber?: string | undefined;
+  court?: string | undefined;
+  cause?: string | undefined;
+  judgmentDate?: string | undefined;
+  level?: "一审" | "二审" | "再审" | "仲裁" | "未知" | undefined;
+  sections: JudicialDocumentSections;
+  reason?: string | undefined;
+};
+
+export type JudicialDocumentSections = {
+  claims?: string | undefined;
+  facts?: string | undefined;
+  reasoning?: string | undefined;
+  outcome?: string | undefined;
+};
+
+export type CaseDigestRawItem = {
+  issue?: unknown;
+  reasoning?: unknown;
+  rule?: unknown;
+  outcome?: unknown;
+  statutes?: unknown;
+  tags?: unknown;
+  weight?: unknown;
+};
+
+export type CaseDigestCandidate = {
+  question: string;
+  answer: string;
+  tags: string[];
+  statute?: string | undefined;
+  pageSection: string;
+  entryType: "case_digest";
+  confidence: number;
+  reviewRequired: boolean;
+  effectiveStatus: "current" | "unknown" | "expired";
+  dedupKey: string;
+  fieldsJson: string;
+};
+
+type NormalizedCaseDigest = {
+  issue: string;
+  reasoning: string;
+  rule: string;
+  outcome: string;
+  statutes: string[];
+  tags: string[];
+  weight: "guidance" | "typical" | "reference";
+};
+
+const CASE_NUMBER_PATTERN = /[（(]\d{4}[）)][\u4e00-\u9fa5A-Za-z0-9]+(?:民|商|知|行|劳|仲|执|赔|破|申|再|终|初|裁)[\u4e00-\u9fa5A-Za-z0-9]*\d+(?:-\d+)?号/;
+const COURT_PATTERN = /([\u4e00-\u9fa5]{2,}(?:人民法院|仲裁委员会|劳动人事争议仲裁委员会))/;
+const DATE_PATTERN = /(?:二〇|二○|二零|[一二三四五六七八九〇零○]{4}|\d{4})年[一二三四五六七八九十\d]{1,2}月[一二三四五六七八九十\d]{1,3}日/;
+const SENSITIVE_PATTERN = /未成年人|未成年子女|国家秘密|商业秘密|不公开审理|身份证(?:号|号码)?[:：]?\s*\d{6,}|(?:1[3-9]\d{9})|[\w.+-]+@[\w.-]+\.\w+/;
+const ADDRESS_PATTERN = /(?:住址|住所地|户籍地|身份证住址)[:：][^\n，。；;]{8,}/;
+
+export function detectJudicialDocument(markdown: string, sections: ParsedKnowledgeSection[]): JudicialDocumentDetection {
+  const text = normalizeDocumentText(markdown || sections.map((section) => section.text).join("\n\n"));
+  const caseNumber = text.match(CASE_NUMBER_PATTERN)?.[0];
+  if (!caseNumber) {
+    return { matched: false, sections: {}, reason: "missing-case-number" };
+  }
+  const kind = detectJudicialKind(text);
+  if (!kind) {
+    return { matched: false, caseNumber, sections: {}, reason: "unsupported-document-kind" };
+  }
+  if (/民事调解书|调解协议/.test(text) && !/指导性案例|典型案例|最高人民法院/.test(text)) {
+    return { matched: false, caseNumber, kind, sections: {}, reason: "mediation-out-of-scope" };
+  }
+  if (SENSITIVE_PATTERN.test(text) || ADDRESS_PATTERN.test(text)) {
+    return { matched: false, caseNumber, kind, sections: {}, reason: "sensitive-material" };
+  }
+  const extractedSections = extractJudicialSections(text);
+  if (!extractedSections.reasoning || !extractedSections.outcome) {
+    return { matched: false, caseNumber, kind, sections: extractedSections, reason: "missing-reasoning-or-outcome" };
+  }
+  return {
+    matched: true,
+    kind,
+    caseNumber,
+    court: text.match(COURT_PATTERN)?.[1],
+    cause: extractCause(text),
+    judgmentDate: normalizeJudgmentDate(text.match(DATE_PATTERN)?.[0]),
+    level: detectCaseLevel(caseNumber, kind),
+    sections: extractedSections,
+  };
+}
+
+export function buildCaseDigestPrompt(input: {
+  fileName: string;
+  detection: JudicialDocumentDetection;
+}): string {
+  const detection = input.detection;
+  const sections = detection.sections;
+  return [
+    "你是司法文书要旨提取助手。",
+    "请按争议焦点把以下司法文书拆成多条 case_digest 条目，输出 JSON 数组，不要输出额外说明。",
+    "类案只供说理参考，不是法律依据；不要把当事人姓名、身份证号、手机号、邮箱或详细地址写入结果。",
+    "输出字段：issue、reasoning、rule、outcome、statutes、tags、weight。",
+    "字段规则：",
+    "1. issue 是单一争议焦点，30 字以内。",
+    "2. reasoning 必须从输入的“本院认为/裁判理由”中原文摘录，不要改写。",
+    "3. rule 可以提炼，但不能引入原文未出现的概念，80 字以内。",
+    "4. outcome 写该焦点对应的判决/裁定/裁决结果要点。",
+    "5. statutes 为字符串数组，例如 [\"《劳动合同法》第 19 条\"]；没有明确法条则为空数组。",
+    "6. tags 为 1-3 个标签，优先使用案由和争议焦点关键词。",
+    "7. weight 只能是 guidance、typical、reference；普通上传材料默认 reference。",
+    `源文件：${input.fileName}`,
+    `案号：${detection.caseNumber ?? "未识别"}`,
+    `法院/机构：${detection.court ?? "未识别"}`,
+    `案由：${detection.cause ?? "未识别"}`,
+    "---必要事实背景---",
+    truncateForPrompt([sections.claims, sections.facts].filter(Boolean).join("\n\n"), 2_000),
+    "---本院认为/裁判理由---",
+    truncateForPrompt(sections.reasoning ?? "", 5_000),
+    "---判决/裁定/裁决结果---",
+    truncateForPrompt(sections.outcome ?? "", 1_500),
+    "只输出 JSON 数组，不要输出其他内容。",
+  ].join("\n\n");
+}
+
+export function normalizeCaseDigestItems(input: {
+  rawItems: unknown[];
+  detection: JudicialDocumentDetection;
+  sourceText: string;
+}): CaseDigestCandidate[] {
+  const normalizedSource = normalizeForEvidence(input.sourceText);
+  const candidates: CaseDigestCandidate[] = [];
+  const seen = new Set<string>();
+  for (const item of input.rawItems) {
+    const digest = normalizeRawDigest(item);
+    if (!digest) {
+      continue;
+    }
+    const span = locateReasoningSpan(normalizedSource, digest.reasoning);
+    if (!span) {
+      continue;
+    }
+    const dedupKey = buildCaseDigestDedupKey(input.detection.caseNumber!, digest.issue);
+    if (seen.has(dedupKey)) {
+      continue;
+    }
+    seen.add(dedupKey);
+    const fields = {
+      schemaVersion: 1,
+      type: "case_digest",
+      caseNumber: input.detection.caseNumber,
+      court: input.detection.court,
+      cause: input.detection.cause,
+      level: input.detection.level,
+      judgmentDate: input.detection.judgmentDate,
+      issue: digest.issue,
+      reasoning: digest.reasoning,
+      reasoningSpan: span,
+      rule: digest.rule,
+      outcome: digest.outcome,
+      statutes: digest.statutes,
+      weight: digest.weight,
+      redactionApplied: true,
+      extractedAt: new Date().toISOString(),
+      extractorVersion: "case-digest-v1",
+      promptVersion: "case-digest-prompt-v1",
+    };
+    candidates.push({
+      question: digest.issue,
+      answer: buildCaseDigestAnswer(digest),
+      tags: digest.tags,
+      statute: digest.statutes.length > 0 ? digest.statutes.join("；") : undefined,
+      pageSection: `${input.detection.caseNumber} · ${digest.issue}`,
+      entryType: "case_digest",
+      confidence: 0.9,
+      reviewRequired: false,
+      effectiveStatus: input.detection.level === "一审" ? "unknown" : "current",
+      dedupKey,
+      fieldsJson: JSON.stringify(fields),
+    });
+  }
+  return candidates;
+}
+
+export function buildCaseDigestDedupKey(caseNumber: string, issue: string): string {
+  const hash = crypto.createHash("sha256").update(normalizeForEvidence(issue)).digest("hex").slice(0, 16);
+  return `case_digest:${caseNumber}:${hash}`;
+}
+
+function detectJudicialKind(text: string): JudicialDocumentKind | undefined {
+  if (/民事判决书|行政判决书|刑事附带民事判决书/.test(text)) {
+    return "judgment";
+  }
+  if (/民事裁定书|行政裁定书/.test(text)) {
+    return "ruling";
+  }
+  if (/仲裁裁决书|裁决书/.test(text) && /仲裁/.test(text)) {
+    return "arbitration_award";
+  }
+  return undefined;
+}
+
+function detectCaseLevel(caseNumber: string | undefined, kind: JudicialDocumentKind): "一审" | "二审" | "再审" | "仲裁" | "未知" {
+  if (kind === "arbitration_award") {
+    return "仲裁";
+  }
+  if (!caseNumber) {
+    return "未知";
+  }
+  if (/再|申/.test(caseNumber)) {
+    return "再审";
+  }
+  if (/终/.test(caseNumber)) {
+    return "二审";
+  }
+  if (/初/.test(caseNumber)) {
+    return "一审";
+  }
+  return "未知";
+}
+
+function extractJudicialSections(text: string): JudicialDocumentSections {
+  return {
+    claims: sliceBetween(text, ["诉称", "上诉请求", "原告诉称", "上诉人上诉请求"], ["辩称", "本院查明", "本院认为"]),
+    facts: sliceBetween(text, ["本院查明", "经审理查明", "本院经审理查明", "查明"], ["本院认为", "裁判理由", "仲裁庭认为"]),
+    reasoning: sliceBetween(text, ["本院认为", "裁判理由", "仲裁庭认为", "本委认为"], ["判决如下", "裁定如下", "裁决如下", "审判长", "仲裁员"]),
+    outcome: sliceBetween(text, ["判决如下", "裁定如下", "裁决如下"], ["审判长", "审判员", "人民陪审员", "书记员", "仲裁员"]),
+  };
+}
+
+function sliceBetween(text: string, startMarkers: string[], endMarkers: string[]): string | undefined {
+  const start = findFirstMarker(text, startMarkers);
+  if (!start) {
+    return undefined;
+  }
+  const from = start.index;
+  const nextEnd = endMarkers
+    .map((marker) => {
+      const index = text.indexOf(marker, from + start.marker.length);
+      return index >= 0 ? index : Number.MAX_SAFE_INTEGER;
+    })
+    .reduce((min, index) => Math.min(min, index), Number.MAX_SAFE_INTEGER);
+  return text.slice(from, nextEnd === Number.MAX_SAFE_INTEGER ? undefined : nextEnd).trim();
+}
+
+function findFirstMarker(text: string, markers: string[]): { marker: string; index: number } | undefined {
+  return markers
+    .map((marker) => ({ marker, index: text.indexOf(marker) }))
+    .filter((item) => item.index >= 0)
+    .sort((left, right) => left.index - right.index)[0];
+}
+
+function extractCause(text: string): string | undefined {
+  const patterns = [
+    /案由[:：]\s*([^\n，。；;]{2,30})/,
+    /(?:劳动争议|合同纠纷|买卖合同纠纷|民间借贷纠纷|侵害商标权纠纷|公司决议纠纷|股东资格确认纠纷)/,
+  ];
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    const value = match?.[1] ?? match?.[0];
+    if (value) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function normalizeJudgmentDate(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return value.replace(/\s+/g, "");
+}
+
+function normalizeRawDigest(value: unknown): NormalizedCaseDigest | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const record = value as CaseDigestRawItem;
+  const issue = readString(record.issue);
+  const reasoning = readString(record.reasoning);
+  const rule = readString(record.rule);
+  const outcome = readString(record.outcome);
+  if (!issue || !reasoning || !rule || !outcome || issue.length > 60) {
+    return null;
+  }
+  return {
+    issue: issue.slice(0, 60),
+    reasoning,
+    rule: rule.slice(0, 120),
+    outcome,
+    statutes: readStringArray(record.statutes).map(normalizeStatuteText).filter(Boolean),
+    tags: normalizeDigestTags(readStringArray(record.tags), issue),
+    weight: normalizeWeight(record.weight),
+  };
+}
+
+function buildCaseDigestAnswer(digest: NormalizedCaseDigest): string {
+  return [
+    `裁判规则：${digest.rule}`,
+    `裁判结果：${digest.outcome}`,
+    `法院说理：${digest.reasoning}`,
+    "类案参考：本条仅供说理思路参考，非法律依据。",
+  ].join("\n\n");
+}
+
+function normalizeDigestTags(tags: string[], issue: string): string[] {
+  const unique = new Set<string>();
+  for (const tag of tags) {
+    const normalized = tag.replace(/\s+/g, "").trim();
+    if (normalized && normalized.length <= 12) {
+      unique.add(normalized);
+    }
+    if (unique.size >= 3) {
+      break;
+    }
+  }
+  if (unique.size === 0) {
+    unique.add(issue.slice(0, 12));
+  }
+  return [...unique];
+}
+
+function normalizeWeight(value: unknown): "guidance" | "typical" | "reference" {
+  return value === "guidance" || value === "typical" || value === "reference" ? value : "reference";
+}
+
+function locateReasoningSpan(normalizedSource: string, reasoning: string): { start: number; end: number; normalizedHash: string } | null {
+  const normalizedReasoning = normalizeForEvidence(reasoning);
+  if (!normalizedReasoning || normalizedReasoning.length < 12) {
+    return null;
+  }
+  const start = normalizedSource.indexOf(normalizedReasoning);
+  if (start < 0) {
+    return null;
+  }
+  return {
+    start,
+    end: start + normalizedReasoning.length,
+    normalizedHash: crypto.createHash("sha256").update(normalizedReasoning).digest("hex"),
+  };
+}
+
+function normalizeDocumentText(text: string): string {
+  return text
+    .replace(/\r\n/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function normalizeForEvidence(text: string): string {
+  return text.replace(/\s+/g, "").replace(/[，,。；;：:]/g, (match) => match).trim();
+}
+
+function truncateForPrompt(text: string, maxLength: number): string {
+  const normalized = text.trim();
+  return normalized.length > maxLength ? `${normalized.slice(0, maxLength)}\n……` : normalized;
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value.replace(/\s+/g, " ").trim() : "";
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map(readString).filter(Boolean);
+}
+
+function normalizeStatuteText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -6,7 +6,7 @@
  * - 作为运行时模块与存储层之间的业务接口。
  */
 import crypto from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { readFile, unlink } from "node:fs/promises";
 import path from "node:path";
 
 import { expandArchiveMaterialEntries, isArchiveFileName } from "../document-pipeline/archive.js";
@@ -27,9 +27,10 @@ import {
   type CaseDigestCandidate,
 } from "./extractors/case-digest.js";
 import type { KnowledgeBaseConfig } from "./config.js";
-import { exportKnowledgeObsidianNote } from "./obsidian-export.js";
+import { exportKnowledgeObsidianNote, resolveKnowledgeObsidianNotePath } from "./obsidian-export.js";
 import {
   KnowledgeDb,
+  type KnowledgeDocumentRecord,
   type KnowledgeDocumentSummary,
   type KnowledgeEntryCandidate,
   type KnowledgeEntryRecord,
@@ -800,6 +801,9 @@ export class KnowledgeBaseService implements KnowledgeBasePort {
       }, "warn");
       return null;
     });
+    if (obsidianPath) {
+      this.db.updateDocumentObsidianPath(document.id, obsidianPath);
+    }
     await this.reportProgress(options, {
       step: "write",
       status: "completed",
@@ -946,7 +950,11 @@ export class KnowledgeBaseService implements KnowledgeBasePort {
     }
     const removedRecordIds = [...localRecordIds].filter((recordId) => !remoteRecordIds.has(recordId));
     if (removedRecordIds.length > 0) {
+      const affectedDocuments = this.db.listDocumentsByEntryBitableRecordIds(removedRecordIds);
       this.db.deleteEntriesByBitableRecordIds(removedRecordIds);
+      const orphanDocuments = this.db.listOrphanDocumentsByIds(affectedDocuments.map((document) => document.id));
+      await this.deleteObsidianNotesForDocuments(orphanDocuments);
+      this.db.deleteOrphanDocumentsByIds(orphanDocuments.map((document) => document.id));
       this.db.deleteOrphanSyncedDocuments();
     }
   }
@@ -954,6 +962,37 @@ export class KnowledgeBaseService implements KnowledgeBasePort {
   /** 关闭知识库数据库连接。 */
   close(): void {
     this.db.close();
+  }
+
+  /** 删除由知识库自动导出的 Obsidian 笔记；只删除可由本地文档元数据反查的系统笔记。 */
+  private async deleteObsidianNotesForDocuments(documents: KnowledgeDocumentRecord[]): Promise<void> {
+    const config = this.config.obsidian;
+    if (!config?.enabled || !config.vaultPath) {
+      return;
+    }
+    const notePaths = new Set<string>();
+    for (const document of documents) {
+      notePaths.add(document.obsidianPath ?? resolveKnowledgeObsidianNotePath(config, {
+        fileName: document.fileName,
+        checksum: document.checksum,
+        sqliteDocumentId: document.id,
+      }));
+    }
+    for (const notePath of notePaths) {
+      if (!isPathInsideDirectory(notePath, path.join(config.vaultPath, config.baseDir))) {
+        this.logger.log("knowledge", "skip obsidian note delete outside knowledge dir", { notePath }, "warn");
+        continue;
+      }
+      await unlink(notePath).catch((error: unknown) => {
+        if (isNodeError(error) && error.code === "ENOENT") {
+          return;
+        }
+        this.logger.log("knowledge", "obsidian note delete failed", {
+          notePath,
+          detail: error instanceof Error ? error.message : String(error),
+        }, "warn");
+      });
+    }
   }
 
   // #endregion
@@ -1553,6 +1592,15 @@ function validateUploadedFile(fileName: string, buffer: Buffer, allowedExtension
   if (sizeMb > maxFileSizeMb) {
     throw new Error(`文件过大，请控制在 ${maxFileSizeMb}MB 以内`);
   }
+}
+
+function isPathInsideDirectory(filePath: string, directory: string): boolean {
+  const relative = path.relative(path.resolve(directory), path.resolve(filePath));
+  return Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
 }
 
 function resolveDownloadedKnowledgeFileName(downloadedFileName: string, messageFileName: string): string {

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -20,6 +20,12 @@ import {
   parseKnowledgeFile,
   type KnowledgeParserUsed,
 } from "./parser.js";
+import {
+  buildCaseDigestPrompt,
+  detectJudicialDocument,
+  normalizeCaseDigestItems,
+  type CaseDigestCandidate,
+} from "./extractors/case-digest.js";
 import type { KnowledgeBaseConfig } from "./config.js";
 import { exportKnowledgeObsidianNote } from "./obsidian-export.js";
 import {
@@ -146,6 +152,12 @@ type ExtractedQa = {
 type ExtractedQaCandidate = ExtractedQa & {
   pageSection: string;
   embedding?: number[] | undefined;
+  entryType?: "article" | "case_digest" | "practice_note" | "case_reflow" | undefined;
+  confidence?: number | undefined;
+  reviewRequired?: boolean | undefined;
+  effectiveStatus?: "current" | "unknown" | "expired" | undefined;
+  dedupKey?: string | undefined;
+  fieldsJson?: string | undefined;
 };
 
 type ChunkExtractionState = {
@@ -332,6 +344,12 @@ export class KnowledgeBaseService implements KnowledgeBasePort {
       ? chapterGrouping.chapters.filter((chapter) => !chapter.skipped).flatMap((chapter) => chapter.sections)
       : parsedDocument.sections;
     const extractionMarkdown = extractionSections.map((section) => section.text).join("\n\n");
+    const judicialDocument = this.config.judicialIngest?.enabled !== false
+      ? detectJudicialDocument(extractionMarkdown || parsedDocument.normalizedMarkdown, extractionSections)
+      : { matched: false as const, sections: {} };
+    if (!judicialDocument.matched && judicialDocument.reason === "sensitive-material") {
+      throw new Error("司法文书包含未脱敏敏感信息，已停止自动入库");
+    }
     const qaDocument = detectStructuredQaDocument(extractionMarkdown, extractionSections);
     let rawExtractedCount = 0;
     let dedupedCount = 0;
@@ -397,7 +415,7 @@ export class KnowledgeBaseService implements KnowledgeBasePort {
     }
 
     const maxQas = options?.maxQas ?? this.config.ingest.maxExtractQas;
-    if (finalCandidates.length > maxQas) {
+    if (isExtractQaLimitEnabled(maxQas) && finalCandidates.length > maxQas) {
       finalCandidates = [...finalCandidates]
         .sort((left, right) => scoreExtractedCandidate(right) - scoreExtractedCandidate(left))
         .slice(0, maxQas);
@@ -507,6 +525,12 @@ export class KnowledgeBaseService implements KnowledgeBasePort {
       ? chapterGrouping.chapters.filter((chapter) => !chapter.skipped).flatMap((chapter) => chapter.sections)
       : parsedDocument.sections;
     const extractionMarkdown = extractionSections.map((section) => section.text).join("\n\n");
+    const judicialDocument = this.config.judicialIngest?.enabled !== false
+      ? detectJudicialDocument(extractionMarkdown || parsedDocument.normalizedMarkdown, extractionSections)
+      : { matched: false as const, sections: {} };
+    if (!judicialDocument.matched && judicialDocument.reason === "sensitive-material") {
+      throw new Error("司法文书包含未脱敏敏感信息，已停止自动入库");
+    }
     const qaDocument = detectStructuredQaDocument(extractionMarkdown, extractionSections);
     const concurrency = this.config.ingest.concurrency;
     let rawExtractedCount = 0;
@@ -516,7 +540,18 @@ export class KnowledgeBaseService implements KnowledgeBasePort {
       chapterGrouping.skippedTitles.length > 0 ? buildSkippedChaptersWarning(chapterGrouping.skippedTitles) : undefined,
     );
 
-    if (qaDocument.matched) {
+    if (judicialDocument.matched) {
+      this.db.clearExtractedChunks(document.id);
+      await this.reportProgress(options, {
+        step: "extract",
+        status: "running",
+        detail: `已识别司法文书（${judicialDocument.caseNumber}），正在提取类案要旨`,
+      });
+      const caseDigestCandidates = await this.extractCaseDigests(input.fileName, judicialDocument, extractionMarkdown);
+      rawExtractedCount = caseDigestCandidates.length;
+      finalCandidates = caseDigestCandidates;
+      dedupedCount = 0;
+    } else if (qaDocument.matched) {
       this.db.clearExtractedChunks(document.id);
       await this.reportProgress(options, {
         step: "extract",
@@ -625,12 +660,16 @@ export class KnowledgeBaseService implements KnowledgeBasePort {
       dedupedCount = rawExtractedCount - finalCandidates.length;
     }
 
-    if (finalCandidates.length > this.config.ingest.maxExtractQas) {
+    if (isExtractQaLimitEnabled(this.config.ingest.maxExtractQas) && finalCandidates.length > this.config.ingest.maxExtractQas) {
       finalCandidates = [...finalCandidates]
         .sort((left, right) => scoreExtractedCandidate(right) - scoreExtractedCandidate(left))
         .slice(0, this.config.ingest.maxExtractQas);
       warning = joinWarnings(warning, buildMaxExtractQasWarning(this.config.ingest.maxExtractQas));
     }
+
+    const beforeDedupKeyFilterCount = finalCandidates.length;
+    finalCandidates = this.filterExistingDedupKeyCandidates(finalCandidates);
+    dedupedCount += beforeDedupKeyFilterCount - finalCandidates.length;
 
     const totalExtracted = finalCandidates.length;
     this.db.updateDocumentStatus(document.id, totalExtracted > 0 ? "writing" : "extracted");
@@ -638,8 +677,8 @@ export class KnowledgeBaseService implements KnowledgeBasePort {
       step: "extract",
       status: "completed",
       detail: totalExtracted > 0
-        ? `已提取 ${totalExtracted} 条问答（原始 ${rawExtractedCount} 条，去重合并 ${dedupedCount} 条）`
-        : "未提取到可入库问答",
+        ? `已提取 ${totalExtracted} 条知识（原始 ${rawExtractedCount} 条，去重合并 ${dedupedCount} 条）`
+        : "未提取到可入库知识",
     });
 
     const tagCounts = new Map<string, number>();
@@ -701,6 +740,12 @@ export class KnowledgeBaseService implements KnowledgeBasePort {
           bitableRecordId,
           embedding,
           embeddingModel: this.embeddingClient.model,
+          entryType: item.entryType,
+          confidence: item.confidence,
+          reviewRequired: item.reviewRequired,
+          effectiveStatus: item.effectiveStatus,
+          dedupKey: item.dedupKey,
+          fieldsJson: item.fieldsJson,
         });
         writeCompleted += 1;
         for (const tag of item.tags) {
@@ -759,8 +804,8 @@ export class KnowledgeBaseService implements KnowledgeBasePort {
       step: "write",
       status: "completed",
       detail: totalExtracted > 0
-        ? `已写入 ${writeCompleted} 条问答${obsidianPath ? "，已导出 Obsidian 笔记" : ""}`
-        : "没有可写入的问答",
+        ? `已写入 ${writeCompleted} 条知识${obsidianPath ? "，已导出 Obsidian 笔记" : ""}`
+        : "没有可写入的知识",
     });
 
     return {
@@ -948,6 +993,34 @@ export class KnowledgeBaseService implements KnowledgeBasePort {
     }
   }
 
+  /** 从司法文书中提取可检索的类案要旨。 */
+  private async extractCaseDigests(
+    fileName: string,
+    detection: Parameters<typeof buildCaseDigestPrompt>[0]["detection"],
+    sourceText: string,
+  ): Promise<CaseDigestCandidate[]> {
+    const session = await this.opencode.createSession("[bridge] knowledge-case-digest");
+    try {
+      const response = await this.opencode.postMessageSync(session.id, buildKnowledgePromptRequest(
+        [{
+          type: "text",
+          text: buildCaseDigestPrompt({
+            fileName,
+            detection,
+          }),
+        }],
+        resolveKnowledgeModel(this.config, "extract"),
+      ));
+      return normalizeCaseDigestItems({
+        rawItems: parseJsonArray(extractAssistantText(response)),
+        detection,
+        sourceText,
+      });
+    } finally {
+      await this.opencode.deleteSession(session.id).catch(() => undefined);
+    }
+  }
+
   /** 从单个文本分段中提取可入库的问答对。 */
   private async extractQa(fileName: string, pageSection: string, chunk: string, prevContext?: string | undefined): Promise<ExtractedQa[]> {
     const session = await this.opencode.createSession("[bridge] knowledge-extract");
@@ -1099,6 +1172,11 @@ export class KnowledgeBaseService implements KnowledgeBasePort {
     } finally {
       await this.opencode.deleteSession(session.id).catch(() => undefined);
     }
+  }
+
+  /** 已存在 dedupKey 的条目不再重复写入，保护同案同争议焦点不会堆出副本。 */
+  private filterExistingDedupKeyCandidates<T extends ExtractedQaCandidate>(candidates: T[]): T[] {
+    return candidates.filter((candidate) => !candidate.dedupKey || !this.db.findByDedupKey(candidate.dedupKey));
   }
 
   /** 用模型对候选检索结果做二次重排。 */
@@ -1460,6 +1538,10 @@ function shouldReportProgress(index: number, total: number): boolean {
   }
   const step = Math.max(1, Math.ceil(total / 5));
   return index === 0 || (index + 1) % step === 0;
+}
+
+function isExtractQaLimitEnabled(limit: number): boolean {
+  return limit > 0;
 }
 
 function validateUploadedFile(fileName: string, buffer: Buffer, allowedExtensions: string[], maxFileSizeMb: number): void {

--- a/src/knowledge/obsidian-export.ts
+++ b/src/knowledge/obsidian-export.ts
@@ -40,11 +40,17 @@ export async function exportKnowledgeObsidianNote(
     return null;
   }
 
-  const baseDir = path.join(config.vaultPath, config.baseDir);
-  await mkdir(baseDir, { recursive: true });
-  const notePath = path.join(baseDir, `${buildNoteFileStem(input)}.md`);
+  const notePath = resolveKnowledgeObsidianNotePath(config, input);
+  await mkdir(path.dirname(notePath), { recursive: true });
   await writeFile(notePath, buildKnowledgeObsidianMarkdown(config, input), "utf8");
   return notePath;
+}
+
+export function resolveKnowledgeObsidianNotePath(
+  config: Pick<KnowledgeObsidianConfig, "vaultPath" | "baseDir">,
+  input: Pick<KnowledgeObsidianExportInput, "fileName" | "checksum" | "sqliteDocumentId">,
+): string {
+  return path.join(config.vaultPath ?? "", config.baseDir, `${buildNoteFileStem(input)}.md`);
 }
 
 export function buildKnowledgeObsidianMarkdown(

--- a/src/runtime/cost-tracker.ts
+++ b/src/runtime/cost-tracker.ts
@@ -85,7 +85,7 @@ export class CostTracker {
       return null;
     }
 
-    const model = resolveModelLabel(input.model);
+    const model = resolveModelLabel(input.model, input.assistantMessage);
     const usage = extractUsage(input.assistantMessage) ?? estimateUsage(input.promptText, input.replyText);
     const price = this.resolvedConfig.modelPrices[`${model.provider}/${model.model}`];
     const estimatedCostCny = price
@@ -242,10 +242,39 @@ function summarizeEntries(entries: UsageLedgerEntry[]): CostWindowSummary {
   };
 }
 
-function resolveModelLabel(model: OpenCodeModelRef | Record<string, unknown> | undefined): { provider: string; model: string } {
-  const provider = typeof model?.providerID === "string" && model.providerID.trim() ? model.providerID.trim() : "opencode-default";
-  const modelId = typeof model?.modelID === "string" && model.modelID.trim() ? model.modelID.trim() : "default";
+function resolveModelLabel(
+  model: OpenCodeModelRef | Record<string, unknown> | undefined,
+  assistantMessage?: OpenCodeMessage | null | undefined,
+): { provider: string; model: string } {
+  const messageModel = extractModelLabel(assistantMessage);
+  const provider = typeof model?.providerID === "string" && model.providerID.trim()
+    ? model.providerID.trim()
+    : messageModel?.provider ?? "opencode-default";
+  const modelId = typeof model?.modelID === "string" && model.modelID.trim()
+    ? model.modelID.trim()
+    : messageModel?.model ?? "default";
   return { provider, model: modelId };
+}
+
+function extractModelLabel(message: OpenCodeMessage | null | undefined): { provider?: string; model?: string } | null {
+  if (!message) {
+    return null;
+  }
+  const candidates = [
+    message.info,
+    message.info.model,
+    message.info.provider,
+    ...message.parts,
+    ...message.parts.map((part) => part.model),
+  ].filter(isRecord);
+  for (const candidate of candidates) {
+    const provider = readString(candidate, ["providerID", "providerId", "provider_id", "provider"]);
+    const model = readString(candidate, ["modelID", "modelId", "model_id", "model"]);
+    if (provider || model) {
+      return { ...(provider ? { provider } : {}), ...(model ? { model } : {}) };
+    }
+  }
+  return null;
 }
 
 function estimateUsage(promptText: string, replyText: string): {
@@ -306,6 +335,16 @@ function readNumber(record: Record<string, unknown>, keys: string[]): number | u
     const value = record[key];
     if (typeof value === "number" && Number.isFinite(value)) {
       return Math.max(0, Math.round(value));
+    }
+  }
+  return undefined;
+}
+
+function readString(record: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
     }
   }
   return undefined;

--- a/test/cost-tracker.test.ts
+++ b/test/cost-tracker.test.ts
@@ -84,6 +84,34 @@ describe("CostTracker", () => {
     await expect(tracker.isDailyLimitExceeded()).resolves.toBe(true);
   });
 
+  it("uses assistant message model metadata when no window override is set", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-cost-model-meta-"));
+    const tracker = new CostTracker({
+      enabled: true,
+      currency: "CNY",
+      modelPrices: {},
+    }, dir, fakeLogger());
+
+    await tracker.recordTurn({
+      turnId: "turn_model",
+      sessionId: "ses_model",
+      promptText: "用户输入",
+      replyText: "模型回复",
+      assistantMessage: {
+        info: {
+          role: "assistant",
+          providerID: "minimax-coding-plan",
+          modelID: "minimax2.7",
+        },
+        parts: [],
+      },
+    });
+
+    const ledger = await readFile(path.join(dir, "usage-ledger.jsonl"), "utf8");
+    expect(ledger).toContain("\"provider\":\"minimax-coding-plan\"");
+    expect(ledger).toContain("\"model\":\"minimax2.7\"");
+  });
+
   it("records external tool calls without persisting user text", async () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-cost-external-"));
     const tracker = new CostTracker({

--- a/test/fixtures/legacy-config.snapshot.json
+++ b/test/fixtures/legacy-config.snapshot.json
@@ -173,6 +173,14 @@
       "extract": "minimax-cn-coding-plan/MiniMax-M2.7",
       "rerank": "minimax-cn-coding-plan/MiniMax-M2.7"
     },
+    "judicialIngest": {
+      "enabled": true,
+      "batchEnabled": false,
+      "sources": [
+        "manual"
+      ],
+      "batchSize": 20
+    },
     "obsidian": {
       "enabled": false,
       "baseDir": "Legal Knowledge",

--- a/test/formatter.test.ts
+++ b/test/formatter.test.ts
@@ -27,7 +27,7 @@ import {
   buildStatusCommandCardPayload,
   buildTurnStatusCardPayload,
 } from "../src/feishu/formatter.js";
-import { buildButtonCallbackTestCardPayload } from "../src/feishu/runtime-cards.js";
+import { buildButtonCallbackTestCardPayload, buildCostCommandCardPayload } from "../src/feishu/runtime-cards.js";
 import { buildAssistantMarkdownPayload } from "../src/feishu/shared-primitives.js";
 
 describe("buildPostPayload", () => {
@@ -251,6 +251,32 @@ describe("buildPostPayload", () => {
     expect(content.body.elements).toHaveLength(4);
   });
 
+  it("renders cost card without price/source columns and normalizes default model labels", () => {
+    const payload = buildCostCommandCardPayload({
+      todayTokens: 58,
+      monthTokens: 6605,
+      recent: [
+        {
+          createdAt: "2026-05-11T00:00:00.000Z",
+          provider: "opencode-default",
+          model: "default",
+          totalTokens: 58,
+          source: "estimated",
+        },
+      ],
+    });
+    const content = JSON.parse(payload.content) as any;
+    const serialized = JSON.stringify(content);
+
+    expect(serialized).toContain("AI 成本摘要");
+    expect(serialized).toContain("OpenCode 默认模型");
+    expect(serialized).toContain("58");
+    expect(serialized).not.toContain("未配置价格");
+    expect(serialized).not.toContain("费用");
+    expect(serialized).not.toContain("来源");
+    expect(serialized).not.toContain("查看完整账单");
+  });
+
   it("renders a guide card with reproducible hero actions", () => {
     const payload = buildGuideCardPayload({ windowLabel: "日常会话" });
     const content = JSON.parse(payload.content) as any;
@@ -283,6 +309,9 @@ describe("buildPostPayload", () => {
     expect(content.header.title.content).toBe("可用模型");
     expect(content.header.template).toBe("indigo");
     expect(serialized).toContain("gpt-5.4-mini");
+    expect(serialized).toContain("openai/gpt-5.2");
+    expect(serialized).not.toContain("gpt-5.3-codex");
+    expect(serialized).not.toContain("openai/gpt-5.5");
     expect(serialized).toContain("/model reset");
   });
 

--- a/test/knowledge-case-digest.test.ts
+++ b/test/knowledge-case-digest.test.ts
@@ -1,0 +1,290 @@
+/**
+ * 职责: 覆盖司法文书 case_digest 入库能力。
+ * 关注点:
+ * - 验证司法文书识别、分段、原文回指和敏感材料拦截。
+ * - 验证 KnowledgeBaseService 会把判决书写成 case_digest，而不是普通问答。
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { buildKnowledgeQueryPayload } from "../src/feishu/knowledge-cards.js";
+import { detectJudicialDocument, normalizeCaseDigestItems } from "../src/knowledge/extractors/case-digest.js";
+import { KnowledgeBaseService } from "../src/knowledge/index.js";
+
+const tempDirs: string[] = [];
+
+describe("case digest judicial ingest", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("detects supported judicial documents and extracts key sections", () => {
+    const detection = detectJudicialDocument(judgmentFixture(), [{ location: "全文", text: judgmentFixture() }]);
+
+    expect(detection.matched).toBe(true);
+    expect(detection.kind).toBe("judgment");
+    expect(detection.caseNumber).toBe("（2024）粤03民终1234号");
+    expect(detection.level).toBe("二审");
+    expect(detection.sections.reasoning).toContain("本院认为");
+    expect(detection.sections.outcome).toContain("判决如下");
+  });
+
+  it("does not classify pleadings, contracts, courses, or disclaimers as judicial documents", () => {
+    const negatives = [
+      "民事起诉状\n原告请求判令被告支付货款。",
+      "劳动合同\n甲方与乙方建立劳动关系。",
+      "课程目录\n第一章 劳动争议处理流程。",
+      "免责声明：本文仅供学习交流，不构成法律意见。",
+    ];
+
+    for (const text of negatives) {
+      expect(detectJudicialDocument(text, [{ location: "全文", text }]).matched).toBe(false);
+    }
+  });
+
+  it("rejects case digests whose reasoning is not an original substring", () => {
+    const detection = detectJudicialDocument(judgmentFixture(), [{ location: "全文", text: judgmentFixture() }]);
+    const items = normalizeCaseDigestItems({
+      detection,
+      sourceText: judgmentFixture(),
+      rawItems: [{
+        issue: "试用期约定是否合法",
+        reasoning: "这是一段模型编造的法院说理。",
+        rule: "试用期应当符合法定上限。",
+        outcome: "维持原判。",
+        statutes: ["《劳动合同法》第 19 条"],
+        tags: ["劳动争议", "试用期"],
+      }],
+    });
+
+    expect(items).toHaveLength(0);
+  });
+
+  it("ingests a judgment as case_digest and keeps metadata in fieldsJson", async () => {
+    stubEmbeddingFetch();
+    const dir = mkdtempSync(join(tmpdir(), "knowledge-case-digest-"));
+    tempDirs.push(dir);
+    const filePath = join(dir, "二审判决书.txt");
+    writeFileSync(filePath, judgmentFixture(), "utf8");
+    const createdRecords: Array<{ tableId: string; fields: Record<string, unknown> }> = [];
+    const requests: string[] = [];
+    const service = new KnowledgeBaseService(
+      createKnowledgeConfig(join(dir, "knowledge.db")),
+      {
+        async downloadMessageResource() {
+          throw new Error("not used");
+        },
+        async createBitableRecord(_appToken, tableId, fields) {
+          createdRecords.push({ tableId, fields });
+          return `${tableId}_${createdRecords.length}`;
+        },
+        async listBitableRecords() {
+          return [];
+        },
+      },
+      createOpenCodeStub(requests),
+      logger(),
+    );
+
+    const result = await service.ingestLocalFile(filePath);
+    const document = await service.getDocument(1);
+
+    expect(result.extractedCount).toBe(1);
+    expect(requests.some((prompt) => prompt.includes("司法文书要旨提取助手"))).toBe(true);
+    expect(requests.some((prompt) => prompt.includes("法律知识提取专家"))).toBe(false);
+    expect(document?.sampleEntries[0]?.entryType).toBe("case_digest");
+    expect(document?.sampleEntries[0]?.dedupKey).toContain("case_digest:（2024）粤03民终1234号:");
+    expect(document?.sampleEntries[0]?.fieldsJson).toContain("\"caseNumber\":\"（2024）粤03民终1234号\"");
+    expect(document?.sampleEntries[0]?.fieldsJson).toContain("\"redactionApplied\":true");
+    expect(createdRecords.at(-1)?.fields).toMatchObject({
+      问题: "试用期约定是否合法",
+      标签: ["劳动争议", "试用期"],
+      "页码/章节": "（2024）粤03民终1234号 · 试用期约定是否合法",
+    });
+    service.close();
+  });
+
+  it("dedupes repeated caseNumber and issue by dedupKey", async () => {
+    stubEmbeddingFetch();
+    const dir = mkdtempSync(join(tmpdir(), "knowledge-case-digest-dedup-"));
+    tempDirs.push(dir);
+    const filePath = join(dir, "二审判决书.txt");
+    writeFileSync(filePath, judgmentFixture(), "utf8");
+    const service = new KnowledgeBaseService(
+      createKnowledgeConfig(join(dir, "knowledge.db")),
+      {
+        async downloadMessageResource() {
+          throw new Error("not used");
+        },
+        async createBitableRecord(_appToken, tableId) {
+          return `${tableId}_${Date.now()}`;
+        },
+        async listBitableRecords() {
+          return [];
+        },
+      },
+      createOpenCodeStub([]),
+      logger(),
+    );
+
+    const first = await service.ingestLocalFile(filePath);
+    const second = await service.ingestLocalFile(filePath);
+
+    expect(first.extractedCount).toBe(1);
+    expect(second.extractedCount).toBe(0);
+    service.close();
+  });
+
+  it("renders case_digest results in a separate case reference section", () => {
+    const payload = buildKnowledgeQueryPayload({
+      question: "试用期超过法定上限怎么办？",
+      results: [{
+        id: 1,
+        documentId: 1,
+        question: "试用期约定是否合法",
+        answer: "裁判规则：试用期不得超过法定上限。\n\n裁判结果：维持原判。\n\n法院说理：本院认为，案涉劳动合同约定六个月试用期，未超过法律规定上限。",
+        tags: ["劳动争议", "试用期"],
+        statute: "《劳动合同法》第 19 条",
+        sourceFile: "二审判决书.txt",
+        pageSection: "（2024）粤03民终1234号 · 试用期约定是否合法",
+        sourceUrl: "https://example.com/base/record",
+        createdAt: Date.now(),
+        entryType: "case_digest",
+        fieldsJson: JSON.stringify({
+          caseNumber: "（2024）粤03民终1234号",
+          court: "广东省深圳市中级人民法院",
+          judgmentDate: "二〇二四年五月十日",
+          issue: "试用期约定是否合法",
+          rule: "试用期不得超过法定上限。",
+          outcome: "维持原判。",
+        }),
+        score: 0.99,
+      }],
+    });
+
+    const serialized = JSON.stringify(JSON.parse(payload.content));
+    expect(serialized).toContain("0 条答案");
+    expect(serialized).toContain("1 条类案");
+    expect(serialized).toContain("类案参考");
+    expect(serialized).toContain("仅供说理思路参考，非法律依据");
+    expect(serialized).not.toContain("答案 1");
+  });
+});
+
+function judgmentFixture(): string {
+  return [
+    "广东省深圳市中级人民法院",
+    "民事判决书",
+    "（2024）粤03民终1234号",
+    "案由：劳动争议",
+    "上诉人某公司上诉请求：撤销一审判决。",
+    "本院经审理查明，双方签订三年期限劳动合同，并约定六个月试用期。",
+    "本院认为，案涉劳动合同约定六个月试用期，未超过法律规定上限。同一用人单位与同一劳动者只能约定一次试用期，双方未提交重复约定试用期的证据。故劳动者关于试用期违法的主张，本院不予支持。",
+    "判决如下：驳回上诉，维持原判。",
+    "二〇二四年五月十日",
+    "书记员 张某",
+  ].join("\n");
+}
+
+function createKnowledgeConfig(sqlitePath: string) {
+  return {
+    enabled: true,
+    autoDetect: { enabled: true, minConfidence: 0.75 },
+    query: { topK: 10, finalTopN: 3, keywordFallbackLimit: 10 },
+    storage: {
+      sqlitePath,
+      bitable: {
+        appToken: "app_token",
+        tableId: "tbl_entries",
+        documentTableId: "tbl_docs",
+      },
+    },
+    embeddingProvider: {
+      baseUrl: new URL("https://example.com/v1/"),
+      apiKey: "token",
+      model: "text-embedding",
+    },
+    models: {},
+    ingest: {
+      allowedExtensions: [".txt"],
+      maxFileSizeMb: 20,
+      pendingTtlMs: 600_000,
+      sessionIdleMs: 1_800_000,
+      concurrency: 3,
+      maxExtractChunks: 30,
+      maxExtractQas: 500,
+    },
+    judicialIngest: {
+      enabled: true,
+      batchEnabled: false,
+      sources: ["manual" as const],
+      batchSize: 20,
+    },
+  };
+}
+
+function createOpenCodeStub(requests: string[]) {
+  return {
+    async createSession(title: string) {
+      return { id: `ses_${title}`, title };
+    },
+    async deleteSession() {
+      return true;
+    },
+    async postMessageSync(_sessionId: string, request: { parts: Array<{ text?: string }> }) {
+      const prompt = request.parts[0]?.text ?? "";
+      requests.push(prompt);
+      if (prompt.includes("司法文书要旨提取助手")) {
+        return assistantMessage(JSON.stringify([{
+          issue: "试用期约定是否合法",
+          reasoning: "本院认为，案涉劳动合同约定六个月试用期，未超过法律规定上限。同一用人单位与同一劳动者只能约定一次试用期，双方未提交重复约定试用期的证据。故劳动者关于试用期违法的主张，本院不予支持。",
+          rule: "试用期不得超过法定上限，且同一用人单位只能约定一次试用期。",
+          outcome: "驳回上诉，维持原判。",
+          statutes: ["《劳动合同法》第 19 条"],
+          tags: ["劳动争议", "试用期"],
+          weight: "reference",
+        }]));
+      }
+      return assistantMessage(JSON.stringify([{ id: 1, score: 0.99 }]));
+    },
+  };
+}
+
+function assistantMessage(text: string) {
+  return {
+    info: {
+      id: "msg_1",
+      role: "assistant",
+      sessionID: "ses_1",
+      finish: "stop",
+      time: { created: Date.now(), completed: Date.now() },
+    },
+    parts: [{ id: "part_1", type: "text", text }],
+  };
+}
+
+function logger() {
+  return {
+    log() {},
+    logTranscript() {},
+  };
+}
+
+function stubEmbeddingFetch() {
+  vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+    data: [{
+      embedding: [0.1, 0.2, 0.3],
+    }],
+  }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  })) as typeof fetch);
+}

--- a/test/knowledge-detector.test.ts
+++ b/test/knowledge-detector.test.ts
@@ -34,6 +34,39 @@ describe("detectLegalQuestion", () => {
     expect(result.matched).toBe(false);
     expect(result.confidence).toBeLessThan(0.5);
   });
+
+  it("does not treat demo scripts with embedded legal examples as real questions", () => {
+    const result = detectLegalQuestion(`# 演示视频脚本·最终版
+**全程语音输入，不动手敲 | 时长：约 4 分钟**
+
+---
+
+## 第一幕：普通聊天（0:00 - 0:40）
+
+🎙 语音：
+> "你好，我是一名法务专员，今天有几件事情要处理"
+
+🎙 语音：
+> "劳动合同里的竞业限制条款，最长可以约定几年"
+
+AI 回复，普通问答卡片呈现，内容简洁。
+
+---
+
+## 第四幕：法律问答（1:35 - 2:10）
+
+🎙 语音：
+> "/法律问答 员工被口头辞退没有书面通知，算违法吗"
+
+AI 回复，卡片展示召回的法条来源。`);
+    expect(result.matched).toBe(false);
+    expect(result.reasons).toContain("meta-document");
+  });
+
+  it("keeps explicit legal question command text detectable outside script context", () => {
+    const result = detectLegalQuestion("法律问答 员工被口头辞退没有书面通知，算违法吗");
+    expect(result.matched).toBe(true);
+  });
 });
 
 describe("detectKnowledgeWebIngest", () => {

--- a/test/knowledge-service.test.ts
+++ b/test/knowledge-service.test.ts
@@ -3,7 +3,7 @@
  * 关注点: 验证核心路径、边界条件和回归场景。
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import PizZip from "pizzip";
@@ -1160,6 +1160,79 @@ describe("KnowledgeBaseService", () => {
     expect(stats?.entryCount).toBe(1);
     documents = await service.listDocuments?.({ limit: 10 });
     expect(documents?.some((item) => item.fileName === "经济补偿指引.pdf")).toBe(false);
+    service.close();
+  });
+
+  it("deletes exported Obsidian notes when their Bitable records are removed", async () => {
+    stubEmbeddingFetch();
+    const dir = mkdtempSync(join(tmpdir(), "knowledge-obsidian-delete-"));
+    tempDirs.push(dir);
+    const filePath = join(dir, "劳动合同.txt");
+    writeFileSync(filePath, "试用期最长不超过六个月。劳动合同期限不满三个月的，不得约定试用期。", "utf8");
+    const obsidianVault = join(dir, "vault");
+    const createdRecordIds: string[] = [];
+    let remoteRecords: Array<{ recordId: string; fields: Record<string, unknown> }> = [];
+    const service = new KnowledgeBaseService(
+      {
+        enabled: true,
+        autoDetect: { enabled: true, minConfidence: 0.75 },
+        query: { topK: 10, finalTopN: 3, keywordFallbackLimit: 10 },
+        storage: {
+          sqlitePath: join(dir, "knowledge.db"),
+          bitable: {
+            appToken: "app_token",
+            tableId: "tbl_entries",
+            documentTableId: "tbl_docs",
+          },
+        },
+        embeddingProvider: {
+          baseUrl: new URL("https://example.com/v1/"),
+          apiKey: "token",
+          model: "text-embedding",
+        },
+        models: {},
+        ingest: {
+          allowedExtensions: [".txt"],
+          maxFileSizeMb: 20,
+          pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 500,
+        },
+        obsidian: {
+          enabled: true,
+          vaultPath: obsidianVault,
+          baseDir: "knowledge",
+          enableWikiLinks: true,
+        },
+      },
+      {
+        async downloadMessageResource() {
+          throw new Error("not used");
+        },
+        async createBitableRecord(_appToken, tableId, fields) {
+          const recordId = `${tableId}_${createdRecordIds.length + 1}`;
+          createdRecordIds.push(recordId);
+          remoteRecords.push({ recordId, fields });
+          return recordId;
+        },
+        async listBitableRecords() {
+          return remoteRecords;
+        },
+      },
+      createOpenCodeStub(),
+      logger(),
+    );
+
+    await service.ingestLocalFile?.(filePath);
+    const document = await service.getDocument?.(1);
+    expect(document?.obsidianPath).toBeTruthy();
+    expect(existsSync(document!.obsidianPath!)).toBe(true);
+
+    remoteRecords = [];
+    await service.syncMirror();
+
+    expect(existsSync(document!.obsidianPath!)).toBe(false);
+    const stats = await service.getStats?.();
+    expect(stats?.documentCount).toBe(0);
+    expect(stats?.entryCount).toBe(0);
     service.close();
   });
 

--- a/test/knowledge-service.test.ts
+++ b/test/knowledge-service.test.ts
@@ -1891,6 +1891,80 @@ describe("KnowledgeBaseService", () => {
     service.close();
   });
 
+  it("treats maxExtractQas=0 as unlimited full ingest", async () => {
+    stubEmbeddingFetchSequence();
+    const dir = mkdtempSync(join(tmpdir(), "knowledge-unlimited-"));
+    tempDirs.push(dir);
+    const service = new KnowledgeBaseService(
+      {
+        enabled: true,
+        autoDetect: { enabled: false, minConfidence: 0.75 },
+        query: { topK: 10, finalTopN: 3, keywordFallbackLimit: 10 },
+        storage: {
+          sqlitePath: join(dir, "knowledge.db"),
+          bitable: {
+            appToken: "app_token",
+            tableId: "tbl_entries",
+            documentTableId: "tbl_docs",
+          },
+        },
+        embeddingProvider: {
+          baseUrl: new URL("https://example.com/v1/"),
+          apiKey: "token",
+          model: "text-embedding",
+        },
+        models: {},
+        ingest: {
+          allowedExtensions: [".txt"],
+          maxFileSizeMb: 20,
+          pendingTtlMs: 600_000, sessionIdleMs: 1_800_000, concurrency: 3, maxExtractChunks: 30, maxExtractQas: 0,
+        },
+      },
+      {
+        async downloadMessageResource() {
+          return {
+            fileName: "faq.txt",
+            mimeType: "text/plain",
+            buffer: Buffer.from([
+              "问：试用期最长多久？",
+              "答：最长不超过六个月。",
+              "",
+              "问：试用期工资可以低于最低工资吗？",
+              "答：不得低于本单位相同岗位最低档工资或者劳动合同约定工资的百分之八十，也不得低于最低工资标准。",
+              "",
+              "问：医疗期内能解除劳动合同吗？",
+              "答：一般不得解除。",
+              "",
+              "问：公司不续签要补偿吗？",
+              "答：符合条件的，应支付经济补偿。",
+              "",
+              "问：试用期可以随意辞退吗？",
+              "答：不可以，仍需符合法定条件。",
+            ].join("\n"), "utf8"),
+          };
+        },
+        async createBitableRecord(_appToken, tableId) {
+          return `${tableId}_${Date.now()}`;
+        },
+        async listBitableRecords() {
+          return [];
+        },
+      },
+      createOpenCodeStub(),
+      logger(),
+    );
+
+    const result = await service.ingestFile({
+      messageId: "om_file_unlimited",
+      fileKey: "file_unlimited",
+      fileName: "faq.txt",
+    });
+
+    expect(result.extractedCount).toBe(5);
+    expect(result.warning ?? "").not.toContain("已按质量评分保留前");
+    service.close();
+  });
+
   it("retries transient terminated errors during extraction", async () => {
     stubEmbeddingFetch();
     const dir = mkdtempSync(join(tmpdir(), "knowledge-"));


### PR DESCRIPTION
## 变更内容

- 新增司法文书 `case_digest` extractor，识别判决书/裁定书/仲裁裁决书并按争议焦点生成类案要旨。
- 知识库入库流程在通用 QA 抽取前优先分流司法文书，写入 `entry_type = case_digest`、`dedup_key` 与 `fields_json`。
- 法律问答卡片将类案参考与普通答案分区展示，明确“类案参考非法律依据”。
- 新增 `judicialIngest` 配置，并将 `maxExtractQas = 0` 解释为不限量入库。
- 更新司法文书入库 backlog 文档与配置快照测试。

## 变更原因

司法文书不适合按普通问答全文抽取。需要把“本院认为/裁判理由”和裁判结果压缩为可检索的类案摘要，同时保留案号、法院、争议焦点、裁判规则和去重 key，降低知识库噪声。

## 影响

- 用户侧：知识库查询结果会把类案结果放到独立“类案参考”区。
- 数据侧：同案同争议焦点通过 `dedup_key` 去重，避免重复入库。
- 配置侧：新增 `knowledgeBase.judicialIngest`，默认启用手动司法文书入库检测，批量外部来源仍默认关闭。

## 验证

- `npm test -- --run test/knowledge-case-digest.test.ts test/knowledge-service.test.ts test/formatter.test.ts test/config-loader.test.ts`
- `npm run lint`
- `npm run typecheck`
