### PR TITLE
[codex] 收口开发规范与启动预检

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,13 @@
 # Bridge Runtime Rules
 
+## Scope
+
+- This file defines the project and runtime contract for Feishu OpenCode Bridge.
+- Codex-specific development workflow, local commands, and implementation hygiene live in `CODEX.md`.
+- Keep runtime/product behavior here; keep coding-agent execution habits in `CODEX.md`.
+- When modifying this repository, read `CODEX.md` after this file.
+- Do not add local command lists, temporary debugging notes, personal workflow preferences, or one-off implementation plans here.
+
 ## Runtime Ownership
 
 - The bridge owns session control for `/new`, `/sessions`, `/switch`, and `/status`.
@@ -16,19 +24,6 @@
 - Do not simulate session creation, switching, closing, or renaming inside the agent response.
 - Treat bridge-injected system state as authoritative for the current window, active session, and visible sessions.
 - Long-term user facts may be injected into `system` as a `[Memory Recall]` block; treat them as stable background context, not current window state.
-
-## Feishu And Lark Operations
-
-- Use `lark-cli` only when the user explicitly asks to operate on Feishu or Lark resources.
-- When the user asks to operate on Feishu or Lark resources, prefer `lark-cli` and the installed `lark-*` skills over ad-hoc code exploration or custom bridge-side implementations.
-- Knowledge CLI fast path:
-  - When the user asks to query the knowledge base, do not search the codebase for the entrypoint.
-  - Go straight to `npm run --silent kb -- query --question "<问题>"`.
-  - For local file ingest, go straight to `npm run --silent kb -- ingest file --path "<绝对路径>"`.
-  - For URL ingest, go straight to `npm run --silent kb -- ingest url --url "<URL>"`.
-  - For PDF parsing diagnostics, go straight to `npm run --silent kb -- parse pdf --path "<绝对路径>"`.
-  - For knowledge-base diagnostics, go straight to `npm run --silent kb -- doctor`.
-  - Prefer the CLI entrypoint over repository exploration unless the user explicitly asks to inspect or modify the knowledge-base implementation.
 
 ## Architecture Guardrails
 
@@ -90,31 +85,12 @@
 - Knowledge-base flows and labor-dispute material generation keep their own module semantics. Contract-assistant skill routing must not hijack knowledge ingestion/query commands or labor-specific generation workflows unless those modules explicitly expose a shared routing contract.
 - New or changed skill routing must include fixtures and tests. Cover positive and negative samples, noisy OCR text, slash-command forced entry, natural language with recent uploaded material, natural language with local path, detector confidence, anti-signals, and prompt override loading.
 
-## Feature Checklist
-
-- Automated coverage currently enforced by CI:
-  - `npm run lint:deps` enforces core, transport, and formatter dependency boundaries
-  - `npm run check:formatter-exports` pins the formatter compatibility export surface
-  - `npm run lint` enforces the common config direct-read restrictions
-  - `npm run check:docs-diff` warns when seam files change without `docs/architecture-baseline.md`
-- Reviewer-only checks still matter:
-  - module boundary: new modules must enter through the runtime module assembly seam
-  - state boundary: avoid copying timer + JSON persistence patterns
-  - command boundary: each action keeps one primary command and at most one compatibility alias
-- High-frequency implementation rules:
-  - do not add business-specific branching to `src/runtime/app.ts`, `src/runtime/turn-executor.ts`, or `src/bridge/router.ts` unless the architecture baseline is updated first
-  - new cards should use the card family entrypoints: `shared-primitives`, `runtime-cards`, `knowledge-cards`, `labor-cards`, `contract-cards`
-  - if a feature changes a seam, update `docs/architecture-baseline.md` in the same PR before merge
-  - 代码注释默认使用中文，除非注释内容是外部 API 原文、协议字段、错误码或必须保持英文的术语
-  - 为新增的重要文件添加文件头注释，沿用项目现有的 `职责 / 关注点` 模板
-  - 为非显而易见的代码路径添加简洁注释，尤其是兼容逻辑、fallback 行为、并发/定时器处理、外部 API 特殊行为和跨模块契约
-  - 注释应解释代码为什么存在、保护什么不变量、或规避什么历史问题；不要添加逐行复述代码的低价值注释
-
 ## Documentation References
 
 - The active architecture contract lives in `docs/architecture-baseline.md`.
 - Post-freeze feature PRs should follow `docs/guidelines/new-feature-checklist.md`.
 - Built-in business extension development should follow `docs/guidelines/business-extension-development.md`.
+- Codex development workflow lives in `CODEX.md`.
 - Active documentation index lives in `docs/README.md`.
 - Observability event naming and fields live in `docs/observability/event-schema.md`.
 - Current docs layout:

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,98 @@
+# Codex 开发准则
+
+## 文件职责
+
+这个文件只约束 Codex 和其他 coding agent 如何修改本仓库。
+
+- 先读 `AGENTS.md`。它定义 Bridge 的运行时契约和架构边界。
+- 再读本文件。它定义开发流程、本地命令、检查清单和实现卫生。
+- 如果两者冲突：产品/运行时行为以 `AGENTS.md` 为准；代码修改方式以本文件为准。
+
+## 放置规则
+
+- 写进 `AGENTS.md`：Bridge 在飞书里的运行时所有权、用户可见行为、架构 guardrails、skill runtime 产品契约。
+- 写进 `CODEX.md`：Codex 如何搜索、实现、验证、操作 CLI、处理 dirty worktree 和维护注释。
+- 写进 `docs/`：长文设计、模块背景、架构解释、完整 checklist、历史记录和排障手册。
+- 不要把临时任务计划、一次性调试结论、个人偏好或未验证猜测写进 `AGENTS.md`。
+
+## 工作方式
+
+- 编辑前先理解现有 seam。优先用 `rg`、聚焦读文件和现行文档，不靠猜。
+- 改动保持手术刀式。除非任务要求，不重构邻近代码、不改名概念、不扩大 framework seam。
+- 尊重 dirty worktree。不要回滚用户改动，也不要清理无关生成物。
+- 不要在 `src/runtime/app.ts`、`src/runtime/turn-executor.ts`、`src/bridge/router.ts` 增加业务特定分支，除非同一改动更新架构基线。
+- 新能力应通过 runtime module、extension meta/runtime seam、shared service 或 workflow 专属模块进入。
+
+## Issue 规范
+
+- 新 issue 必须使用 `.github/ISSUE_TEMPLATE/` 下的模板，不开 blank issue。
+- Bug 使用 `bug_report.yml`，必须写清背景、问题、复现步骤、期望行为和影响范围；日志必须脱敏。
+- 新能力或增强使用 `feature_request.yml`，必须写清业务场景、期望行为、验收标准和非目标。
+- 技术债或重构使用 `tech_debt.yml`，必须写清源码依据、维护风险、建议方案、验收标准和非目标。
+- 文档问题使用 `docs.yml`，必须写清目标文档、当前误导点或缺口、期望内容和验收标准。
+- 安全问题不要开公开 issue，走 `.github/ISSUE_TEMPLATE/config.yml` 指向的 GitHub Security Advisory。
+- 涉及 architecture seam 的 issue，要引用 `docs/architecture-baseline.md` 或说明为什么不需要改架构基线。
+
+## PR 规范
+
+- PR 描述使用 `.github/PULL_REQUEST_TEMPLATE.md`，至少填写变更内容、变更原因、影响和验证。
+- 新功能 PR 应附上 `docs/guidelines/new-feature-checklist.md` 的自检结果。
+- 如果改了 framework seam、runtime module seam、transport、config、extension API 或观测事件，同一 PR 必须更新对应 docs。
+- PR 应保持一个清晰主题。不要把无关修复、格式化、文档搬迁和业务行为改动混进同一个 PR。
+- PR 验证区必须列出实际运行过的命令；没跑的检查要说明原因。
+- 用户可见行为、飞书卡片、命令输出、配置字段或迁移行为变化，要在 PR 影响区明确写出。
+- 发布相关 PR 要说明版本号、目标平台、artifact、回滚路径和人工验收结果。
+
+## Release 流程
+
+- release 前先跑：`npm run lint`、`npm run typecheck`、`npm test`。
+- 如果改了 dependency boundary、formatter export、docs seam，再补跑：`npm run lint:deps`、`npm run check:formatter-exports`、`npm run check:docs-diff`。
+- 先构建产物：`npm run build`。
+- 生成 portable 包：`npm run release:portable`。脚本输出到 `release/`，包名形如 `feishu-opencode-bridge-<platform>-<arch>.*`。
+- 发布 artifact 前确认包内包含 `dist/`、`scripts/runtime/`、启动器、配置样例和 README，不包含 `src/`。
+- 发布说明应覆盖：版本号、主要变化、兼容性/迁移说明、验证命令、已知风险、回滚方式。
+- portable 更新链路以 `scripts/runtime/update.mjs` 为准；下载、切换、回滚都必须显式触发，不覆盖用户数据目录。
+- 如果重新引入或升级原生依赖，按 `docs/deploy.md` 的目标环境要求，在 Linux x64 上重新验证 `npm ci`、`npm run build`、`npm test`。
+
+## 飞书、Lark 与知识库操作
+
+- 只有用户明确要求操作飞书或 Lark 资源时，才使用 `lark-cli`。
+- 操作飞书或 Lark 资源时，优先用 `lark-cli` 和已安装的 `lark-*` skills，不写临时脚本绕过。
+- 知识库 CLI fast path：
+  - 查询：`npm run --silent kb -- query --question "<问题>"`
+  - 本地文件入库：`npm run --silent kb -- ingest file --path "<绝对路径>"`
+  - URL 入库：`npm run --silent kb -- ingest url --url "<URL>"`
+  - PDF 解析诊断：`npm run --silent kb -- parse pdf --path "<绝对路径>"`
+  - 知识库诊断：`npm run --silent kb -- doctor`
+- 除非用户明确要求检查或修改知识库实现，否则优先使用这些 CLI 入口。
+
+## 实现规则
+
+- 配置改动必须经过 `src/config/schema.ts`、`src/config/loader.ts` 和模块配置注册表。
+- 新卡片应使用卡片家族入口：`shared-primitives`、`runtime-cards`、`knowledge-cards`、`labor-cards`、`contract-cards`。
+- runtime 和 transport 事件必须使用 `docs/observability/event-schema.md`，不要发明临时事件名。
+- 如果功能改变 architecture seam，合并前必须更新 `docs/architecture-baseline.md`。
+- 代码注释默认使用中文，除非注释内容是外部 API 原文、协议字段、错误码或必须保持英文的术语。
+- 为新增的重要文件添加文件头注释，沿用项目现有的 `职责 / 关注点` 模板。
+- 为非显而易见的代码路径添加简洁注释，尤其是兼容逻辑、fallback 行为、并发/定时器处理、外部 API 特殊行为和跨模块契约。
+- 注释应解释代码为什么存在、保护什么不变量、或规避什么历史问题；不要添加逐行复述代码的低价值注释。
+
+## 检查命令
+
+先跑最窄的相关检查，再按风险扩大范围。
+
+- `npm run lint`
+- `npm run typecheck`
+- `npm run lint:deps`
+- `npm run check:formatter-exports`
+- `npm run check:docs-diff`
+- 定向测试：`npm test -- <test-pattern>`
+- 触碰共享 runtime seam、transport、cards、config、extension loading 或跨模块行为时，跑完整测试：`npm test`
+
+## 文档入口
+
+- `docs/architecture-baseline.md`：现行架构契约。
+- `docs/guidelines/new-feature-checklist.md`：freeze 后新功能 PR 自检清单。
+- `docs/guidelines/business-extension-development.md`：内置业务扩展开发规范。
+- `docs/README.md`：现行文档索引。
+- `docs/observability/event-schema.md`：可观测性事件名和字段。

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ OpenCode turn 执行链抽象出 `prepareTurnExecution` / `handlePermissionAsked
 
 </details>
 
+</details>
+
 ## 💡 核心能力
 
 **会话窗口**：支持私聊、群聊、话题群的 session 绑定、切换、关闭、重命名

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,8 +4,13 @@
 
 查阅时请优先使用现行文档。归档文件只用于补充背景，不应覆盖当前生效的架构基线或规范。
 
-`AGENTS.md` 是面向 coding agent 和其他仓库感知型助手的高优先级执行指南。
-它适合承载高频、强约束的操作规则，例如 runtime ownership、GitHub 交付约定、issue 写作规则、架构 guardrails，以及 framework freeze 之后的新功能自检摘要。
+`AGENTS.md` 是面向 coding agent 和其他仓库感知型助手的项目/运行时契约入口。
+它只承载 Bridge runtime ownership、Feishu 输出约束、架构 guardrails、skill runtime 产品行为和现行文档索引。
+
+`CODEX.md` 是 Codex 的开发执行准则。
+它承载本地命令、知识库 CLI fast path、issue/PR/release 流程、实现卫生、注释要求和检查清单。
+新增规则时，先判断它是产品/运行时契约还是开发执行习惯，避免再次把两类内容混进同一个文件。
+
 当你需要这些规则背后的长文解释、设计理由、模块背景或历史上下文时，再进入 `docs/` 查阅。
 
 ## 当前入口
@@ -47,9 +52,10 @@
 
 ## 与 AGENTS 的关系
 
-- `AGENTS.md`：面向 agent 的精简高频操作规则。
+- `AGENTS.md`：项目/运行时契约，不放 Codex 工作流细节。
+- `CODEX.md`：Codex 开发执行准则、issue/PR/release 流程、常用命令和检查清单。
 - `docs/architecture-baseline.md`：补充 `AGENTS.md` 中架构 guardrails 背后的完整契约。
-- `docs/guidelines/new-feature-checklist.md`：补充 `AGENTS.md` 中新功能规则的完整清单。
+- `docs/guidelines/new-feature-checklist.md`：补充新功能规则的完整清单。
 - `docs/modules/*`：模块背景和设计说明，细节程度高于 `AGENTS.md`。
 - `docs/archive/*`：历史资料，只提供背景，不覆盖当前规则。
 

--- a/docs/observability/event-schema.md
+++ b/docs/observability/event-schema.md
@@ -36,6 +36,36 @@
 
 ## 事件名
 
+### `turn.checkpoint`
+
+在普通 turn 的关键阶段发出，用于拆分入站、模块判断、会话准备、OpenCode 请求和首帧延迟。
+
+必填字段：
+
+- `checkpoint`
+- `chatId`
+- `conversationKey`
+
+可选字段：
+
+- `turnId`
+- `sessionId`
+- `messageId`
+- `messageType`
+- `durationMs`
+- `claimed`
+- `eventType`
+- `replyLength`
+
+允许值：
+
+- `checkpoint`：`message_received`、`modules_finished`、`session_ready`、`prompt_async_accepted`、`first_opencode_event`、`first_text_delta`、`final_reply`
+
+触发点：
+
+- `BridgeApp` 收到消息、完成模块判断、准备好 session 时。
+- `TurnExecutor` 发送 OpenCode 请求、收到首个 OpenCode 事件、收到首个文本增量、收敛最终回复时。
+
 ### `turn.started`
 
 在排队中的 turn 开始执行时发出。
@@ -176,7 +206,7 @@
 
 允许值：
 
-- `hook`：`handleMessage`、`beforeTurn`、`afterTurn`、`stop`
+- `hook`：`handleMessage`、`claimFileInstruction`、`beforeTurn`、`afterTurn`、`handleCardAction`、`stop`
 - `result`：`claimed`、`ignored`、`completed`
 
 触发点：

--- a/src/runtime/preflight.ts
+++ b/src/runtime/preflight.ts
@@ -30,7 +30,15 @@ export async function runStartupPreflight(
   });
 
   await runCheck("飞书鉴权", report, async () => {
-    await feishu.getTenantToken();
+    try {
+      await feishu.getTenantToken();
+    } catch (error) {
+      if (isTransientNetworkError(error)) {
+        report(`跳过 飞书鉴权：${formatErrorDetail(error)}。运行中会在连接和发送消息时重试。`);
+        return;
+      }
+      throw error;
+    }
   });
 
   await runCheck("OpenCode 健康检查", report, async () => {
@@ -76,6 +84,19 @@ async function runCheck(name: string, report: ReportFn, fn: () => Promise<void>)
     throw new Error(`启动检查失败：${name} · ${detail}`);
   }
   report(`已通过 ${name}`);
+}
+
+function isTransientNetworkError(error: unknown): boolean {
+  const detail = formatErrorDetail(error);
+  return /fetch failed|network|ECONNRESET|ECONNREFUSED|ENOTFOUND|EAI_AGAIN|ETIMEDOUT|timeout|socket|TLS|certificate/i.test(detail);
+}
+
+function formatErrorDetail(error: unknown): string {
+  if (error instanceof Error) {
+    const cause = error.cause instanceof Error ? `: ${error.cause.message}` : "";
+    return `${error.message}${cause}`;
+  }
+  return String(error);
 }
 
 /** 检查目标目录当前是否具备可读写权限。 */

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -109,6 +109,20 @@ describe("runStartupPreflight", () => {
     }, () => {})).rejects.toThrow(/飞书鉴权/i);
   });
 
+  it("continues when Feishu token preflight hits a transient network error", async () => {
+    stubHealthyFetch();
+
+    const report = vi.fn();
+    await expect(runStartupPreflight(baseConfig(), {
+      getTenantToken: async () => {
+        throw new TypeError("fetch failed");
+      },
+    }, report)).resolves.toBeUndefined();
+
+    expect(report).toHaveBeenCalledWith(expect.stringContaining("跳过 飞书鉴权"));
+    expect(report).toHaveBeenCalledWith("已通过 飞书鉴权");
+  });
+
   it("fails when OpenCode is unavailable", async () => {
     vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();


### PR DESCRIPTION
## 变更内容

- 新增 `CODEX.md`，把 Codex 开发执行准则从 `AGENTS.md` 中拆出，`AGENTS.md` 保持项目/运行时契约定位。
- 修复 README 项目动态中 `0.2.0` 历史折叠块未闭合导致后续内容全部折叠的问题。
- 补充 `turn.checkpoint` observability 事件规范，并扩展 module hook 枚举。
- 放宽启动 preflight 中飞书 token 获取的瞬时网络错误，改为提示跳过并交给运行期重试。

## 变更原因

当前 `AGENTS.md` 同时承载运行时契约和 Codex 开发流程，容易混淆规则职责；README 折叠块也影响项目首页阅读。preflight 方面，启动时网络偶发失败不应阻断后续本地检查和运行期重试。

## 影响

- 文档侧：入口职责更清晰，README 展示恢复正常。
- 运行时：飞书鉴权遇到 `fetch failed` 等瞬时网络错误时不再直接启动失败。
- 可观测性：turn checkpoint 事件字段有正式文档锚点。

## 验证

- `npm test -- --run test/preflight.test.ts`
- `npm run lint`
- `npm run typecheck`
