### PR TITLE
[codex] 收口案件工作台上下文与输入兼容

### DIFF
--- a/src/bridge/router.ts
+++ b/src/bridge/router.ts
@@ -42,6 +42,9 @@ export function routeIncomingText(text: string): RoutedText {
   if (!normalized.startsWith("/")) {
     return { kind: "message", text };
   }
+  if (normalized.includes("\n")) {
+    return { kind: "message", text };
+  }
 
   const parts = normalized.split(/\s+/);
   const rawCommand = parts[0]?.slice(1) ?? "";

--- a/src/case-workbench/context-store.ts
+++ b/src/case-workbench/context-store.ts
@@ -1,0 +1,172 @@
+/**
+ * 职责: 保存案件工作台可召回上下文。
+ * 关注点:
+ * - 为普通 OpenCode 对话提供最近案件分析结果。
+ * - 按用户和会话维度查找当前案件，避免跨人串案。
+ * - 仅保存业务摘要与工作台 Markdown，不负责执行领域分析。
+ */
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { Logger } from "../logging/logger.js";
+
+export type CaseWorkbenchContext = {
+  caseId: string;
+  title: string;
+  userId: string;
+  chatId: string;
+  conversationKey: string;
+  source: "labor";
+  docUrl?: string | undefined;
+  markdown: string;
+  summary?: string | undefined;
+  issues: string[];
+  claimBasis: string[];
+  evidence: string[];
+  missingEvidence: string[];
+  updatedAt: number;
+};
+
+type StoreFile = {
+  version: 1;
+  contexts: CaseWorkbenchContext[];
+};
+
+const MAX_CONTEXTS = 50;
+const MAX_MARKDOWN_LENGTH = 120_000;
+const CONTEXT_TTL_MS = 14 * 24 * 60 * 60 * 1000;
+
+export class CaseWorkbenchContextStore {
+  private contexts = new Map<string, CaseWorkbenchContext>();
+  private dirty = false;
+  private persistTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    private readonly dataDir: string,
+    private readonly logger: Logger,
+  ) {}
+
+  private get filePath(): string {
+    return path.join(this.dataDir, "case-workbench-contexts.json");
+  }
+
+  async restore(): Promise<void> {
+    try {
+      const raw = await readFile(this.filePath, "utf8");
+      const parsed = JSON.parse(raw) as StoreFile;
+      if (parsed.version !== 1 || !Array.isArray(parsed.contexts)) {
+        return;
+      }
+      const now = Date.now();
+      for (const context of parsed.contexts) {
+        if (now - context.updatedAt <= CONTEXT_TTL_MS) {
+          this.contexts.set(context.caseId, normalizeContext(context));
+        }
+      }
+      this.logger.log("case-workbench/context", "restored case contexts", {
+        count: this.contexts.size,
+      });
+    } catch {
+      // 首次启动或旧文件损坏时不阻断运行。
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.persistTimer) {
+      clearTimeout(this.persistTimer);
+      this.persistTimer = null;
+    }
+    await this.flush();
+  }
+
+  async flush(): Promise<void> {
+    if (this.dirty) {
+      await this.persist();
+    }
+  }
+
+  upsert(context: CaseWorkbenchContext): void {
+    this.contexts.set(context.caseId, normalizeContext(context));
+    this.schedulePersist();
+  }
+
+  findRecent(input: {
+    userId: string;
+    conversationKey?: string | undefined;
+    chatId?: string | undefined;
+  }): CaseWorkbenchContext | null {
+    const candidates = [...this.contexts.values()]
+      .filter((context) => context.userId === input.userId)
+      .filter((context) => !input.conversationKey || context.conversationKey === input.conversationKey || context.chatId === input.chatId)
+      .sort((left, right) => right.updatedAt - left.updatedAt);
+    return candidates[0] ?? null;
+  }
+
+  private schedulePersist(): void {
+    this.dirty = true;
+    if (this.persistTimer) {
+      return;
+    }
+    this.persistTimer = setTimeout(() => {
+      this.persistTimer = null;
+      void this.persist();
+    }, 1000);
+  }
+
+  private async persist(): Promise<void> {
+    try {
+      await mkdir(this.dataDir, { recursive: true });
+      const contexts = [...this.contexts.values()]
+        .sort((left, right) => right.updatedAt - left.updatedAt)
+        .slice(0, MAX_CONTEXTS);
+      await writeFile(this.filePath, JSON.stringify({ version: 1, contexts } satisfies StoreFile, null, 2), "utf8");
+      this.dirty = false;
+    } catch (error) {
+      this.logger.log("case-workbench/context", "persist failed", {
+        detail: error instanceof Error ? error.message : String(error),
+      }, "warn");
+    }
+  }
+}
+
+export function renderCaseWorkbenchContextBlock(context: CaseWorkbenchContext): string {
+  return [
+    "[Current Case Workbench Context]",
+    `案件ID：${context.caseId}`,
+    `案件标题：${context.title}`,
+    context.docUrl ? `工作台文档：${context.docUrl}` : "",
+    context.summary ? `案件摘要：${context.summary}` : "",
+    "",
+    "争议焦点：",
+    ...formatList(context.issues),
+    "",
+    "请求权基础：",
+    ...formatList(context.claimBasis),
+    "",
+    "证据清单：",
+    ...formatList(context.evidence),
+    "",
+    "待补材料：",
+    ...formatList(context.missingEvidence),
+    "",
+    "工作台正文：",
+    context.markdown.slice(0, MAX_MARKDOWN_LENGTH),
+    "",
+    "使用要求：用户提到当前案件、刚才的工作台、案件分析结果或要求生成仲裁申请书/证据目录/代理意见时，优先基于以上工作台内容回答；不要臆造工作台没有的事实、金额或证据。",
+  ].filter((line) => line !== "").join("\n");
+}
+
+function normalizeContext(context: CaseWorkbenchContext): CaseWorkbenchContext {
+  return {
+    ...context,
+    markdown: context.markdown.slice(0, MAX_MARKDOWN_LENGTH),
+    issues: context.issues.filter(Boolean).slice(0, 12),
+    claimBasis: context.claimBasis.filter(Boolean).slice(0, 12),
+    evidence: context.evidence.filter(Boolean).slice(0, 20),
+    missingEvidence: context.missingEvidence.filter(Boolean).slice(0, 12),
+  };
+}
+
+function formatList(items: string[]): string[] {
+  return items.length > 0 ? items.map((item) => `- ${item}`) : ["- 暂无"];
+}

--- a/src/case-workbench/feishu-doc-reader.ts
+++ b/src/case-workbench/feishu-doc-reader.ts
@@ -1,0 +1,122 @@
+/**
+ * 职责: 读取普通对话中引用的飞书云文档。
+ * 关注点:
+ * - 通过 lark-cli 复用本机已有飞书认证与文档读取能力。
+ * - 将引用文档转换为可注入 OpenCode 的轻量上下文块。
+ * - 失败时降级为空上下文，不阻断普通对话。
+ */
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import type { Logger } from "../logging/logger.js";
+
+const execFileAsync = promisify(execFile);
+const MAX_REFERENCED_DOCS = 2;
+const MAX_DOC_TEXT_LENGTH = 50_000;
+
+export async function readReferencedFeishuDocuments(text: string, logger: Logger): Promise<string[]> {
+  const urls = extractFeishuDocumentUrls(text).slice(0, MAX_REFERENCED_DOCS);
+  if (urls.length === 0) {
+    return [];
+  }
+  const blocks: string[] = [];
+  for (const url of urls) {
+    const content = await fetchFeishuDocument(url, logger);
+    if (!content) {
+      continue;
+    }
+    blocks.push(renderReferencedFeishuDocumentBlock(url, content));
+  }
+  return blocks;
+}
+
+function extractFeishuDocumentUrls(text: string): string[] {
+  const candidates = text.match(/https?:\/\/[^\s<>"'）)]+/g) ?? [];
+  const seen = new Set<string>();
+  const urls: string[] = [];
+  for (const candidate of candidates) {
+    const url = candidate.replace(/[，。；、,.!?！？]+$/g, "");
+    if (!/\/\/(?:[a-z0-9-]+\.)?(?:feishu|larksuite)\.cn\//i.test(url)) {
+      continue;
+    }
+    if (!/(?:\/docx?\/|\/wiki\/|\/docs\/|\/file\/)/i.test(url)) {
+      continue;
+    }
+    if (!seen.has(url)) {
+      seen.add(url);
+      urls.push(url);
+    }
+  }
+  return urls;
+}
+
+async function fetchFeishuDocument(url: string, logger: Logger): Promise<string | null> {
+  const args = ["docs", "+fetch", "--api-version", "v2", "--doc", url, "--format", "json"];
+  try {
+    const { stdout } = await execFileAsync("lark-cli", args, {
+      maxBuffer: 10 * 1024 * 1024,
+      timeout: 60_000,
+    });
+    return normalizeFetchedDocument(stdout);
+  } catch (error) {
+    logger.log("case-workbench/context", "referenced feishu document fetch failed", {
+      url,
+      detail: error instanceof Error ? error.message : String(error),
+    }, "warn");
+    return null;
+  }
+}
+
+function normalizeFetchedDocument(stdout: string): string | null {
+  const trimmed = stdout.trim();
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    const text = extractTextFromJson(parsed);
+    return text ? text.slice(0, MAX_DOC_TEXT_LENGTH) : trimmed.slice(0, MAX_DOC_TEXT_LENGTH);
+  } catch {
+    return trimmed.slice(0, MAX_DOC_TEXT_LENGTH);
+  }
+}
+
+function extractTextFromJson(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(extractTextFromJson).filter(Boolean).join("\n");
+  }
+  if (!value || typeof value !== "object") {
+    return "";
+  }
+  const record = value as Record<string, unknown>;
+  const preferred = [
+    record["content"],
+    record["markdown"],
+    record["xml"],
+    record["text"],
+    record["docx_xml"],
+    record["data"],
+  ].map(extractTextFromJson).filter(Boolean);
+  if (preferred.length > 0) {
+    return preferred.join("\n");
+  }
+  return Object.entries(record)
+    .filter(([key]) => !["url", "token", "id"].includes(key))
+    .map(([, item]) => extractTextFromJson(item))
+    .filter(Boolean)
+    .join("\n");
+}
+
+function renderReferencedFeishuDocumentBlock(url: string, content: string): string {
+  return [
+    "[Referenced Feishu Document]",
+    `来源：${url}`,
+    "",
+    content,
+    "",
+    "使用要求：如果用户要求根据该模板生成材料，请优先遵循此文档的结构、标题和措辞风格；不要把模板中的示例事实当作当前案件事实。",
+  ].join("\n");
+}

--- a/src/case-workbench/runtime-module.ts
+++ b/src/case-workbench/runtime-module.ts
@@ -11,6 +11,8 @@ import { buildNoticeCardPayload } from "../feishu/shared-primitives.js";
 import { createTextPreview, type Logger } from "../logging/logger.js";
 import type { IncomingChatMessage } from "../runtime/app.js";
 import type { FeishuTransport } from "../runtime/feishu-transport.js";
+import { renderCaseWorkbenchContextBlock, type CaseWorkbenchContextStore } from "./context-store.js";
+import { readReferencedFeishuDocuments } from "./feishu-doc-reader.js";
 
 export type CaseWorkbenchLaborPort = {
   startCaseWorkbenchCollection(
@@ -24,15 +26,41 @@ type CaseWorkbenchRuntimeModuleDeps = {
   logger: Logger;
   transport: FeishuTransport;
   labor: CaseWorkbenchLaborPort;
+  contextStore?: CaseWorkbenchContextStore | undefined;
+  docReader?: ((text: string, logger: Logger) => Promise<string[]>) | undefined;
 };
-
-type CaseWorkbenchIntent = "labor" | "workbench" | null;
 
 export class CaseWorkbenchRuntimeModule implements RuntimeModule {
   readonly name = "case-workbench";
   readonly priority = 35;
 
   constructor(private readonly deps: CaseWorkbenchRuntimeModuleDeps) {}
+
+  async start(): Promise<void> {
+    await this.deps.contextStore?.restore();
+  }
+
+  async stop(): Promise<void> {
+    await this.deps.contextStore?.stop();
+  }
+
+  async beforeTurn(context: { turn: { plainText: string; senderOpenId: string; conversationKey: string; chatId: string } }): Promise<{ systemBlocks?: string[] } | void> {
+    const blocks: string[] = [];
+    const docReader = this.deps.docReader ?? readReferencedFeishuDocuments;
+    blocks.push(...await docReader(context.turn.plainText, this.deps.logger));
+
+    if (this.deps.contextStore && shouldRecallCaseContext(context.turn.plainText)) {
+      const current = this.deps.contextStore.findRecent({
+        userId: context.turn.senderOpenId,
+        conversationKey: context.turn.conversationKey,
+        chatId: context.turn.chatId,
+      });
+      if (current) {
+        blocks.push(renderCaseWorkbenchContextBlock(current));
+      }
+    }
+    return blocks.length > 0 ? { systemBlocks: blocks } : undefined;
+  }
 
   async handleMessage(context: RuntimeModuleMessageContext): Promise<RuntimeModuleHandleResult> {
     const { message, routed } = context;
@@ -48,21 +76,11 @@ export class CaseWorkbenchRuntimeModule implements RuntimeModule {
         .filter((argument) => argument.trim() !== "新建" && argument.trim().toLowerCase() !== "new")
         .join(" ")
         .trim() || undefined;
-      await this.startLaborFastPath(message, title);
+      await this.sendWorkbenchEntryCard(message, title);
       return { claimed: true };
     }
 
-    const intent = detectCaseWorkbenchIntent(message.plainText);
-    if (!intent) {
-      return { claimed: false };
-    }
-    if (intent === "labor") {
-      await this.startLaborFastPath(message, extractCaseWorkbenchTitle(message.plainText));
-      return { claimed: true };
-    }
-
-    await this.sendWorkbenchEntryCard(message);
-    return { claimed: true };
+    return { claimed: false };
   }
 
   async handleCardAction(
@@ -92,6 +110,7 @@ export class CaseWorkbenchRuntimeModule implements RuntimeModule {
     const chatId = typeof value.chatId === "string" ? value.chatId : "";
     const conversationKey = typeof value.conversationKey === "string" ? value.conversationKey : "";
     const chatType = typeof value.chatType === "string" ? value.chatType : "group";
+    const title = typeof value.title === "string" && value.title.trim() ? value.title.trim() : undefined;
     if (!chatId || !conversationKey) {
       return buildCaseWorkbenchToast("入口卡片缺少上下文，请重新发送 /案件工作台。", "warning");
     }
@@ -102,23 +121,14 @@ export class CaseWorkbenchRuntimeModule implements RuntimeModule {
       openMessageId,
       conversationKey,
       actorOpenId,
+      title,
     });
     return buildCaseWorkbenchToast("已进入材料收集。", "success");
   }
 
-  private async startLaborFastPath(
-    message: Pick<IncomingChatMessage, "chatId" | "chatType" | "messageId" | "conversationKey" | "senderOpenId">,
-    title?: string | undefined,
-  ): Promise<void> {
-    this.deps.logger.log("case-workbench/runtime", "case workbench fast-path to labor", {
-      conversationKey: message.conversationKey,
-      hasTitle: Boolean(title),
-    });
-    await this.deps.labor.startCaseWorkbenchCollection(message, title);
-  }
-
   private async sendWorkbenchEntryCard(
     message: Pick<IncomingChatMessage, "chatId" | "chatType" | "messageId" | "conversationKey" | "senderOpenId">,
+    title?: string | undefined,
   ): Promise<void> {
     const payload = buildCaseWorkbenchPayload({
       domains: ["劳动争议分析"],
@@ -126,6 +136,7 @@ export class CaseWorkbenchRuntimeModule implements RuntimeModule {
       chatType: message.chatType,
       conversationKey: message.conversationKey,
       requesterOpenId: message.senderOpenId,
+      title,
     });
     await this.deps.transport.sendPayload(message.chatId, payload, {
       event: "case workbench entry sent",
@@ -141,6 +152,7 @@ export class CaseWorkbenchRuntimeModule implements RuntimeModule {
     openMessageId: string;
     conversationKey: string;
     actorOpenId: string;
+    title?: string | undefined;
   }): void {
     setTimeout(() => {
       void (async () => {
@@ -160,13 +172,18 @@ export class CaseWorkbenchRuntimeModule implements RuntimeModule {
         } catch (error) {
           this.logCardUpdateFailure(error);
         } finally {
-          await this.deps.labor.startCaseWorkbenchCollection({
+          const collectionMessage = {
             chatId: input.chatId,
             chatType: input.chatType,
             messageId: input.openMessageId,
             conversationKey: input.conversationKey,
             senderOpenId: input.actorOpenId,
-          });
+          };
+          if (input.title) {
+            await this.deps.labor.startCaseWorkbenchCollection(collectionMessage, input.title);
+          } else {
+            await this.deps.labor.startCaseWorkbenchCollection(collectionMessage);
+          }
         }
       })();
     }, 0);
@@ -207,30 +224,15 @@ function chatIdFromValue(value: Record<string, unknown>): string {
   return typeof value.chatId === "string" ? value.chatId : "";
 }
 
-function detectCaseWorkbenchIntent(text: string): CaseWorkbenchIntent {
-  const normalized = text.replace(/\s+/g, " ").trim().toLowerCase();
-  if (!normalized || /(不要|不用|先别|取消).{0,8}(工作台|分析|整理|生成)/.test(normalized)) {
-    return null;
+function shouldRecallCaseContext(text: string): boolean {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return false;
   }
-  const hasLaborDomain = /(劳动|仲裁|工资|加班|工伤|社保|解除|辞退|离职|赔偿|补偿|用人单位|员工)/.test(normalized);
-  const hasLaborWorkflowNoun = /(劳动分析|劳动争议工作台|劳动仲裁材料|劳动.{0,8}(材料|证据|工作台|证据链)|仲裁材料|证据链|工作台)/.test(normalized);
-  const hasProductionAction = /(做|整理|梳理|生成|输出|形成|编写|起草|录入)/.test(normalized);
-  if (hasLaborDomain && hasLaborWorkflowNoun && (hasProductionAction || /劳动分析|工作台|证据链/.test(normalized))) {
-    return "labor";
-  }
-  const hasCaseWorkbench = /(案件工作台|办案工作台|新建案子|新建案件|打开工作台|进入工作台)/.test(normalized);
-  if (hasCaseWorkbench) {
-    return "workbench";
-  }
-  return null;
-}
-
-function extractCaseWorkbenchTitle(text: string): string | undefined {
-  const normalized = text
-    .replace(/[，。；、,.!?！？]/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-  return normalized.length > 6 ? normalized.slice(0, 60) : undefined;
+  const refersCurrentCase = /(当前|这个|该|刚才|上面|前面).{0,12}(案件|案子|工作台|分析结果|材料|证据)/.test(normalized)
+    || /(案件分析结果|工作台结果|劳动分析结果)/.test(normalized);
+  const asksCaseOutput = /(仲裁申请书|起诉状|证据目录|证据清单|代理意见|答辩状|质证意见|文书|补证|诉请|请求事项)/.test(normalized);
+  return refersCurrentCase || asksCaseOutput;
 }
 
 function buildCaseWorkbenchToast(content: string, type: "success" | "warning"): Record<string, unknown> {

--- a/src/contract-assistant/runtime-module.ts
+++ b/src/contract-assistant/runtime-module.ts
@@ -40,7 +40,6 @@ import type {
   ContractClause,
   ContractAssistantFileInput,
   ContractAssistantFileRef,
-  ContractAssistantIntentResult,
   ContractState,
   ContractWorkbenchModelResult,
   InvoiceRecognizeProgressEvent,
@@ -98,14 +97,6 @@ type PendingUploadInteraction = {
   expiresAt: number;
 };
 
-type RecentMaterialEntry = {
-  kind: PendingUploadKind;
-  conversationKey: string;
-  requesterOpenId: string;
-  file: ContractAssistantFileRef;
-  expiresAt: number;
-};
-
 type PendingDraftInteraction = {
   kind: "contract-draft-onboard";
   chatId: string;
@@ -133,7 +124,6 @@ type PendingInteraction = PendingUploadInteraction | PendingDraftInteraction | P
 
 const CONTRACT_EXTRACT_COMMAND_ALIASES = new Set(["contract-extract", "合同录入"]);
 const INVOICE_RECOGNIZE_COMMAND_ALIASES = new Set(["invoice-recognize", "识别发票"]);
-const SKILL_INTENT_CONFIDENCE_THRESHOLD = 0.72;
 
 export class ContractAssistantRuntimeModule implements RuntimeModule {
   readonly name = "contract-assistant";
@@ -141,7 +131,6 @@ export class ContractAssistantRuntimeModule implements RuntimeModule {
 
   private readonly interactions: PersistedInteractionManager<PendingInteraction>;
   private readonly featureConfig: ContractAssistantConfig;
-  private readonly recentMaterials = new Map<string, RecentMaterialEntry[]>();
 
   constructor(private readonly deps: ContractAssistantRuntimeModuleDeps) {
     this.featureConfig = deps.config.contractAssistant ?? DEFAULT_CONTRACT_ASSISTANT_CONFIG;
@@ -233,8 +222,6 @@ export class ContractAssistantRuntimeModule implements RuntimeModule {
       return { claimed: true };
     }
 
-    this.rememberRecentMaterial(message);
-
     if (pending && routed?.kind === "command" && isContractReentryCommand(routed.command, pending.kind)) {
       await this.sendNotice(message, {
         title: pending.kind === "contract-workbench" ? "已有合同起草会话" : "已有合同起草引导",
@@ -253,8 +240,7 @@ export class ContractAssistantRuntimeModule implements RuntimeModule {
     }
 
     if (!pending) {
-      const claimed = await this.handleNaturalLanguageIntent(message);
-      return { claimed };
+      return { claimed: false };
     }
 
     if (pending.kind === "contract-draft-onboard") {
@@ -278,8 +264,7 @@ export class ContractAssistantRuntimeModule implements RuntimeModule {
     if (message.messageType === "file" || message.senderOpenId !== pending.requesterOpenId) {
       return false;
     }
-    const forcedKind = detectPendingUploadKind(message.plainText);
-    const pendingKind = forcedKind ?? await this.classifyPendingUploadKind(message.plainText, pending.file.fileName);
+    const pendingKind = detectPendingUploadKind(message.plainText);
     if (!pendingKind) {
       return false;
     }
@@ -556,152 +541,6 @@ export class ContractAssistantRuntimeModule implements RuntimeModule {
     return true;
   }
 
-  private async handleNaturalLanguageIntent(message: IncomingChatMessage): Promise<boolean> {
-    if (message.messageType === "file" || message.messageType === "image" || !this.featureConfig.enabled || !this.deps.service) {
-      return false;
-    }
-    const text = message.plainText.trim();
-    if (!text || looksLikeKnowledgeOrLaborRequest(text)) {
-      return false;
-    }
-    if (isCaseWorkbenchEntrypoint(text)) {
-      return false;
-    }
-    if (isCaseTodoQuery(text)) {
-      await this.handleCaseTodos(message, text);
-      return true;
-    }
-    const localInvoiceFiles = await this.resolveLocalInvoiceFilesFromText(text);
-    if (localInvoiceFiles.length > 0) {
-      if (localInvoiceFiles.length === 1) {
-        await this.handleInvoiceRecognize(message, buildLocalContractFileInput(localInvoiceFiles[0]!));
-      } else {
-        await this.handleInvoiceRecognizeBatch(message, localInvoiceFiles.map(buildLocalContractFileInput));
-      }
-      return true;
-    }
-    const recentInvoice = this.findRecentMaterial(message, "invoice-recognize");
-    if (recentInvoice && isInvoiceActionRequest(text)) {
-      await this.handleInvoiceRecognize(message, recentInvoice.file);
-      return true;
-    }
-    if (isExactInvoiceStart(text)) {
-      await this.startPendingUpload(message, "invoice-recognize", "请直接上传 1 份发票文件，我会识别字段并写入发票记录。");
-      return true;
-    }
-    const localPath = extractLocalPath(text) ?? undefined;
-    const intent = await this.classifyIntentSafely({
-      userText: text,
-      localPath,
-      hasRecentFile: Boolean(localPath || recentInvoice),
-    });
-    if (!isConfidentIntent(intent)) {
-      return false;
-    }
-    if (intent.skill === "invoice-recognize" || intent.skill === "contract-extract") {
-      if (!localPath) {
-        const recentFile = this.findRecentMaterial(message, intent.skill);
-        if (recentFile) {
-          if (intent.skill === "invoice-recognize") {
-            await this.handleInvoiceRecognize(message, recentFile.file);
-            return true;
-          }
-          await this.handleContractExtract(message, recentFile.file);
-          return true;
-        }
-        await this.startPendingUpload(
-          message,
-          intent.skill,
-          intent.skill === "invoice-recognize"
-            ? "我已识别到你想执行发票识别。请上传发票文件，或在同一句里提供本地文件路径；也可以用 `/识别发票` 强制进入发票识别。"
-            : "我已识别到你想执行合同录入。请上传合同文件，或在同一句里提供本地文件路径；也可以用 `/合同录入` 强制进入合同录入。",
-        );
-        return true;
-      }
-      const file = buildLocalContractFileInput(localPath);
-      if (intent.skill === "invoice-recognize") {
-        await this.handleInvoiceRecognize(message, file);
-        return true;
-      }
-      await this.handleContractExtract(message, file);
-      return true;
-    }
-    if (intent.skill === "case-manage") {
-      await this.handleCaseCreate(message, text);
-      return true;
-    }
-    if (intent.skill === "contract-draft") {
-      await this.handleContractDraft(message, text);
-      return true;
-    }
-    return false;
-  }
-
-  private rememberRecentMaterial(message: IncomingChatMessage): void {
-    if (message.messageType !== "file" && message.messageType !== "image") {
-      return;
-    }
-    const kind = this.isFileAcceptableFor("invoice-recognize", message.file.fileName)
-      ? "invoice-recognize"
-      : this.isFileAcceptableFor("contract-extract", message.file.fileName)
-        ? "contract-extract"
-        : null;
-    if (!kind) {
-      return;
-    }
-    const expiresAt = Date.now() + this.featureConfig.ingest.pendingTtlMs;
-    const entry: RecentMaterialEntry = {
-      kind,
-      conversationKey: message.conversationKey,
-      requesterOpenId: message.senderOpenId,
-      file: {
-        messageId: message.messageId,
-        fileKey: message.file.fileKey,
-        fileName: message.file.fileName,
-        size: message.file.size,
-      },
-      expiresAt,
-    };
-    const existing = this.recentMaterials.get(message.conversationKey) ?? [];
-    const next = [
-      entry,
-      ...existing.filter((item) => item.expiresAt > Date.now() && item.file.messageId !== message.messageId),
-    ].slice(0, 8);
-    this.recentMaterials.set(message.conversationKey, next);
-  }
-
-  private findRecentMaterial(
-    message: Pick<IncomingChatMessage, "conversationKey" | "senderOpenId">,
-    kind: PendingUploadKind,
-  ): RecentMaterialEntry | null {
-    const entries = this.recentMaterials.get(message.conversationKey) ?? [];
-    const now = Date.now();
-    const alive = entries.filter((entry) => entry.expiresAt > now);
-    if (alive.length !== entries.length) {
-      if (alive.length === 0) {
-        this.recentMaterials.delete(message.conversationKey);
-      } else {
-        this.recentMaterials.set(message.conversationKey, alive);
-      }
-    }
-    return alive.find((entry) => entry.kind === kind && entry.requesterOpenId === message.senderOpenId) ?? null;
-  }
-
-  private async classifyPendingUploadKind(text: string, fileName: string): Promise<PendingUploadKind | null> {
-    const intent = await this.classifyIntentSafely({
-      userText: text,
-      fileName,
-      hasRecentFile: true,
-    });
-    if (!isConfidentIntent(intent)) {
-      return null;
-    }
-    if (intent.skill === "invoice-recognize" || intent.skill === "contract-extract") {
-      return intent.skill;
-    }
-    return null;
-  }
-
   private async resolveLocalInvoiceFilesFromText(text: string): Promise<string[]> {
     if (!/(发票|票据)/.test(text) || !/(识别|录入|写入|填入|填写|处理)/.test(text)) {
       return [];
@@ -726,22 +565,6 @@ export class ContractAssistantRuntimeModule implements RuntimeModule {
       .filter((entry) => entry.isFile() && this.isFileAcceptableFor("invoice-recognize", entry.name))
       .map((entry) => path.join(candidatePath, entry.name))
       .sort((left, right) => path.basename(left).localeCompare(path.basename(right), "zh-Hans-CN"));
-  }
-
-  private async classifyIntentSafely(input: {
-    userText: string;
-    fileName?: string | undefined;
-    localPath?: string | undefined;
-    hasRecentFile?: boolean | undefined;
-  }): Promise<ContractAssistantIntentResult | null> {
-    try {
-      return await this.deps.service!.classifyIntent(input);
-    } catch (error) {
-      this.deps.logger.log("contract-assistant", "skill intent router skipped", {
-        detail: error instanceof Error ? error.message : String(error),
-      }, "warn");
-      return null;
-    }
   }
 
   private async startContractDraftOnboard(
@@ -2260,18 +2083,7 @@ function detectPendingUploadKind(text: string): PendingUploadKind | null {
       return "invoice-recognize";
     }
   }
-  const normalizedText = text.trim().replace(/^\/+/, "").toLowerCase();
-  if (CONTRACT_EXTRACT_COMMAND_ALIASES.has(normalizedText)) {
-    return "contract-extract";
-  }
-  if (INVOICE_RECOGNIZE_COMMAND_ALIASES.has(normalizedText)) {
-    return "invoice-recognize";
-  }
   return null;
-}
-
-function isConfidentIntent(intent: ContractAssistantIntentResult | null): intent is ContractAssistantIntentResult {
-  return Boolean(intent && intent.skill !== "none" && intent.confidence >= SKILL_INTENT_CONFIDENCE_THRESHOLD);
 }
 
 function extractLocalPath(text: string): string | null {
@@ -2314,47 +2126,6 @@ function buildLocalContractFileInput(localPath: string): ContractAssistantFileIn
 
 function getContractFileName(file: ContractAssistantFileInput): string {
   return file.fileName?.trim() || ("localPath" in file ? path.basename(file.localPath) : "上传文件");
-}
-
-function looksLikeKnowledgeOrLaborRequest(text: string): boolean {
-  const normalized = text.replace(/\s+/g, "");
-  return /(知识库|入库|检索知识|查询知识|劳动争议工作台|劳动案件工作台|证据链|生成材料|劳动分析)/.test(normalized);
-}
-
-function isCaseTodoQuery(text: string): boolean {
-  const normalized = text.replace(/\s+/g, "");
-  if (!/(待办|提醒|事项)/.test(normalized)) {
-    return false;
-  }
-  if (/(新增|录入|写入|添加|设置|更新|修改|改成|完成|删除)/.test(normalized)) {
-    return false;
-  }
-  return /(查看|查询|列出|看看|展示|今日|今天|案件)/.test(normalized);
-}
-
-function isCaseWorkbenchEntrypoint(text: string): boolean {
-  const normalized = text.replace(/\s+/g, "");
-  return /^(启动|打开|进入|开启)?(案件|办案)工作台$/.test(normalized)
-    || /^case-workbench$/i.test(text.trim());
-}
-
-function isExactInvoiceStart(text: string): boolean {
-  const normalized = text.trim().replace(/^\/+/, "").replace(/\s+/g, "");
-  return normalized === "发票识别" || normalized === "识别发票" || normalized.toLowerCase() === "invoice-recognize";
-}
-
-function isInvoiceActionRequest(text: string): boolean {
-  const normalized = text.replace(/\s+/g, "");
-  if (!/(发票|票据)/.test(normalized)) {
-    return false;
-  }
-  if (isExactInvoiceStart(text)) {
-    return true;
-  }
-  if (/(为什么|为何|原因|怎么回事|如何解决|能不能|可以吗|是否|吗[？?]?|[？?])/.test(normalized)) {
-    return false;
-  }
-  return /(识别|录入|录一下|写入|填入|填写|入账|记账|登记|处理)/.test(normalized);
 }
 
 function isInvoiceLedgerQuery(text: string): boolean {

--- a/src/extensions/definition.ts
+++ b/src/extensions/definition.ts
@@ -20,6 +20,7 @@ import type { CostTracker } from "../runtime/cost-tracker.js";
 import type { FeishuTransport } from "../runtime/feishu-transport.js";
 import type { SessionBindingRecord, SessionWindowRecord } from "../store/mappings.js";
 import type { WhitelistStore } from "../store/whitelist.js";
+import type { CaseWorkbenchContextStore } from "../case-workbench/context-store.js";
 
 export type RuntimeModuleOutboundPort = ExtensionOutboundPort;
 
@@ -41,6 +42,7 @@ export type RuntimeExtensionContext = {
   memory?: unknown;
   knowledge: KnowledgeBasePort | null;
   costTracker?: Pick<CostTracker, "recordExternalCall"> | undefined;
+  caseContextStore?: CaseWorkbenchContextStore | undefined;
   whitelist: Pick<WhitelistStore, "bind">;
   getSessionWindow(conversationKey: string, chatType?: string): SessionWindowRecord;
   saveSessionWindow(conversationKey: string, window: SessionWindowRecord): Promise<void>;

--- a/src/feishu/contract-cards.ts
+++ b/src/feishu/contract-cards.ts
@@ -43,6 +43,7 @@ export type CaseWorkbenchCardView = {
   chatType?: string | undefined;
   conversationKey?: string | undefined;
   requesterOpenId?: string | undefined;
+  title?: string | undefined;
 };
 
 export type CaseCreateProgressView = {
@@ -319,6 +320,7 @@ function buildCaseWorkbenchActionValue(view: CaseWorkbenchCardView, action: "sta
     chatType: view.chatType,
     conversationKey: view.conversationKey,
     requesterOpenId: view.requesterOpenId,
+    title: view.title,
   };
 }
 

--- a/src/feishu/designer-card-templates.ts
+++ b/src/feishu/designer-card-templates.ts
@@ -2299,7 +2299,7 @@ export const DESIGNER_CARD_TEMPLATES = {
       "elements": [
         {
           "tag": "markdown",
-          "content": "请上传劳动相关材料，直接发送到聊天窗口即可。",
+          "content": "请上传案件相关材料，直接发送到聊天窗口即可。",
           "text_align": "left",
           "text_size": "heading",
           "margin": "0px 0px 0px 0px"

--- a/src/feishu/ws.ts
+++ b/src/feishu/ws.ts
@@ -639,14 +639,6 @@ function parsePostMessage(rawContent: string, mentions: NormalizedMention[], bot
       for (const element of row) {
         if (!isRecord(element)) continue;
         const tag = typeof element.tag === "string" ? element.tag : "";
-        if (tag === "text" || tag === "a") {
-          const text = typeof element.text === "string" ? element.text : "";
-          if (text) {
-            rowParts.push(text);
-          }
-          continue;
-        }
-
         if (tag === "at") {
           hasAnyMention = true;
           const mention = {
@@ -660,6 +652,12 @@ function parsePostMessage(rawContent: string, mentions: NormalizedMention[], bot
             continue;
           }
           rowParts.push(formatVisibleMention(mention.name));
+          continue;
+        }
+
+        const text = extractPostElementText(element);
+        if (text) {
+          rowParts.push(text);
         }
       }
 
@@ -676,6 +674,54 @@ function parsePostMessage(rawContent: string, mentions: NormalizedMention[], bot
   } catch {
     return { plainText: "", hasAnyMention: false, hasExactBotMention: false };
   }
+}
+
+function extractPostElementText(value: unknown, seen = new Set<unknown>()): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (!value || typeof value !== "object" || seen.has(value)) {
+    return "";
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => extractPostElementText(item, seen))
+      .filter(Boolean)
+      .join("\n");
+  }
+
+  const record = value as Record<string, unknown>;
+  const tag = typeof record.tag === "string" ? record.tag : "";
+  if (tag === "img" || tag === "media") {
+    return "";
+  }
+
+  const directText = firstStringFromKeys(record, ["text", "un_escape", "href", "url"]);
+  const nestedText = firstTextFromKeys(record, ["content", "elements", "children", "lines"], seen);
+  return [directText, nestedText].filter(Boolean).join(nestedText ? "\n" : "");
+}
+
+function firstStringFromKeys(record: Record<string, unknown>, keys: string[]): string {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value;
+    }
+  }
+  return "";
+}
+
+function firstTextFromKeys(record: Record<string, unknown>, keys: string[], seen: Set<unknown>): string {
+  for (const key of keys) {
+    const value = record[key];
+    const text = extractPostElementText(value, seen);
+    if (text.trim()) {
+      return text;
+    }
+  }
+  return "";
 }
 
 function parseFileMessage(rawContent: string): TextParseResult {

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -33,6 +33,22 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === "object" ? value as Record<string, unknown> : null;
 }
 
+/** 将飞书可能传回的对象或 JSON 字符串统一成普通对象。 */
+function parseRecordLike(value: unknown): Record<string, unknown> | null {
+  const record = asRecord(value);
+  if (record) {
+    return record;
+  }
+  if (typeof value !== "string" || !value.trim()) {
+    return null;
+  }
+  try {
+    return asRecord(JSON.parse(value));
+  } catch {
+    return null;
+  }
+}
+
 /** 沿嵌套路径读取字符串字段。 */
 function readNestedString(value: unknown, ...path: string[]): string {
   let current: unknown = value;
@@ -81,7 +97,7 @@ export function normalizeCardActionCallback(event: unknown): NormalizedCardActio
 /** 优先读取标准 action.value；缺失时只查找权限按钮 value。 */
 function extractActionValue(event: unknown): Record<string, unknown> {
   const direct = asRecord(asRecord(event)?.action)?.value;
-  const directRecord = asRecord(direct);
+  const directRecord = parseRecordLike(direct);
   if (directRecord) {
     return directRecord;
   }
@@ -103,7 +119,7 @@ function findPermissionActionValue(value: unknown, depth: number): Record<string
     return null;
   }
 
-  const record = asRecord(value);
+  const record = parseRecordLike(value);
   if (!record) {
     return null;
   }

--- a/src/knowledge/runtime-module.ts
+++ b/src/knowledge/runtime-module.ts
@@ -24,7 +24,7 @@ import {
   type ToolUpdateView,
 } from "../feishu/shared-primitives.js";
 import { createTextPreview, type Logger, type TranscriptType } from "../logging/logger.js";
-import type { IncomingChatMessage, IncomingFileMessage } from "../runtime/app.js";
+import type { IncomingChatMessage } from "../runtime/app.js";
 import type { FeishuTransport } from "../runtime/feishu-transport.js";
 import {
   getActiveSession,
@@ -35,7 +35,7 @@ import {
 import type { SessionBindingRecord, SessionWindowRecord } from "../store/mappings.js";
 import { ActiveKnowledgeIngestStore, type ActiveKnowledgeIngestRecordMap } from "../store/active-ingests.js";
 import { routeIncomingText, type RoutedText } from "../bridge/router.js";
-import { detectKnowledgeMaterialIngestIntent, detectKnowledgeWebIngest, detectLegalQuestion } from "./detector.js";
+import { detectKnowledgeWebIngest } from "./detector.js";
 import {
   type KnowledgeBasePort,
   type KnowledgeIngestProgressStep,
@@ -87,23 +87,6 @@ type KnowledgeIngestSessionStats = {
   failures: Array<{ sourceFile: string; reason: string; elapsedMs?: number | undefined }>;
 };
 
-type RecentKnowledgeMaterial = {
-  chatId: string;
-  conversationKey: string;
-  requesterOpenId: string;
-  messageId: string;
-  fileKey: string;
-  fileName: string;
-  size?: number | undefined;
-  resourceType?: "file" | "image" | "folder" | undefined;
-  createdAt: number;
-};
-
-const KNOWLEDGE_INGEST_TEXT_PATTERN = /(^|[\s/])(?:kb-ingest-start|入库|导入|收录|加入知识库|添加到知识库|写入知识库|保存到知识库|放进知识库|同步到知识库)(?=$|\s)/i;
-const KNOWLEDGE_INGEST_START_TEXT_PATTERN = /^(?:知识入库|开始知识入库|开启知识入库|进入知识入库)$/;
-const KNOWLEDGE_INGEST_END_TEXT_PATTERN = /^(?:知识入库完成|知识入库结束|入库完成|结束入库)$/;
-const MAX_RECENT_KNOWLEDGE_MATERIALS = 10;
-
 type KnowledgeRuntimeModuleDeps = {
   config: AppConfig;
   logger: Logger;
@@ -127,7 +110,6 @@ export class KnowledgeRuntimeModule implements RuntimeModule {
   private readonly runningKnowledgeIngests = new Map<string, { requesterOpenId: string }>();
   private readonly knowledgeIngestQueues = new Map<string, KnowledgeIngestQueueState>();
   private readonly knowledgeIngestSessionStats = new Map<string, KnowledgeIngestSessionStats>();
-  private readonly recentKnowledgeMaterials = new Map<string, RecentKnowledgeMaterial[]>();
   private readonly timers = new Map<string, NodeJS.Timeout>();
 
   constructor(private readonly deps: KnowledgeRuntimeModuleDeps) {
@@ -158,18 +140,16 @@ export class KnowledgeRuntimeModule implements RuntimeModule {
       clearTimeout(timeout);
     }
     this.timers.clear();
-    this.recentKnowledgeMaterials.clear();
     this.deps.knowledge?.close();
   }
 
   /** 处理知识查询、知识入库和知识模式相关输入。 */
   async handleMessage(context: RuntimeModuleMessageContext): Promise<RuntimeModuleHandleResult> {
-    const { message, routed, pendingInteraction } = context;
+    const { message, routed } = context;
     const activeKnowledgeIngest = this.findKnowledgeIngestInteraction(message);
     if (activeKnowledgeIngest) {
       if (
-        (routed?.kind === "command" && routed.command.kind === "knowledge-ingest-end")
-        || matchesKnowledgeIngestEndInstruction(message.plainText)
+        routed?.kind === "command" && routed.command.kind === "knowledge-ingest-end"
       ) {
         await this.endKnowledgeIngestInteraction(message, activeKnowledgeIngest, { replyToMessageId: message.messageId });
         return { claimed: true };
@@ -189,44 +169,12 @@ export class KnowledgeRuntimeModule implements RuntimeModule {
       return { claimed: false };
     }
 
-    if (this.captureRecentKnowledgeMaterial(message)) {
-      return { claimed: false };
-    }
-
-    if (matchesKnowledgeIngestStartInstruction(message.plainText)) {
-      const claimed = await this.handleKnowledgeCommand(message, {
-        kind: "knowledge-ingest",
-      });
-      if (claimed) {
-        return { claimed: true };
-      }
-    }
-
-    const naturalKnowledgeQuestion = parseNaturalKnowledgeQuestion(message.plainText);
-    if (naturalKnowledgeQuestion) {
-      const claimed = await this.handleKnowledgeCommand(message, {
-        kind: "knowledge-query",
-        question: naturalKnowledgeQuestion,
-        explicit: true,
-      });
-      if (claimed) {
-        return { claimed: true };
-      }
-    }
-
     const backgroundKnowledgeIngest = this.getInteraction(message.conversationKey);
     if (backgroundKnowledgeIngest) {
       await this.restoreOrCreateNormalSessionForBackgroundIngest(message, backgroundKnowledgeIngest);
     }
 
-    if (await this.handleRecentMaterialIngestIntent(message)) {
-      return { claimed: true };
-    }
-
-    const claimed = pendingInteraction?.kind === "file-await-instruction"
-      ? false
-      : await this.handleKnowledgeQueryMessage(message);
-    return { claimed };
+    return { claimed: false };
   }
 
   async claimFileInstruction(
@@ -299,7 +247,7 @@ export class KnowledgeRuntimeModule implements RuntimeModule {
           template: "yellow",
           icon: "maybe_outlined",
           message: message.chatType === "p2p"
-            ? "私聊里不再使用 `/legal-query-start`。直接发送问题即可；如需批量入库，请使用 `/知识入库`。"
+            ? "私聊里不再使用 `/legal-query-start`。知识库问答请使用 `/法律问答 <问题>`；如需批量入库，请使用 `/知识入库`。"
             : "知识库模式入口已从 `/legal-query-start` 迁移到 `/法律咨询开始`。如需单次检索，也可以使用 `/法律问答 <问题>`。",
         });
         return true;
@@ -310,7 +258,7 @@ export class KnowledgeRuntimeModule implements RuntimeModule {
           template: "yellow",
           icon: "maybe_outlined",
           message: message.chatType === "p2p"
-            ? "私聊里不再使用 `/legal-query-end`。直接发送问题即可，不需要显式退出。"
+            ? "私聊里不再使用 `/legal-query-end`。知识库问答请使用 `/法律问答 <问题>`，不需要显式退出。"
             : "知识库模式退出命令已从 `/legal-query-end` 迁移到 `/法律咨询结束`。",
         });
         return true;
@@ -321,7 +269,7 @@ export class KnowledgeRuntimeModule implements RuntimeModule {
           template: "yellow",
           icon: "maybe_outlined",
           message: message.chatType === "p2p"
-            ? "私聊里不再使用 `/legal-query <问题>`。直接发送问题即可；如需强制走知识库查询，请使用 `/法律问答 <问题>`。"
+            ? "私聊里不再使用 `/legal-query <问题>`。知识库问答请使用 `/法律问答 <问题>`。"
             : "单次知识库检索已从 `/legal-query <问题>` 迁移到 `/法律问答 <问题>`；连续检索模式请使用 `/法律咨询开始`。",
         });
         return true;
@@ -345,7 +293,7 @@ export class KnowledgeRuntimeModule implements RuntimeModule {
         title: "私聊里直接提问即可",
         template: "blue",
         icon: "search_outlined",
-        message: "私聊不需要显式切换知识库模式。直接发送问题即可，由 OpenCode 自主决定是否使用知识库；如需批量入库，请使用 `/知识入库`。",
+        message: "私聊不需要显式切换知识库模式。知识库问答请使用 `/法律问答 <问题>`；如需批量入库，请使用 `/知识入库`。",
       });
       return true;
     }
@@ -464,8 +412,8 @@ export class KnowledgeRuntimeModule implements RuntimeModule {
           template: "blue",
           icon: "search_outlined",
           message: clearedIngestPending
-            ? "已退出知识入库模式；当前仍是知识库模式。接下来直接发送问题即可检索知识库，发送 `/法律咨询结束` 可退出。"
-            : "接下来直接发送问题即可检索知识库，发送 `/法律咨询结束` 可退出。",
+            ? "已退出知识入库模式；当前仍是知识库模式。请使用 `/法律问答 <问题>` 检索知识库，发送 `/法律咨询结束` 可退出。"
+            : "请使用 `/法律问答 <问题>` 检索知识库，发送 `/法律咨询结束` 可退出。",
         });
         return true;
       }
@@ -476,8 +424,8 @@ export class KnowledgeRuntimeModule implements RuntimeModule {
         template: "indigo",
         icon: "search_outlined",
         message: clearedIngestPending
-          ? "已退出知识入库模式，并切换到知识库查询模式。接下来直接发送问题即可检索知识库，发送 `/法律咨询结束` 可退出。"
-          : "接下来直接发送问题即可检索知识库，发送 `/法律咨询结束` 可退出。",
+          ? "已退出知识入库模式，并切换到知识库查询模式。请使用 `/法律问答 <问题>` 检索知识库，发送 `/法律咨询结束` 可退出。"
+          : "请使用 `/法律问答 <问题>` 检索知识库，发送 `/法律咨询结束` 可退出。",
       });
       return true;
     }
@@ -541,42 +489,6 @@ export class KnowledgeRuntimeModule implements RuntimeModule {
     await this.enqueueKnowledgeIngestInput(fileMessage, pending);
   }
 
-  private async startKnowledgeIngestFromRecentMaterials(
-    materials: RecentKnowledgeMaterial[],
-    message: IncomingChatMessage,
-  ): Promise<void> {
-    if (!this.deps.knowledge) {
-      await this.sendNotice(message, {
-        title: "知识库未启用",
-        template: "yellow",
-        icon: "maybe_outlined",
-        message: "当前未启用法律知识库，请联系部署者补充 knowledgeBase 配置。",
-      });
-      return;
-    }
-    const pending = await this.openKnowledgeIngestInteraction(message);
-    for (const material of materials) {
-      const fileMessage: IncomingChatMessage = {
-        ...message,
-        chatId: material.chatId,
-        conversationKey: material.conversationKey,
-        messageId: material.messageId,
-        rawContent: material.fileName,
-        plainText: material.fileName,
-        messageType: "file",
-        file: {
-          fileKey: material.fileKey,
-          fileName: material.fileName,
-          size: material.size,
-        },
-        resourceType: material.resourceType,
-      };
-      await this.enqueueKnowledgeIngestInput(fileMessage, pending);
-    }
-    this.clearRecentKnowledgeMaterials(message);
-    await this.endKnowledgeIngestInteraction(message, pending, { replyToMessageId: message.messageId });
-  }
-
   private async openKnowledgeIngestInteraction(
     message: Pick<IncomingChatMessage, "chatId" | "chatType" | "messageId" | "conversationKey" | "threadKey" | "senderOpenId">,
   ): Promise<PendingKnowledgeIngestInteraction> {
@@ -618,110 +530,6 @@ export class KnowledgeRuntimeModule implements RuntimeModule {
     return interaction;
   }
 
-  private async handleKnowledgeQueryMessage(message: IncomingChatMessage): Promise<boolean> {
-    if (message.messageType === "file" || !this.deps.knowledge) {
-      return false;
-    }
-
-    const window = this.deps.getSessionWindow(message.conversationKey, message.chatType);
-    const knowledgeModeDetection = window.interactionMode === "knowledge"
-      ? detectLegalQuestion(message.plainText)
-      : null;
-    if (
-      window.interactionMode === "knowledge"
-      && knowledgeModeDetection?.matched
-      && knowledgeModeDetection.confidence >= this.deps.config.knowledgeBase.autoDetect.minConfidence
-    ) {
-      try {
-        await this.sendKnowledgeQueryWithProgress(message, message.plainText);
-      } catch (error) {
-        const detail = error instanceof Error ? error.message : String(error);
-        await this.sendPayload(message.chatId, buildNoticeCardPayload({
-          title: "知识检索失败",
-          level: "error",
-        message: detail,
-        }), {
-          event: "knowledge query failed",
-          transcriptType: "outbound-final",
-          textPreview: detail,
-          len: detail.length,
-        }, { replyToMessageId: message.messageId });
-      }
-      return true;
-    }
-
-    if (!this.deps.config.knowledgeBase.autoDetect.enabled) {
-      return false;
-    }
-
-    const detection = detectLegalQuestion(message.plainText);
-    if (!detection.matched) {
-      return false;
-    }
-
-    try {
-      const result = await this.deps.knowledge.query(message.plainText);
-      if (result.results.length === 0) {
-        return false;
-      }
-      await this.sendKnowledgeQueryWithProgress(message, message.plainText, result);
-      return true;
-    } catch (error) {
-      this.deps.logger.log("knowledge/query", "auto-detect query failed", {
-        detail: error instanceof Error ? error.message : String(error),
-        confidence: detection.confidence,
-      }, "warn");
-      return false;
-    }
-  }
-
-  private captureRecentKnowledgeMaterial(message: IncomingChatMessage): boolean {
-    if (message.messageType !== "file" || !this.deps.knowledge) {
-      return false;
-    }
-    if (!this.isSupportedRecentKnowledgeMaterial(message)) {
-      return false;
-    }
-    const key = this.getRecentKnowledgeMaterialKey(message);
-    const expiresBefore = Date.now() - this.deps.config.knowledgeBase.ingest.pendingTtlMs;
-    const existing = (this.recentKnowledgeMaterials.get(key) ?? [])
-      .filter((item) => item.createdAt >= expiresBefore && item.messageId !== message.messageId);
-    existing.push({
-      chatId: message.chatId,
-      conversationKey: message.conversationKey,
-      requesterOpenId: message.senderOpenId,
-      messageId: message.messageId,
-      fileKey: message.file.fileKey,
-      fileName: message.file.fileName,
-      size: message.file.size,
-      resourceType: message.resourceType,
-      createdAt: Date.now(),
-    });
-    this.recentKnowledgeMaterials.set(key, existing.slice(-MAX_RECENT_KNOWLEDGE_MATERIALS));
-    return true;
-  }
-
-  private async handleRecentMaterialIngestIntent(message: IncomingChatMessage): Promise<boolean> {
-    if (message.messageType !== "text" || !this.deps.knowledge) {
-      return false;
-    }
-    const materials = this.getRecentKnowledgeMaterials(message);
-    if (materials.length === 0) {
-      return false;
-    }
-    const detection = detectKnowledgeMaterialIngestIntent(message.plainText);
-    if (!detection.matched) {
-      return false;
-    }
-    this.deps.logger.log("knowledge/ingest", "recent material ingest claimed", {
-      confidence: detection.confidence,
-      reasons: detection.reasons.join(","),
-      materialCount: materials.length,
-    });
-    await this.startKnowledgeIngestFromRecentMaterials(materials, message);
-    return true;
-  }
-
   private async sendKnowledgeQueryWithProgress(
     message: Pick<IncomingChatMessage, "chatId" | "messageId">,
     question: string,
@@ -754,40 +562,6 @@ export class KnowledgeRuntimeModule implements RuntimeModule {
         len: question.length,
       },
     );
-  }
-
-  private getRecentKnowledgeMaterials(message: Pick<IncomingChatMessage, "chatId" | "senderOpenId">): RecentKnowledgeMaterial[] {
-    const key = this.getRecentKnowledgeMaterialKey(message);
-    const expiresBefore = Date.now() - this.deps.config.knowledgeBase.ingest.pendingTtlMs;
-    const materials = (this.recentKnowledgeMaterials.get(key) ?? []).filter((item) => item.createdAt >= expiresBefore);
-    if (materials.length === 0) {
-      this.recentKnowledgeMaterials.delete(key);
-      return [];
-    }
-    this.recentKnowledgeMaterials.set(key, materials);
-    return materials;
-  }
-
-  private clearRecentKnowledgeMaterials(message: Pick<IncomingChatMessage, "chatId" | "senderOpenId">): void {
-    this.recentKnowledgeMaterials.delete(this.getRecentKnowledgeMaterialKey(message));
-  }
-
-  private getRecentKnowledgeMaterialKey(message: Pick<IncomingChatMessage, "chatId" | "senderOpenId">): string {
-    return `${message.chatId}:${message.senderOpenId}`;
-  }
-
-  private isSupportedRecentKnowledgeMaterial(message: IncomingFileMessage): boolean {
-    const extension = message.file.fileName.toLowerCase().match(/\.[a-z0-9]+$/)?.[0] ?? "";
-    if (!this.deps.config.knowledgeBase.ingest.allowedExtensions.includes(extension)) {
-      return false;
-    }
-    if (typeof message.file.size !== "number") {
-      return true;
-    }
-    if (message.file.size <= 0) {
-      return false;
-    }
-    return message.file.size <= this.deps.config.knowledgeBase.ingest.maxFileSizeMb * 1024 * 1024;
   }
 
   private async enqueueKnowledgeIngestInput(message: IncomingChatMessage, pending: PendingKnowledgeIngestInteraction): Promise<boolean> {
@@ -1502,34 +1276,13 @@ function formatKnowledgeAllowedExtensions(allowedExtensions: readonly string[]):
 
 function matchesKnowledgeIngestInstruction(text: string): boolean {
   const routed = routeIncomingText(text.trim());
-  if (routed.kind === "command" && routed.command.kind === "knowledge-ingest") {
-    return true;
-  }
-  return KNOWLEDGE_INGEST_TEXT_PATTERN.test(text.trim());
-}
-
-function matchesKnowledgeIngestStartInstruction(text: string): boolean {
-  const trimmed = text.trim();
-  const routed = routeIncomingText(trimmed);
-  if (routed.kind === "command" && routed.command.kind === "knowledge-ingest") {
-    return true;
-  }
-  return KNOWLEDGE_INGEST_START_TEXT_PATTERN.test(trimmed);
+  return routed.kind === "command" && routed.command.kind === "knowledge-ingest";
 }
 
 function matchesKnowledgeIngestEndInstruction(text: string): boolean {
   const trimmed = text.trim();
   const routed = routeIncomingText(trimmed);
-  if (routed.kind === "command" && routed.command.kind === "knowledge-ingest-end") {
-    return true;
-  }
-  return KNOWLEDGE_INGEST_END_TEXT_PATTERN.test(trimmed);
-}
-
-function parseNaturalKnowledgeQuestion(text: string): string | null {
-  const match = text.trim().match(/^法律问答(?:\s+|[：:])(.+)$/s);
-  const question = match?.[1]?.trim();
-  return question ? question : null;
+  return routed.kind === "command" && routed.command.kind === "knowledge-ingest-end";
 }
 
 function applyKnowledgeIngestProgress(state: KnowledgeIngestProgressState, update: KnowledgeIngestProgressUpdate): void {

--- a/src/labor/extension.ts
+++ b/src/labor/extension.ts
@@ -44,6 +44,7 @@ export const laborSkillExtension: BuiltinExtensionDefinition = {
       knowledge: context.knowledge,
       service,
       transport: context.transport,
+      caseContextStore: context.caseContextStore,
     });
   },
 };

--- a/src/labor/runtime-module.ts
+++ b/src/labor/runtime-module.ts
@@ -25,10 +25,11 @@ import {
 } from "../feishu/labor-cards.js";
 import { createTextPreview, type Logger } from "../logging/logger.js";
 import type { KnowledgeBasePort } from "../knowledge/index.js";
-import type { IncomingChatMessage, IncomingFileMessage } from "../runtime/app.js";
+import type { IncomingChatMessage } from "../runtime/app.js";
 import type { RoutedText } from "../bridge/router.js";
 import type { FeishuTransport } from "../runtime/feishu-transport.js";
 import { PersistedInteractionManager } from "../runtime/persisted-interaction-manager.js";
+import type { CaseWorkbenchContextStore } from "../case-workbench/context-store.js";
 import type {
   LaborAnalyzeResult,
   LaborSkillService,
@@ -45,6 +46,7 @@ type LaborRuntimeModuleDeps = {
   knowledge: KnowledgeBasePort | null;
   service: LaborSkillService | null;
   transport: FeishuTransport;
+  caseContextStore?: CaseWorkbenchContextStore | undefined;
 };
 
 type LaborCommand = Extract<RoutedText, { kind: "command" }>["command"];
@@ -89,20 +91,6 @@ type LaborProgressState = {
   }>;
 };
 
-type RecentLaborMaterial = {
-  chatId: string;
-  conversationKey: string;
-  requesterOpenId: string;
-  messageId: string;
-  fileKey: string;
-  fileName: string;
-  size?: number | undefined;
-  resourceType?: "file" | "image" | "folder" | undefined;
-  createdAt: number;
-};
-
-const MAX_RECENT_LABOR_MATERIALS = 10;
-
 export class LaborRuntimeModule implements RuntimeModule {
   readonly name = "labor";
   readonly priority = 40;
@@ -110,7 +98,6 @@ export class LaborRuntimeModule implements RuntimeModule {
   private readonly featureConfig;
   private readonly interactions: PersistedInteractionManager<PendingLaborInteraction>;
   private readonly checkpoints: LaborCaseCheckpointStore;
-  private readonly recentMaterials = new Map<string, RecentLaborMaterial[]>();
   private readonly finishingCollections = new Set<string>();
 
   constructor(private readonly deps: LaborRuntimeModuleDeps) {
@@ -138,7 +125,6 @@ export class LaborRuntimeModule implements RuntimeModule {
 
   /** 停止交互状态管理器并刷新断点。 */
   async stop(): Promise<void> {
-    this.recentMaterials.clear();
     await this.interactions.stop();
     await this.checkpoints.stop();
   }
@@ -149,11 +135,6 @@ export class LaborRuntimeModule implements RuntimeModule {
     const pending = this.findInteraction(message);
 
     if (pending) {
-      if (routed?.kind === "command" && isLegacyLaborCommand(routed.command)) {
-        await this.sendLegacyMigrationNotice(message);
-        return { claimed: true };
-      }
-
       if (routed?.kind === "command" && isLaborFinishCommand(routed.command)) {
         await this.startFinishCollection(message, pending);
         return { claimed: true };
@@ -161,7 +142,7 @@ export class LaborRuntimeModule implements RuntimeModule {
 
       if (message.senderOpenId !== pending.requesterOpenId) {
         await this.sendNotice(message, {
-          title: "当前劳动分析任务仅限发起人继续",
+          title: "当前材料收集任务仅限发起人继续",
           template: "yellow",
           icon: "maybe_outlined",
           message: "请由当前发起人继续补充材料或说明。",
@@ -169,14 +150,9 @@ export class LaborRuntimeModule implements RuntimeModule {
         return { claimed: true };
       }
 
-      if (isLaborFinishText(message.plainText)) {
-        await this.startFinishCollection(message, pending);
-        return { claimed: true };
-      }
-
       if (routed?.kind === "command" && isCaseWorkbenchStartCommand(routed.command)) {
         await this.sendNotice(message, {
-          title: "已有劳动分析正在收集",
+          title: "已有材料收集正在进行",
           template: "yellow",
           icon: "maybe_outlined",
           message: "请继续上传材料，或发送 `/完成上传` 开始分析。",
@@ -192,14 +168,7 @@ export class LaborRuntimeModule implements RuntimeModule {
       return { claimed: true };
     }
 
-    if (this.captureRecentMaterial(message)) {
-      return { claimed: false };
-    }
-
     if (routed?.kind !== "command") {
-      if (await this.handleRecentMaterialIntent(message)) {
-        return { claimed: true };
-      }
       return { claimed: false };
     }
 
@@ -214,21 +183,9 @@ export class LaborRuntimeModule implements RuntimeModule {
     if (command.kind !== "passthrough") {
       return false;
     }
-    if (isLegacyLaborCommand(command)) {
-      await this.sendLegacyMigrationNotice(message);
-      return true;
-    }
 
-    if (!isCaseWorkbenchStartCommand(command) && !isLaborFinishCommand(command)) {
+    if (!isLaborFinishCommand(command)) {
       return false;
-    }
-
-    if (isCaseWorkbenchStartCommand(command)) {
-      const title = command.arguments
-        .join(" ")
-        .trim() || undefined;
-      await this.startCaseWorkbenchCollection(message, title);
-      return true;
     }
 
     await this.sendNotice(message, {
@@ -248,10 +205,10 @@ export class LaborRuntimeModule implements RuntimeModule {
   ): Promise<void> {
     if (!this.featureConfig.enabled || !this.deps.service) {
       await this.sendNotice(message, {
-        title: "劳动 skill 未启用",
+        title: "当前分析领域未启用",
         template: "yellow",
         icon: "maybe_outlined",
-        message: "当前未启用 laborSkill，请先补充 `laborSkill` 配置。",
+        message: "当前未启用所选分析领域，请先补充对应配置。",
       });
       return;
     }
@@ -271,17 +228,6 @@ export class LaborRuntimeModule implements RuntimeModule {
       collectionOptions.suppressInitialCard = options.suppressInitialCard;
     }
     await this.startCollection(message, title, collectionOptions);
-  }
-
-  private async sendLegacyMigrationNotice(
-    message: Pick<IncomingChatMessage, "chatId" | "messageId">,
-  ): Promise<void> {
-    await this.sendNotice(message, {
-      title: "劳动分析入口已更新",
-      template: "yellow",
-      icon: "maybe_outlined",
-      message: "该命令已并入 `/案件工作台`，请使用新入口；上传完成后点击卡片按钮或发送 `/完成上传`。",
-    });
   }
 
   /** 创建新的劳动分析收集态交互。 */
@@ -578,6 +524,7 @@ export class LaborRuntimeModule implements RuntimeModule {
       if (!result.docUrl) {
         await this.sendLaborMarkdownFallback(message, pending, result);
       }
+      this.saveCaseWorkbenchContext(pending, result);
 
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
@@ -743,6 +690,35 @@ export class LaborRuntimeModule implements RuntimeModule {
     this.clearInteraction(pending.conversationKey);
   }
 
+  private saveCaseWorkbenchContext(pending: PendingLaborInteraction, result: LaborAnalyzeResult): void {
+    this.deps.caseContextStore?.upsert({
+      caseId: pending.caseId,
+      title: result.title,
+      userId: pending.requesterOpenId,
+      chatId: pending.chatId,
+      conversationKey: pending.conversationKey,
+      source: "labor",
+      docUrl: result.docUrl,
+      markdown: result.markdown,
+      summary: result.aggregate.summary,
+      issues: result.aggregate.keyIssues.length > 0
+        ? result.aggregate.keyIssues
+        : result.aggregate.issues.map((item) => item.issue),
+      claimBasis: result.aggregate.claimBasis.map((item) => [
+        item.claim,
+        item.basis,
+        item.evidence.length > 0 ? `证据：${item.evidence.join("、")}` : "",
+      ].filter(Boolean).join("｜")),
+      evidence: result.aggregate.evidenceRows.map((item) => [
+        item.name,
+        item.proves,
+        item.support ? `支持方向：${item.support}` : "",
+      ].filter(Boolean).join("｜")),
+      missingEvidence: result.aggregate.missingEvidence,
+      updatedAt: Date.now(),
+    });
+  }
+
   private async sendLaborMarkdownFallback(
     triggerMessage: Pick<IncomingChatMessage, "messageId">,
     pending: Pick<PendingLaborInteraction, "chatId">,
@@ -771,102 +747,6 @@ export class LaborRuntimeModule implements RuntimeModule {
         this.clearInteraction(conversationKey);
       }
     }
-  }
-
-  private captureRecentMaterial(message: IncomingChatMessage): boolean {
-    if (message.messageType !== "file" || !this.featureConfig.enabled || !this.deps.service) {
-      return false;
-    }
-    if (!this.isSupportedRecentMaterial(message)) {
-      return false;
-    }
-    const key = this.getRecentMaterialKey(message);
-    const expiresBefore = Date.now() - this.featureConfig.ingest.pendingTtlMs;
-    const existing = (this.recentMaterials.get(key) ?? [])
-      .filter((item) => item.createdAt >= expiresBefore && item.messageId !== message.messageId);
-    existing.push({
-      chatId: message.chatId,
-      conversationKey: message.conversationKey,
-      requesterOpenId: message.senderOpenId,
-      messageId: message.messageId,
-      fileKey: message.file.fileKey,
-      fileName: message.file.fileName,
-      size: message.file.size,
-      resourceType: message.resourceType,
-      createdAt: Date.now(),
-    });
-    this.recentMaterials.set(key, existing.slice(-MAX_RECENT_LABOR_MATERIALS));
-    return true;
-  }
-
-  private async handleRecentMaterialIntent(message: IncomingChatMessage): Promise<boolean> {
-    if (message.messageType !== "text" || !this.featureConfig.enabled || !this.deps.service) {
-      return false;
-    }
-    const materials = this.getRecentMaterials(message);
-    if (materials.length === 0) {
-      return false;
-    }
-    const detection = detectLaborRecentMaterialIntent(message.plainText);
-    if (!detection.matched) {
-      return false;
-    }
-    this.deps.logger.log("labor/runtime", "recent material labor analysis claimed", {
-      confidence: detection.confidence,
-      reasons: detection.reasons.join(","),
-      materialCount: materials.length,
-    });
-    const pending = await this.startCollection(message, undefined);
-    for (const material of materials) {
-      pending.files.push({
-        messageId: material.messageId,
-        fileKey: material.fileKey,
-        fileName: material.fileName,
-        size: material.size,
-        resourceType: material.resourceType,
-      });
-    }
-    const note = message.plainText.trim();
-    if (note) {
-      pending.notes.push(note);
-    }
-    this.clearRecentMaterials(message);
-    await this.finishCollection(message, pending);
-    return true;
-  }
-
-  private getRecentMaterials(message: Pick<IncomingChatMessage, "chatId" | "senderOpenId">): RecentLaborMaterial[] {
-    const key = this.getRecentMaterialKey(message);
-    const expiresBefore = Date.now() - this.featureConfig.ingest.pendingTtlMs;
-    const materials = (this.recentMaterials.get(key) ?? []).filter((item) => item.createdAt >= expiresBefore);
-    if (materials.length === 0) {
-      this.recentMaterials.delete(key);
-      return [];
-    }
-    this.recentMaterials.set(key, materials);
-    return materials;
-  }
-
-  private clearRecentMaterials(message: Pick<IncomingChatMessage, "chatId" | "senderOpenId">): void {
-    this.recentMaterials.delete(this.getRecentMaterialKey(message));
-  }
-
-  private getRecentMaterialKey(message: Pick<IncomingChatMessage, "chatId" | "senderOpenId">): string {
-    return `${message.chatId}:${message.senderOpenId}`;
-  }
-
-  private isSupportedRecentMaterial(message: IncomingFileMessage): boolean {
-    const extension = message.file.fileName.toLowerCase().match(/\.[a-z0-9]+$/)?.[0] ?? "";
-    if (!this.featureConfig.ingest.allowedExtensions.includes(extension)) {
-      return false;
-    }
-    if (typeof message.file.size !== "number") {
-      return true;
-    }
-    if (message.file.size <= 0) {
-      return false;
-    }
-    return message.file.size <= this.featureConfig.ingest.maxFileSizeMb * 1024 * 1024;
   }
 
   private findInteraction(message: IncomingChatMessage): PendingLaborInteraction | null {
@@ -1017,16 +897,6 @@ function isLaborFinishCommand(command: LaborCommand): boolean {
   return normalized === "完成上传" || normalized === "材料收集完成";
 }
 
-function isLaborFinishText(text: string): boolean {
-  const normalized = text
-    .replace(/^[\s\-*•·●▪▫]+/g, "")
-    .replace(/\s+/g, "")
-    .replace(/[，。；、,.!?！？～~]+$/g, "")
-    .trim()
-    .toLowerCase();
-  return normalized === "完成上传" || normalized === "材料收集完成";
-}
-
 function shouldCollectLaborInput(message: IncomingChatMessage): boolean {
   if (message.messageType === "file") {
     return true;
@@ -1056,63 +926,6 @@ function shouldCollectLaborInput(message: IncomingChatMessage): boolean {
 function isCaseWorkbenchStartCommand(command: LaborCommand): boolean {
   return command.kind === "passthrough"
     && command.name.trim().toLowerCase() === "案件工作台";
-}
-
-function isLegacyLaborCommand(command: LaborCommand): boolean {
-  if (command.kind !== "passthrough") {
-    return false;
-  }
-  const normalized = command.name.trim().toLowerCase();
-  return normalized === "劳动分析"
-    || normalized === "劳动分析结束"
-    || normalized === "labor-start"
-    || normalized === "labor-end";
-}
-
-type LaborRecentMaterialIntentResult = {
-  matched: boolean;
-  confidence: number;
-  reasons: string[];
-};
-
-function detectLaborRecentMaterialIntent(text: string): LaborRecentMaterialIntentResult {
-  const normalized = text.replace(/\s+/g, " ").trim().toLowerCase();
-  if (!normalized) {
-    return { matched: false, confidence: 0, reasons: [] };
-  }
-  if (/(不要|不用|先别|取消).{0,8}(分析|生成|整理|工作台)/.test(normalized)) {
-    return { matched: false, confidence: 0, reasons: ["negative-labor-intent"] };
-  }
-
-  const reasons: string[] = [];
-  let confidence = 0;
-  if (/(劳动|仲裁|工资|社保|解除|辞退|离职|赔偿|补偿)/.test(normalized)) {
-    confidence += 0.3;
-    reasons.push("labor-domain");
-  }
-  if (/(劳动分析|劳动争议|证据链|工作台|证据清单)/.test(normalized)) {
-    confidence += 0.35;
-    reasons.push("labor-output");
-  }
-  if (/(分析|生成|整理|梳理|输出|起草)/.test(normalized)) {
-    confidence += 0.25;
-    reasons.push("analysis-action");
-  }
-  if (/(刚才|这些|这个|文件|材料|证据)/.test(normalized)) {
-    confidence += 0.15;
-    reasons.push("material-reference");
-  }
-  if (/^劳动分析$/.test(normalized)) {
-    confidence += 0.65;
-    reasons.push("short-strong-intent");
-  }
-
-  const bounded = Math.min(1, Number(confidence.toFixed(2)));
-  return {
-    matched: bounded >= 0.65,
-    confidence: bounded,
-    reasons,
-  };
 }
 
 function renderProcessingMessage(state: LaborProgressState): string {

--- a/src/runtime/runtime-modules.ts
+++ b/src/runtime/runtime-modules.ts
@@ -6,6 +6,7 @@
  */
 import type { ModuleManager } from "../bridge/module.js";
 import { ModuleManager as RuntimeModuleManager } from "../bridge/module.js";
+import { CaseWorkbenchContextStore } from "../case-workbench/context-store.js";
 import { CaseWorkbenchRuntimeModule, type CaseWorkbenchLaborPort } from "../case-workbench/runtime-module.js";
 import type { AppConfig } from "../config/schema.js";
 import type { ExtensionDefinition } from "../extension-api/index.js";
@@ -64,6 +65,7 @@ export function createRuntimeModules(options: {
   });
 
   const moduleManager = new RuntimeModuleManager(options.logger);
+  const caseContextStore = new CaseWorkbenchContextStore(options.config.storage.dataDir, options.logger);
   let knowledgeModule: KnowledgeRuntimeModule | null = null;
   let laborPort: CaseWorkbenchLaborPort | null = null;
 
@@ -79,6 +81,7 @@ export function createRuntimeModules(options: {
       memory,
       knowledge,
       costTracker: options.costTracker,
+      caseContextStore,
       whitelist: options.whitelist,
       getSessionWindow: options.getSessionWindow,
       saveSessionWindow: options.saveSessionWindow,
@@ -105,6 +108,7 @@ export function createRuntimeModules(options: {
       logger: options.logger,
       transport: options.transport,
       labor: laborPort,
+      contextStore: caseContextStore,
     }));
   }
 

--- a/test/case-workbench-runtime-module.test.ts
+++ b/test/case-workbench-runtime-module.test.ts
@@ -27,7 +27,11 @@ function createTextMessage(text: string, overrides: Partial<IncomingChatMessage>
   } as IncomingChatMessage;
 }
 
-function createModule() {
+function createModule(contextStore?: {
+  restore: () => Promise<void>;
+  stop: () => Promise<void>;
+  findRecent: (input: { userId: string; conversationKey?: string | undefined; chatId?: string | undefined }) => unknown;
+}, docReader?: (text: string) => Promise<string[]>) {
   const sendPayload = vi.fn(async () => ({ messageId: "out-1" }));
   const updatePayload = vi.fn(async () => ({ messageId: "om_card" }));
   const startCaseWorkbenchCollection = vi.fn(async () => undefined);
@@ -35,6 +39,8 @@ function createModule() {
     logger: { log: vi.fn() } as never,
     transport: { sendPayload, updatePayload } as never,
     labor: { startCaseWorkbenchCollection },
+    contextStore: contextStore as never,
+    docReader: docReader as never,
   });
   return { module, sendPayload, updatePayload, startCaseWorkbenchCollection };
 }
@@ -44,49 +50,9 @@ describe("CaseWorkbenchRuntimeModule", () => {
     vi.useRealTimers();
   });
 
-  it("fast-paths /案件工作台 to labor collection while there is only one runnable domain", async () => {
+  it("sends the workbench entry card for /案件工作台", async () => {
     const { module, sendPayload, startCaseWorkbenchCollection } = createModule();
     const message = createTextMessage("/案件工作台 王某违法解除");
-
-    const result = await module.handleMessage({
-      message,
-      routed: routeIncomingText(message.plainText),
-    });
-
-    expect(result).toEqual({ claimed: true });
-    expect(startCaseWorkbenchCollection).toHaveBeenCalledWith(message, "王某违法解除");
-    expect(sendPayload).not.toHaveBeenCalled();
-  });
-
-  it("does not pass the 新建 control word as the labor case title", async () => {
-    const { module, startCaseWorkbenchCollection } = createModule();
-    const message = createTextMessage("/案件工作台 新建 王某违法解除");
-
-    const result = await module.handleMessage({
-      message,
-      routed: routeIncomingText(message.plainText),
-    });
-
-    expect(result).toEqual({ claimed: true });
-    expect(startCaseWorkbenchCollection).toHaveBeenCalledWith(message, "王某违法解除");
-  });
-
-  it("fast-paths explicit labor natural language to labor collection", async () => {
-    const { module, startCaseWorkbenchCollection } = createModule();
-    const message = createTextMessage("帮我整理这批劳动仲裁材料，生成劳动争议工作台");
-
-    const result = await module.handleMessage({
-      message,
-      routed: routeIncomingText(message.plainText),
-    });
-
-    expect(result).toEqual({ claimed: true });
-    expect(startCaseWorkbenchCollection).toHaveBeenCalledWith(message, expect.stringContaining("劳动仲裁材料"));
-  });
-
-  it("sends the workbench entry card for generic workbench intent", async () => {
-    const { module, sendPayload, startCaseWorkbenchCollection } = createModule();
-    const message = createTextMessage("打开案件工作台");
 
     const result = await module.handleMessage({
       message,
@@ -100,8 +66,52 @@ describe("CaseWorkbenchRuntimeModule", () => {
     const payload = JSON.stringify(calls[0]?.[1] ?? {});
     expect(payload).toContain("案件工作台已开启");
     expect(payload).toContain("请选择你需要分析的领域");
-    expect(payload).toContain("劳动法");
-    expect(payload).toContain("公司法");
+    expect(payload).toContain("王某违法解除");
+  });
+
+  it("does not pass the 新建 control word as the labor case title", async () => {
+    const { module, sendPayload, startCaseWorkbenchCollection } = createModule();
+    const message = createTextMessage("/案件工作台 新建 王某违法解除");
+
+    const result = await module.handleMessage({
+      message,
+      routed: routeIncomingText(message.plainText),
+    });
+
+    expect(result).toEqual({ claimed: true });
+    expect(startCaseWorkbenchCollection).not.toHaveBeenCalled();
+    const calls = sendPayload.mock.calls as unknown as Array<[string, unknown]>;
+    const payload = JSON.stringify(calls[0]?.[1] ?? {});
+    expect(payload).toContain("王某违法解除");
+    expect(payload).not.toContain("新建 王某违法解除");
+  });
+
+  it("does not start labor collection from natural-language labor text", async () => {
+    const { module, sendPayload, startCaseWorkbenchCollection } = createModule();
+    const message = createTextMessage("帮我整理这批劳动仲裁材料，生成劳动争议工作台");
+
+    const result = await module.handleMessage({
+      message,
+      routed: routeIncomingText(message.plainText),
+    });
+
+    expect(result).toEqual({ claimed: false });
+    expect(sendPayload).not.toHaveBeenCalled();
+    expect(startCaseWorkbenchCollection).not.toHaveBeenCalled();
+  });
+
+  it("does not start the workbench from natural-language generic workbench text", async () => {
+    const { module, sendPayload, startCaseWorkbenchCollection } = createModule();
+    const message = createTextMessage("打开案件工作台");
+
+    const result = await module.handleMessage({
+      message,
+      routed: routeIncomingText(message.plainText),
+    });
+
+    expect(result).toEqual({ claimed: false });
+    expect(startCaseWorkbenchCollection).not.toHaveBeenCalled();
+    expect(sendPayload).not.toHaveBeenCalled();
   });
 
   it("does not hijack low-confidence document requests", async () => {
@@ -116,6 +126,76 @@ describe("CaseWorkbenchRuntimeModule", () => {
     expect(result).toEqual({ claimed: false });
     expect(sendPayload).not.toHaveBeenCalled();
     expect(startCaseWorkbenchCollection).not.toHaveBeenCalled();
+  });
+
+  it("injects recent case workbench context before ordinary drafting turns", async () => {
+    const contextStore = {
+      restore: vi.fn(async () => undefined),
+      stop: vi.fn(async () => undefined),
+      findRecent: vi.fn(() => ({
+        caseId: "case_1",
+        title: "张三劳动争议案",
+        userId: "ou_user",
+        chatId: "chat-1",
+        conversationKey: "chat-1:thread-1",
+        source: "labor",
+        docUrl: "https://example.com/doc",
+        markdown: "# 工作台\n\n违法解除争议分析",
+        summary: "违法解除劳动争议",
+        issues: ["违法解除"],
+        claimBasis: ["赔偿金｜劳动合同法第八十七条"],
+        evidence: ["解除通知｜证明解除事实"],
+        missingEvidence: ["工资流水原件"],
+        updatedAt: Date.now(),
+      })),
+    };
+    const { module } = createModule(contextStore);
+
+    const result = await module.beforeTurn?.({
+      turn: {
+        plainText: "请根据当前案件分析结果生成仲裁申请书",
+        senderOpenId: "ou_user",
+        conversationKey: "chat-1:thread-1",
+        chatId: "chat-1",
+      },
+    } as never);
+
+    expect(contextStore.findRecent).toHaveBeenCalledWith({
+      userId: "ou_user",
+      conversationKey: "chat-1:thread-1",
+      chatId: "chat-1",
+    });
+    const block = result?.systemBlocks?.join("\n") ?? "";
+    expect(block).toContain("[Current Case Workbench Context]");
+    expect(block).toContain("张三劳动争议案");
+    expect(block).toContain("违法解除争议分析");
+    expect(block).toContain("赔偿金｜劳动合同法第八十七条");
+  });
+
+  it("injects referenced Feishu template documents into ordinary turns", async () => {
+    const docReader = vi.fn(async () => [
+      [
+        "[Referenced Feishu Document]",
+        "来源：https://example.feishu.cn/docx/template",
+        "仲裁申请书模板正文",
+      ].join("\n"),
+    ]);
+    const { module } = createModule(undefined, docReader);
+
+    const result = await module.beforeTurn?.({
+      turn: {
+        plainText: "请按照这个模板生成材料：https://example.feishu.cn/docx/template",
+        senderOpenId: "ou_user",
+        conversationKey: "chat-1:thread-1",
+        chatId: "chat-1",
+      },
+    } as never);
+
+    expect(docReader).toHaveBeenCalledWith(
+      "请按照这个模板生成材料：https://example.feishu.cn/docx/template",
+      expect.anything(),
+    );
+    expect(result?.systemBlocks?.join("\n")).toContain("仲裁申请书模板正文");
   });
 
   it("only lets the requester operate the workbench entry card", async () => {
@@ -161,6 +241,30 @@ describe("CaseWorkbenchRuntimeModule", () => {
       conversationKey: "chat-1:thread-1",
       senderOpenId: "ou_user",
     });
+  });
+
+  it("passes the case title from the entry card action to labor collection", async () => {
+    vi.useFakeTimers();
+    const { module, startCaseWorkbenchCollection } = createModule();
+
+    await module.handleCardAction("ou_user", "om_card", {
+      kind: "case-workbench-action",
+      action: "start-material-collection",
+      requesterOpenId: "ou_user",
+      chatId: "chat-1",
+      chatType: "group",
+      conversationKey: "chat-1:thread-1",
+      title: "王某违法解除",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(startCaseWorkbenchCollection).toHaveBeenCalledWith({
+      chatId: "chat-1",
+      chatType: "group",
+      messageId: "om_card",
+      conversationKey: "chat-1:thread-1",
+      senderOpenId: "ou_user",
+    }, "王某违法解除");
   });
 
   it("still starts material collection when entry card update fails", async () => {

--- a/test/contract-draft-onboard.test.ts
+++ b/test/contract-draft-onboard.test.ts
@@ -258,7 +258,7 @@ describe("ContractAssistantRuntimeModule onboard draft", () => {
     }
   });
 
-  it("routes natural language case todo queries without calling OpenCode intent classification", async () => {
+  it("does not route natural language case todo queries", async () => {
     const { module, sendPayload, classifyIntent, listCaseTodos, tempDir } = createModule();
     try {
       const message = createTextMessage("查看今日待办");
@@ -267,13 +267,10 @@ describe("ContractAssistantRuntimeModule onboard draft", () => {
         routed: routeIncomingText(message.plainText),
       });
 
-      expect(result).toEqual({ claimed: true });
-      expect(listCaseTodos).toHaveBeenCalledWith("查看今日待办");
+      expect(result).toEqual({ claimed: false });
+      expect(listCaseTodos).not.toHaveBeenCalled();
       expect(classifyIntent).not.toHaveBeenCalled();
-      const payload = JSON.stringify(sendPayload.mock.calls.at(-1)?.[1] ?? {});
-      expect(payload).toContain("案件提醒");
-      expect(payload).toContain("今日提交证据目录");
-      expect(payload).toContain("rec_case_todo_1");
+      expect(sendPayload).not.toHaveBeenCalled();
     } finally {
       await cleanupModule(module, tempDir);
     }
@@ -294,7 +291,7 @@ describe("ContractAssistantRuntimeModule onboard draft", () => {
           fileName: "invoice.pdf",
           size: 1024,
         },
-      }, createTextMessage("识别发票"));
+      }, createTextMessage("/识别发票"));
 
       expect(claimed).toBe(true);
       expect(recognizeInvoice).toHaveBeenCalledTimes(1);
@@ -308,7 +305,7 @@ describe("ContractAssistantRuntimeModule onboard draft", () => {
     }
   });
 
-  it("uses skill intent routing to claim an uploaded invoice without fixed wording", async () => {
+  it("does not use natural language skill intent routing to claim an uploaded invoice", async () => {
     const { module, sendPayload, recognizeInvoice, classifyIntent, tempDir } = createModule(undefined, {
       classifyIntent: async () => ({
         skill: "invoice-recognize",
@@ -332,25 +329,16 @@ describe("ContractAssistantRuntimeModule onboard draft", () => {
         },
       }, createTextMessage("处理一下，录进去"));
 
-      expect(claimed).toBe(true);
-      expect(classifyIntent).toHaveBeenCalledWith(expect.objectContaining({
-        userText: "处理一下，录进去",
-        fileName: "invoice.pdf",
-        hasRecentFile: true,
-      }));
-      expect(recognizeInvoice).toHaveBeenCalledWith(expect.objectContaining({
-        messageId: "msg-file",
-        fileName: "invoice.pdf",
-      }), expect.any(Function));
-      const progressSerialized = JSON.stringify(sendPayload.mock.calls.at(-1)?.[1] ?? {});
-      expect(progressSerialized).toContain("发票识别");
-      expect(progressSerialized).toContain("本地提取字段：等待中");
+      expect(claimed).toBe(false);
+      expect(classifyIntent).not.toHaveBeenCalled();
+      expect(recognizeInvoice).not.toHaveBeenCalled();
+      expect(sendPayload).not.toHaveBeenCalled();
     } finally {
       await cleanupModule(module, tempDir);
     }
   });
 
-  it("starts upload card from natural invoice intent and then runs invoice progress card", async () => {
+  it("does not start upload card from natural invoice intent", async () => {
     const { module, sendPayload, recognizeInvoice, classifyIntent, tempDir } = createModule(undefined, {
       classifyIntent: async () => ({
         skill: "invoice-recognize",
@@ -366,12 +354,9 @@ describe("ContractAssistantRuntimeModule onboard draft", () => {
         routed: routeIncomingText(request.plainText),
       });
 
-      expect(first).toEqual({ claimed: true });
-      expect(classifyIntent).toHaveBeenCalledWith(expect.objectContaining({
-        userText: "这张发票录一下",
-        hasRecentFile: false,
-      }));
-      expect(JSON.stringify(sendPayload.mock.calls.at(-1)?.[1] ?? {})).toContain("等待上传发票文件");
+      expect(first).toEqual({ claimed: false });
+      expect(classifyIntent).not.toHaveBeenCalled();
+      expect(sendPayload).not.toHaveBeenCalled();
 
       const file = createFileMessage("invoice.pdf");
       const second = await module.handleMessage({
@@ -380,19 +365,14 @@ describe("ContractAssistantRuntimeModule onboard draft", () => {
         pendingInteraction: null,
       });
 
-      expect(second).toEqual({ claimed: true });
-      expect(recognizeInvoice).toHaveBeenCalledWith(expect.objectContaining({
-        fileName: "invoice.pdf",
-      }), expect.any(Function));
-      const progressSerialized = JSON.stringify(sendPayload.mock.calls.at(-1)?.[1] ?? {});
-      expect(progressSerialized).toContain("发票识别");
-      expect(progressSerialized).toContain("本地提取字段：等待中");
+      expect(second).toEqual({ claimed: false });
+      expect(recognizeInvoice).not.toHaveBeenCalled();
     } finally {
       await cleanupModule(module, tempDir);
     }
   });
 
-  it("reuses the recent uploaded invoice when the next message asks to write the ledger", async () => {
+  it("does not reuse recent uploaded invoice from a natural language request", async () => {
     const { module, sendPayload, recognizeInvoice, classifyIntent, tempDir } = createModule();
     try {
       const file = createFileMessage("invoice.pdf");
@@ -409,16 +389,10 @@ describe("ContractAssistantRuntimeModule onboard draft", () => {
         routed: routeIncomingText(request.plainText),
       });
 
-      expect(result).toEqual({ claimed: true });
+      expect(result).toEqual({ claimed: false });
       expect(classifyIntent).not.toHaveBeenCalled();
-      expect(recognizeInvoice).toHaveBeenCalledWith(expect.objectContaining({
-        messageId: file.messageId,
-        fileKey: "file_1",
-        fileName: "invoice.pdf",
-      }), expect.any(Function));
-      const allPayloads = JSON.stringify(sendPayload.mock.calls.map((call) => call[1]));
-      expect(allPayloads).toContain("发票识别");
-      expect(allPayloads).not.toContain("等待上传发票文件");
+      expect(recognizeInvoice).not.toHaveBeenCalled();
+      expect(sendPayload).not.toHaveBeenCalled();
     } finally {
       await cleanupModule(module, tempDir);
     }
@@ -449,7 +423,7 @@ describe("ContractAssistantRuntimeModule onboard draft", () => {
     }
   });
 
-  it("routes natural language with a local invoice path to invoice recognize", async () => {
+  it("does not route natural language with a local invoice path to invoice recognize", async () => {
     const { module, recognizeInvoice, classifyIntent, tempDir } = createModule(undefined, {
       classifyIntent: async () => ({
         skill: "invoice-recognize",
@@ -465,20 +439,15 @@ describe("ContractAssistantRuntimeModule onboard draft", () => {
         routed: routeIncomingText(message.plainText),
       });
 
-      expect(result).toEqual({ claimed: true });
-      expect(classifyIntent).toHaveBeenCalledWith(expect.objectContaining({
-        localPath: "/tmp/invoice.pdf",
-      }));
-      expect(recognizeInvoice).toHaveBeenCalledWith(expect.objectContaining({
-        localPath: "/tmp/invoice.pdf",
-        fileName: "invoice.pdf",
-      }), expect.any(Function));
+      expect(result).toEqual({ claimed: false });
+      expect(classifyIntent).not.toHaveBeenCalled();
+      expect(recognizeInvoice).not.toHaveBeenCalled();
     } finally {
       await cleanupModule(module, tempDir);
     }
   });
 
-  it("routes natural language desktop invoice folder directly to invoice recognition", async () => {
+  it("does not route natural language desktop invoice folder directly to invoice recognition", async () => {
     const { module, recognizeInvoice, classifyIntent, sendPayload, updatePayload, tempDir } = createModule();
     const previousHome = process.env.HOME;
     process.env.HOME = tempDir;
@@ -494,15 +463,11 @@ describe("ContractAssistantRuntimeModule onboard draft", () => {
         routed: routeIncomingText(message.plainText),
       });
 
-      expect(result).toEqual({ claimed: true });
+      expect(result).toEqual({ claimed: false });
       expect(classifyIntent).not.toHaveBeenCalled();
-      expect(recognizeInvoice).toHaveBeenCalledWith(expect.objectContaining({
-        localPath: invoicePath,
-        fileName: "invoice.pdf",
-      }), expect.any(Function));
-      expect(JSON.stringify(sendPayload.mock.calls[0]?.[1] ?? {})).toContain("invoice.pdf");
-      expect(JSON.stringify(sendPayload.mock.calls[0]?.[1] ?? {})).not.toContain("等待上传发票文件");
-      expect(updatePayload).toHaveBeenCalled();
+      expect(recognizeInvoice).not.toHaveBeenCalled();
+      expect(sendPayload).not.toHaveBeenCalled();
+      expect(updatePayload).not.toHaveBeenCalled();
     } finally {
       if (previousHome === undefined) {
         delete process.env.HOME;
@@ -513,7 +478,7 @@ describe("ContractAssistantRuntimeModule onboard draft", () => {
     }
   });
 
-  it("lets pending invoice upload state consume desktop invoice folder text", async () => {
+  it("does not let natural language create pending invoice upload state", async () => {
     const { module, recognizeInvoice, classifyIntent, sendPayload, tempDir } = createModule(undefined, {
       classifyIntent: async () => ({
         skill: "invoice-recognize",
@@ -542,13 +507,10 @@ describe("ContractAssistantRuntimeModule onboard draft", () => {
         routed: routeIncomingText(second.plainText),
       });
 
-      expect(result).toEqual({ claimed: true });
-      expect(classifyIntent).toHaveBeenCalledTimes(1);
-      expect(recognizeInvoice).toHaveBeenCalledWith(expect.objectContaining({
-        localPath: invoicePath,
-        fileName: "invoice.pdf",
-      }), expect.any(Function));
-      expect(JSON.stringify(sendPayload.mock.calls.at(-1)?.[1] ?? {})).not.toContain("当前正在等待文件");
+      expect(result).toEqual({ claimed: false });
+      expect(classifyIntent).not.toHaveBeenCalled();
+      expect(recognizeInvoice).not.toHaveBeenCalled();
+      expect(sendPayload).not.toHaveBeenCalled();
     } finally {
       if (previousHome === undefined) {
         delete process.env.HOME;
@@ -559,7 +521,7 @@ describe("ContractAssistantRuntimeModule onboard draft", () => {
     }
   });
 
-  it("routes natural case creation through the skill intent router", async () => {
+  it("does not route natural case creation through the skill intent router", async () => {
     const { module, createCase, tempDir } = createModule(undefined, {
       classifyIntent: async () => ({
         skill: "case-manage",
@@ -575,8 +537,8 @@ describe("ContractAssistantRuntimeModule onboard draft", () => {
         routed: routeIncomingText(message.plainText),
       });
 
-      expect(result).toEqual({ claimed: true });
-      expect(createCase).toHaveBeenCalledWith(message.plainText, expect.any(Function));
+      expect(result).toEqual({ claimed: false });
+      expect(createCase).not.toHaveBeenCalled();
     } finally {
       await cleanupModule(module, tempDir);
     }

--- a/test/contract-prompt-overrides.test.ts
+++ b/test/contract-prompt-overrides.test.ts
@@ -226,5 +226,5 @@ describe("contract prompt overrides", () => {
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }
-  });
+  }, 10_000);
 });

--- a/test/contract-prompt-overrides.test.ts
+++ b/test/contract-prompt-overrides.test.ts
@@ -194,8 +194,6 @@ describe("contract prompt overrides", () => {
   });
 
   it("lets invoice write flow skip model calls when local structure or cache is enough", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "invoice-direct-read-test-"));
-    const invoicePath = path.join(tempDir, "invoice.pdf");
     let promptSeen = "";
     const service = createService(async (_sessionId, request) => {
       promptSeen = String(request.parts[0]?.text ?? "");
@@ -214,17 +212,37 @@ describe("contract prompt overrides", () => {
         }],
       };
     });
+    (service as unknown as {
+      evidenceExtractor: {
+        prepareFile: () => Promise<{
+          fileName: string;
+          mimeType: string;
+          buffer: Buffer;
+          extension: string;
+          localPath: string;
+          extractedText: string;
+        }>;
+      };
+    }).evidenceExtractor.prepareFile = async () => ({
+      fileName: "invoice.pdf",
+      mimeType: "application/pdf",
+      buffer: Buffer.from("invoice fixture"),
+      extension: ".pdf",
+      localPath: "/tmp/invoice.pdf",
+      extractedText: [
+        "电子发票（普通发票）",
+        "发票号码 26952000001657386511",
+        "开票日期 2026年04月23日",
+        "购买方名称 测试客户",
+        "销售方名称 北京市隆安（深圳）律师事务所",
+        "价税合计（小写） ¥8000.00",
+      ].join("\n"),
+    });
 
-    try {
-      await writeFile(invoicePath, "%PDF-1.4\n% text layer missing invoice fields\n");
+    const result = await service.recognizeInvoice({ localPath: "/tmp/invoice.pdf", fileName: "invoice.pdf" });
 
-      const result = await service.recognizeInvoice({ localPath: invoicePath, fileName: "invoice.pdf" });
-
-      expect(promptSeen).toBe("");
-      expect(result.record["发票号"]).toBe("26952000001657386511");
-      expect(result.record["购买方"]).toBe("测试客户");
-    } finally {
-      await rm(tempDir, { recursive: true, force: true });
-    }
-  }, 10_000);
+    expect(promptSeen).toBe("");
+    expect(result.record["发票号"]).toBe("26952000001657386511");
+    expect(result.record["购买方"]).toBe("测试客户");
+  });
 });

--- a/test/group-chat.test.ts
+++ b/test/group-chat.test.ts
@@ -388,6 +388,51 @@ describe("group chat support", () => {
     });
   });
 
+  it("preserves markdown-like post input from rich text nodes", () => {
+    const content = {
+      zh_cn: {
+        title: "",
+        content: [
+          [{ tag: "text", text: "# 案件说明" }],
+          [{ tag: "text", text: "- 诉求：违法解除赔偿金" }],
+          [{
+            tag: "code_block",
+            content: [
+              [{ tag: "text", text: "```md" }],
+              [{ tag: "text", text: "| 项目 | 金额 |" }],
+              [{ tag: "text", text: "| --- | --- |" }],
+              [{ tag: "text", text: "```" }],
+            ],
+          }],
+        ],
+      },
+    };
+
+    const normalized = normalizeIncomingMessage({
+      message: {
+        chat_id: "oc_p2p_md",
+        chat_type: "p2p",
+        message_id: "om_md",
+        message_type: "post",
+        content: JSON.stringify(content),
+      },
+      sender: {
+        sender_id: {
+          open_id: "ou_123",
+        },
+      },
+    }, makeOptions());
+
+    expect(normalized?.plainText).toBe([
+      "# 案件说明",
+      "- 诉求：违法解除赔偿金",
+      "```md",
+      "| 项目 | 金额 |",
+      "| --- | --- |",
+      "```",
+    ].join("\n"));
+  });
+
   it("separates p2p mainline and thread windows while keeping prompts unchanged", () => {
     const normalized = normalizeIncomingMessage({
       message: {

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -137,6 +137,40 @@ describe("startBridgeHttpServer", () => {
     expect(await response.json()).toEqual({ card: { title: "权限已处理" } });
   });
 
+  it("delegates permission callbacks when action value is a JSON string", async () => {
+    const port = await reservePort();
+    const handlePermissionCardAction = vi.fn(async () => ({ card: { title: "权限已处理" } }));
+    const server = await startBridgeHttpServer(
+      createConfig(port, { enabled: true }),
+      { handlePermissionCardAction },
+      logger(),
+    );
+    servers.push(server);
+
+    const value = {
+      kind: "permission",
+      conversationKey: "oc_p2p_1:main",
+      turnId: "turn_1",
+      sessionId: "ses_1",
+      permissionId: "perm_1",
+      policy: "once",
+      nonce: "nonce_1",
+    };
+    const response = await fetch(`http://127.0.0.1:${port}/webhook/card`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        operator: { operator_id: { open_id: "ou_requester" } },
+        context: { open_message_id: "om_permission_1" },
+        action: { value: JSON.stringify(value) },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(handlePermissionCardAction).toHaveBeenCalledWith("ou_requester", "om_permission_1", value);
+    expect(await response.json()).toEqual({ card: { title: "权限已处理" } });
+  });
+
   it("delegates non-permission card actions to the generic handler", async () => {
     const port = await reservePort();
     const handlePermissionCardAction = vi.fn(async () => ({ card: { title: "权限已处理" } }));

--- a/test/knowledge-flow.test.ts
+++ b/test/knowledge-flow.test.ts
@@ -15,7 +15,7 @@ import type { ChatWhitelist } from "../src/store/whitelist.js";
 import { FakeOpenCodeClient, FakeOpenCodeEventStream } from "./integration/fakes.js";
 
 describe("knowledge base bridge flow", () => {
-  it("routes private high-confidence legal questions to the knowledge card when results exist", async () => {
+  it("keeps private legal-looking questions on the normal OpenCode path without /法律问答", async () => {
     const outbound = createOutbound();
     const eventStream = new FakeOpenCodeEventStream();
     const opencode = new FakeOpenCodeClient(eventStream, { kind: "message-flow", finalText: "这是普通 OpenCode 回复。" });
@@ -50,16 +50,16 @@ describe("knowledge base bridge flow", () => {
 
     await app.handleIncomingMessage(createTextMessage("劳动合同试用期最长多久？"));
 
-    expect(knowledgeQuery).toHaveBeenCalledWith("劳动合同试用期最长多久？");
+    await vi.waitFor(() => {
+      const updatedPayloads = (outbound.updateMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
+      expect(JSON.stringify(updatedPayloads)).toContain("这是普通 OpenCode 回复。");
+    });
+    expect(knowledgeQuery).not.toHaveBeenCalled();
     const replyPayloads = (outbound.replyMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
-    const updatedPayloads = (outbound.updateMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
-    expect(JSON.stringify(replyPayloads)).toContain("知识检索进行中");
-    expect(JSON.stringify(updatedPayloads)).toContain("法律咨询");
-    expect(JSON.stringify(updatedPayloads)).toContain("试用期最长不超过六个月");
-    expect(JSON.stringify(updatedPayloads)).not.toContain("这是普通 OpenCode 回复。");
+    expect(JSON.stringify(replyPayloads)).not.toContain("知识检索进行中");
   });
 
-  it("falls back to a normal private OpenCode turn when auto knowledge lookup has no results", async () => {
+  it("does not probe knowledge results for natural legal questions", async () => {
     const outbound = createOutbound();
     const eventStream = new FakeOpenCodeEventStream();
     const opencode = new FakeOpenCodeClient(eventStream, { kind: "message-flow", finalText: "这是普通 OpenCode 回复。" });
@@ -87,12 +87,12 @@ describe("knowledge base bridge flow", () => {
       const updatedPayloads = (outbound.updateMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
       expect(JSON.stringify(updatedPayloads)).toContain("这是普通 OpenCode 回复。");
     });
-    expect(knowledgeQuery).toHaveBeenCalledWith("劳动合同试用期最长多久？");
+    expect(knowledgeQuery).not.toHaveBeenCalled();
     const replyPayloads = (outbound.replyMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
     expect(JSON.stringify(replyPayloads)).not.toContain("法律咨询");
   });
 
-  it("routes copied knowledge-base questions when lookup returns results", async () => {
+  it("keeps copied knowledge-base questions on the normal OpenCode path without /法律问答", async () => {
     const outbound = createOutbound();
     const eventStream = new FakeOpenCodeEventStream();
     const opencode = new FakeOpenCodeClient(eventStream, { kind: "message-flow", finalText: "这是普通 OpenCode 回复。" });
@@ -127,11 +127,12 @@ describe("knowledge base bridge flow", () => {
 
     await app.handleIncomingMessage(createTextMessage("员工试用期最长多久？"));
 
-    expect(knowledgeQuery).toHaveBeenCalledWith("员工试用期最长多久？");
-    const updatedPayloads = (outbound.updateMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
-    expect(JSON.stringify(updatedPayloads)).toContain("法律咨询");
-    expect(JSON.stringify(updatedPayloads)).toContain("员工试用期最长不超过六个月");
-    expect(opencode.sessions.size).toBe(0);
+    await vi.waitFor(() => {
+      const updatedPayloads = (outbound.updateMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
+      expect(JSON.stringify(updatedPayloads)).toContain("这是普通 OpenCode 回复。");
+    });
+    expect(knowledgeQuery).not.toHaveBeenCalled();
+    expect(opencode.sessions.size).toBe(1);
   });
 
   it("routes /法律问答 through bridge-side knowledge lookup in private chat", async () => {
@@ -177,7 +178,7 @@ describe("knowledge base bridge flow", () => {
     expect(JSON.stringify(updatedPayloads)).toContain("试用期最长不超过六个月");
   });
 
-  it("routes natural language 法律问答 through bridge-side knowledge lookup", async () => {
+  it("does not route bare 法律问答 text through bridge-side knowledge lookup", async () => {
     const outbound = createOutbound();
     const eventStream = new FakeOpenCodeEventStream();
     const opencode = new FakeOpenCodeClient(eventStream, { kind: "message-flow", finalText: "not used" });
@@ -212,9 +213,11 @@ describe("knowledge base bridge flow", () => {
 
     await app.handleIncomingMessage(createTextMessage("法律问答 劳动合同试用期最长多久？"));
 
-    expect(knowledgeQuery).toHaveBeenCalledWith("劳动合同试用期最长多久？");
-    const updatedPayloads = (outbound.updateMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
-    expect(JSON.stringify(updatedPayloads)).toContain("试用期最长不超过六个月");
+    await vi.waitFor(() => {
+      const updatedPayloads = (outbound.updateMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
+      expect(JSON.stringify(updatedPayloads)).toContain("not used");
+    });
+    expect(knowledgeQuery).not.toHaveBeenCalled();
   });
 
   it("starts ingest mode and keeps consuming files until /kb-ingest-end", async () => {
@@ -271,7 +274,7 @@ describe("knowledge base bridge flow", () => {
       resourceType: "folder",
     });
     expect(ingestFile).not.toHaveBeenCalled();
-    await app.handleIncomingMessage(createIngestReplyMessage("知识入库完成", "om_end"));
+    await app.handleIncomingMessage(createIngestReplyMessage("/知识入库完成", "om_end"));
     await vi.waitFor(() => {
       expect(ingestFile).toHaveBeenCalledTimes(2);
     });
@@ -293,7 +296,7 @@ describe("knowledge base bridge flow", () => {
     expect(JSON.stringify(replyPayloads)).not.toContain("已收到结束指令，将处理完当前队列后结束");
   });
 
-  it("starts ingest mode from natural language 知识入库", async () => {
+  it("does not start ingest mode from natural language 知识入库", async () => {
     const outbound = createOutbound();
     const eventStream = new FakeOpenCodeEventStream();
     const opencode = new FakeOpenCodeClient(eventStream, { kind: "message-flow", finalText: "not used" });
@@ -316,11 +319,11 @@ describe("knowledge base bridge flow", () => {
     await app.handleIncomingMessage(createTextMessage("知识入库"));
 
     const replyPayloads = (outbound.replyMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
-    expect(JSON.stringify(replyPayloads)).toContain("知识入库已开启");
-    expect(JSON.stringify(replyPayloads)).toContain("发送文件或 URL 即可入库");
+    expect(JSON.stringify(replyPayloads)).not.toContain("知识入库已开启");
+    expect(JSON.stringify(replyPayloads)).not.toContain("发送文件或 URL 即可入库");
   });
 
-  it("ingests recently uploaded files when the next message asks to save them to the knowledge base", async () => {
+  it("does not ingest recently uploaded files from a natural language request", async () => {
     const outbound = createOutbound();
     const eventStream = new FakeOpenCodeEventStream();
     const opencode = new FakeOpenCodeClient(eventStream, { kind: "message-flow", finalText: "文件总结完成。" });
@@ -353,23 +356,11 @@ describe("knowledge base bridge flow", () => {
 
     await app.handleIncomingMessage(createTextMessage("把刚才上传的三本书收入知识库", "om_ingest_recent"));
 
-    await vi.waitFor(() => {
-      expect(ingestFile).toHaveBeenCalledTimes(3);
-    });
-    expect(ingestFile.mock.calls.map((call) => call[0].fileName)).toEqual([
-      "公司法实务.pdf",
-      "合同法案例.pdf",
-      "知产合规.pdf",
-    ]);
+    expect(ingestFile).not.toHaveBeenCalled();
     const replyPayloads = (outbound.replyMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
     const updatedPayloads = (outbound.updateMessage.mock.calls as unknown as Array<[string, { content: string }]>).map((call) => call[1]);
-    expect(JSON.stringify(replyPayloads)).toContain("知识入库已开启");
-    expect(JSON.stringify(updatedPayloads)).toContain("知识入库完成");
-    expect(JSON.stringify(updatedPayloads)).toContain("公司法实务.pdf");
-    expect(JSON.stringify(updatedPayloads)).toContain("入库 6");
-    expect(JSON.stringify(updatedPayloads)).toContain("公司法实务.pdf");
-    expect(JSON.stringify(updatedPayloads)).toContain("合同法案例.pdf");
-    expect(JSON.stringify(updatedPayloads)).toContain("知产合规.pdf");
+    expect(JSON.stringify(replyPayloads)).not.toContain("知识入库已开启");
+    expect(JSON.stringify(updatedPayloads)).not.toContain("知识入库完成");
   });
 
   it("does not hijack recent uploaded files when the next message only asks for a summary", async () => {

--- a/test/labor-runtime-module.test.ts
+++ b/test/labor-runtime-module.test.ts
@@ -166,6 +166,7 @@ async function createModule(existingTempDir?: string) {
       durationMs: 10,
     },
   }));
+  const caseContextUpsert = vi.fn();
 
   const logger = { log: vi.fn() };
   const module = new LaborRuntimeModule({
@@ -195,6 +196,7 @@ async function createModule(existingTempDir?: string) {
       sendPayload: sendPayload as never,
       updatePayload: updatePayload as never,
     }),
+    caseContextStore: { upsert: caseContextUpsert } as never,
   });
 
   return {
@@ -208,6 +210,7 @@ async function createModule(existingTempDir?: string) {
     finalizeReviewOnly,
     buildAuthoritySearchDraft,
     appendAuthoritySearch,
+    caseContextUpsert,
     logger,
   };
 }
@@ -217,12 +220,20 @@ async function cleanupModule(module: LaborRuntimeModule, tempDir: string): Promi
   await rm(tempDir, { recursive: true, force: true });
 }
 
+async function startCollectionFromWorkbench(
+  module: LaborRuntimeModule,
+  message: IncomingChatMessage,
+  title?: string,
+): Promise<void> {
+  await module.startCaseWorkbenchCollection(message, title);
+}
+
 describe("LaborRuntimeModule", () => {
   it("marks an active collection checkpoint expired when starting a new collection", async () => {
       const { module, tempDir } = await createModule();
     try {
       const first = createTextMessage("/案件工作台");
-      await module.handleMessage({ message: first, routed: routeIncomingText(first.plainText) });
+      await startCollectionFromWorkbench(module, first);
       await module.handleMessage({ message: createFileMessage("旧材料.pdf"), routed: null });
       const second = createTextMessage("/案件工作台", { messageId: "msg-second" });
       await module.startCaseWorkbenchCollection(second);
@@ -238,7 +249,7 @@ describe("LaborRuntimeModule", () => {
     }
   });
 
-  it("shows a retirement notice for the legacy /labor-start alias", async () => {
+  it("ignores the legacy /labor-start alias", async () => {
     const { module, tempDir, sendPayload } = await createModule();
     try {
       const start = createTextMessage("/labor-start 劳动争议演示");
@@ -247,9 +258,8 @@ describe("LaborRuntimeModule", () => {
         routed: routeIncomingText(start.plainText),
       });
 
-      expect(result).toEqual({ claimed: true });
-      const payloadCalls = sendPayload.mock.calls as unknown as Array<[string, unknown]>;
-      expect(JSON.stringify(payloadCalls[0]?.[1] ?? {})).toContain("劳动分析入口已更新");
+      expect(result).toEqual({ claimed: false });
+      expect(sendPayload).not.toHaveBeenCalled();
       const interactions = (module as unknown as {
         interactions: { get(key: string): unknown };
       }).interactions;
@@ -259,7 +269,7 @@ describe("LaborRuntimeModule", () => {
     }
   });
 
-  it("shows a migration notice for the legacy /劳动分析 command", async () => {
+  it("ignores the legacy /劳动分析 command", async () => {
     const { module, tempDir, sendPayload, extractMaterial } = await createModule();
     try {
       const start = createTextMessage("/劳动分析 劳动争议演示");
@@ -268,11 +278,9 @@ describe("LaborRuntimeModule", () => {
         routed: routeIncomingText(start.plainText),
       });
 
-      expect(result).toEqual({ claimed: true });
+      expect(result).toEqual({ claimed: false });
       expect(extractMaterial).not.toHaveBeenCalled();
-      const payloadCalls = sendPayload.mock.calls as unknown as Array<[string, unknown]>;
-      expect(JSON.stringify(payloadCalls[0]?.[1] ?? {})).toContain("该命令已并入");
-      expect(JSON.stringify(payloadCalls[0]?.[1] ?? {})).toContain("/案件工作台");
+      expect(sendPayload).not.toHaveBeenCalled();
     } finally {
       await cleanupModule(module, tempDir);
     }
@@ -300,15 +308,10 @@ describe("LaborRuntimeModule", () => {
   });
 
   it("collects files and notes silently, and only starts analysis after /完成上传", async () => {
-    const { module, tempDir, sendPayload, updatePayload, extractMaterial, finalizeAnalysis, finalizeReviewOnly } = await createModule();
+    const { module, tempDir, sendPayload, updatePayload, extractMaterial, finalizeAnalysis, finalizeReviewOnly, caseContextUpsert } = await createModule();
     try {
       const start = createTextMessage("/案件工作台 劳动争议演示");
-      const startResult = await module.handleMessage({
-        message: start,
-        routed: routeIncomingText(start.plainText),
-      });
-
-      expect(startResult).toEqual({ claimed: true });
+      await startCollectionFromWorkbench(module, start, "劳动争议演示");
       expect(sendPayload).toHaveBeenCalledTimes(1);
 
       const interactionBefore = (module as unknown as {
@@ -386,6 +389,16 @@ describe("LaborRuntimeModule", () => {
       expect(JSON.stringify(updatedPayloads.map((call) => call[2]))).toContain("证据1.pdf｜耗时");
       expect(JSON.stringify(updatedPayloads.map((call) => call[2]))).not.toContain("命中缓存");
       expect(JSON.stringify(updatedPayloads.map((call) => call[2]))).not.toContain("进展：《证据1.pdf》已完成");
+      expect(caseContextUpsert).toHaveBeenCalledWith(expect.objectContaining({
+        title: "劳动争议分析",
+        userId: "ou_user",
+        conversationKey: start.conversationKey,
+        docUrl: "https://example.com/doc",
+        markdown: "### 劳动争议分析",
+        issues: expect.arrayContaining(["解除是否合法"]),
+        claimBasis: expect.arrayContaining([expect.stringContaining("经济补偿或赔偿金")]),
+        evidence: expect.arrayContaining([expect.stringContaining("解除通知")]),
+      }));
     } finally {
       await cleanupModule(module, tempDir);
     }
@@ -395,7 +408,7 @@ describe("LaborRuntimeModule", () => {
     const { module, tempDir, extractMaterial, expandMaterialFile, finalizeAnalysis } = await createModule();
     try {
       const start = createTextMessage("/案件工作台");
-      await module.handleMessage({ message: start, routed: routeIncomingText(start.plainText) });
+      await startCollectionFromWorkbench(module, start);
       const folderMessage = createFileMessage("发票.zip", { resourceType: "folder" });
       await module.handleMessage({ message: folderMessage, routed: null });
       expandMaterialFile.mockResolvedValueOnce([
@@ -425,10 +438,7 @@ describe("LaborRuntimeModule", () => {
     const { module, tempDir, sendPayload, extractMaterial } = await createModule();
     try {
       const start = createTextMessage("/案件工作台 劳动争议演示");
-      await module.handleMessage({
-        message: start,
-        routed: routeIncomingText(start.plainText),
-      });
+      await startCollectionFromWorkbench(module, start, "劳动争议演示");
 
       const chat = createTextMessage("你好");
       const result = await module.handleMessage({
@@ -452,10 +462,7 @@ describe("LaborRuntimeModule", () => {
     const { module, tempDir, extractMaterial, finalizeAnalysis } = await createModule();
     try {
       const start = createTextMessage("/案件工作台 劳动争议演示");
-      await module.handleMessage({
-        message: start,
-        routed: routeIncomingText(start.plainText),
-      });
+      await startCollectionFromWorkbench(module, start, "劳动争议演示");
       await module.handleMessage({
         message: createFileMessage("证据1.pdf"),
         routed: null,
@@ -477,14 +484,11 @@ describe("LaborRuntimeModule", () => {
     }
   });
 
-  it("accepts exact natural language finish text while collecting", async () => {
+  it("does not accept natural language finish text while collecting", async () => {
     const { module, tempDir, extractMaterial, finalizeAnalysis, finalizeReviewOnly } = await createModule();
     try {
       const start = createTextMessage("/案件工作台 劳动争议演示");
-      await module.handleMessage({
-        message: start,
-        routed: routeIncomingText(start.plainText),
-      });
+      await startCollectionFromWorkbench(module, start, "劳动争议演示");
       await module.handleMessage({
         message: createFileMessage("证据1.pdf"),
         routed: null,
@@ -496,12 +500,10 @@ describe("LaborRuntimeModule", () => {
         routed: routeIncomingText(finish.plainText),
       });
 
-      expect(result).toEqual({ claimed: true });
-      await vi.waitFor(() => {
-        expect(extractMaterial).toHaveBeenCalledTimes(1);
-        expect(finalizeAnalysis).toHaveBeenCalledTimes(1);
-        expect(finalizeReviewOnly).toHaveBeenCalledTimes(1);
-      });
+      expect(result).toEqual({ claimed: false });
+      expect(extractMaterial).not.toHaveBeenCalled();
+      expect(finalizeAnalysis).not.toHaveBeenCalled();
+      expect(finalizeReviewOnly).not.toHaveBeenCalled();
     } finally {
       await cleanupModule(module, tempDir);
     }
@@ -511,10 +513,7 @@ describe("LaborRuntimeModule", () => {
     const { module, tempDir, extractMaterial } = await createModule();
     try {
       const start = createTextMessage("/案件工作台 劳动争议演示");
-      await module.handleMessage({
-        message: start,
-        routed: routeIncomingText(start.plainText),
-      });
+      await startCollectionFromWorkbench(module, start, "劳动争议演示");
 
       const note = createTextMessage("完成上传了");
       const result = await module.handleMessage({
@@ -537,10 +536,7 @@ describe("LaborRuntimeModule", () => {
     const { module, tempDir, extractMaterial } = await createModule();
     try {
       const start = createTextMessage("/案件工作台 劳动争议演示");
-      await module.handleMessage({
-        message: start,
-        routed: routeIncomingText(start.plainText),
-      });
+      await startCollectionFromWorkbench(module, start, "劳动争议演示");
 
       const note = createTextMessage("还没完成上传，等我继续补材料");
       const result = await module.handleMessage({
@@ -559,7 +555,7 @@ describe("LaborRuntimeModule", () => {
     }
   });
 
-  it("starts labor analysis from recently uploaded materials when the next message asks for a labor workbench", async () => {
+  it("does not start labor analysis from recently uploaded materials via natural language", async () => {
     const { module, tempDir, sendPayload, updatePayload, extractMaterial, finalizeAnalysis } = await createModule();
     try {
       const fileOne = createFileMessage("解除通知.pdf");
@@ -584,30 +580,17 @@ describe("LaborRuntimeModule", () => {
         routed: routeIncomingText(trigger.plainText),
       });
 
-      expect(triggerResult).toEqual({ claimed: true });
-      expect(extractMaterial).toHaveBeenCalledTimes(2);
-      const extractCalls = extractMaterial.mock.calls as unknown as Array<[file: { fileName: string }]>;
-      expect(extractCalls.map((call) => call[0].fileName)).toEqual(["解除通知.pdf", "工资流水.pdf"]);
-      expect(finalizeAnalysis).toHaveBeenCalledTimes(1);
-      const finalizeCalls = finalizeAnalysis.mock.calls as unknown as Array<[input: { materialCount: number; notes: string[] }]>;
-      const finalizeInput = finalizeCalls[0]?.[0];
-      expect(finalizeInput).toEqual(expect.objectContaining({
-        materialCount: 2,
-        notes: ["把刚才这些证据生成劳动争议证据链工作台"],
-      }));
-      const payloadCalls = sendPayload.mock.calls as unknown as Array<[string, unknown]>;
-      expect(JSON.stringify(payloadCalls[0]?.[1] ?? {})).toContain("材料收集中");
-      expect(JSON.stringify(payloadCalls[1]?.[1] ?? {})).toContain("材料分析进行中");
-      const updatedPayloads = updatePayload.mock.calls as unknown as Array<[string, string, unknown]>;
-      const completedSerialized = JSON.stringify(updatedPayloads.find((call) => JSON.stringify(call[2]).includes("材料分析完成"))?.[2] ?? {});
-      expect(completedSerialized).toContain("材料分析完成");
-      expect(completedSerialized).toContain("材料 2");
+      expect(triggerResult).toEqual({ claimed: false });
+      expect(extractMaterial).not.toHaveBeenCalled();
+      expect(finalizeAnalysis).not.toHaveBeenCalled();
+      expect(sendPayload).not.toHaveBeenCalled();
+      expect(updatePayload).not.toHaveBeenCalled();
     } finally {
       await cleanupModule(module, tempDir);
     }
   });
 
-  it("starts labor workflow from recent materials when asked for an evidence list Word", async () => {
+  it("does not start labor workflow from recent materials via natural language", async () => {
     const { module, tempDir, sendPayload, updatePayload, extractMaterial, finalizeAnalysis } = await createModule();
     try {
       const file = createFileMessage("劳动仲裁材料.pdf");
@@ -624,19 +607,11 @@ describe("LaborRuntimeModule", () => {
         routed: routeIncomingText(trigger.plainText),
       });
 
-      expect(triggerResult).toEqual({ claimed: true });
-      expect(extractMaterial).toHaveBeenCalledTimes(1);
-      expect(finalizeAnalysis).toHaveBeenCalledTimes(1);
-      const finalizeCalls = finalizeAnalysis.mock.calls as unknown as Array<[input: { materialCount: number; notes: string[]; preferredTitle?: string }]>;
-      expect(finalizeCalls[0]?.[0]).toEqual(expect.objectContaining({
-        materialCount: 1,
-        notes: [trigger.plainText],
-      }));
-      const payloadCalls = sendPayload.mock.calls as unknown as Array<[string, unknown]>;
-      expect(JSON.stringify(payloadCalls[0]?.[1] ?? {})).toContain("材料收集中");
-      expect(JSON.stringify(payloadCalls[1]?.[1] ?? {})).toContain("材料分析进行中");
-      const updatedPayloads = updatePayload.mock.calls as unknown as Array<[string, string, unknown]>;
-      expect(JSON.stringify(updatedPayloads.find((call) => JSON.stringify(call[2]).includes("材料分析完成"))?.[2] ?? {})).toContain("材料分析完成");
+      expect(triggerResult).toEqual({ claimed: false });
+      expect(extractMaterial).not.toHaveBeenCalled();
+      expect(finalizeAnalysis).not.toHaveBeenCalled();
+      expect(sendPayload).not.toHaveBeenCalled();
+      expect(updatePayload).not.toHaveBeenCalled();
     } finally {
       await cleanupModule(module, tempDir);
     }
@@ -646,7 +621,7 @@ describe("LaborRuntimeModule", () => {
     const { module, tempDir, sendPayload, updatePayload, appendAuthoritySearch, finalizeReviewOnly } = await createModule();
     try {
       const start = createTextMessage("/案件工作台 劳动争议演示");
-      await module.handleMessage({ message: start, routed: routeIncomingText(start.plainText) });
+      await startCollectionFromWorkbench(module, start, "劳动争议演示");
       await module.handleMessage({ message: createFileMessage("证据1.pdf"), routed: null });
       const end = createTextMessage("/完成上传");
       await module.handleMessage({ message: end, routed: routeIncomingText(end.plainText) });
@@ -696,7 +671,7 @@ describe("LaborRuntimeModule", () => {
     appendAuthoritySearch.mockRejectedValueOnce(new Error("pkulaw timeout"));
     try {
       const start = createTextMessage("/案件工作台 劳动争议演示");
-      await module.handleMessage({ message: start, routed: routeIncomingText(start.plainText) });
+      await startCollectionFromWorkbench(module, start, "劳动争议演示");
       await module.handleMessage({ message: createFileMessage("证据1.pdf"), routed: null });
 
       await module.handleMessage({ message: createTextMessage("/完成上传"), routed: routeIncomingText("/完成上传") });
@@ -750,10 +725,7 @@ describe("LaborRuntimeModule", () => {
     const { module, tempDir, sendPayload, extractMaterial, finalizeAnalysis } = await createModule();
     try {
       const start = createTextMessage("/案件工作台 劳动争议演示");
-      await module.handleMessage({
-        message: start,
-        routed: routeIncomingText(start.plainText),
-      });
+      await startCollectionFromWorkbench(module, start, "劳动争议演示");
 
       const end = createTextMessage("/完成上传");
       const result = await module.handleMessage({
@@ -780,10 +752,7 @@ describe("LaborRuntimeModule", () => {
     const { module, tempDir, sendPayload, extractMaterial } = await createModule();
     try {
       const firstStart = createTextMessage("/案件工作台 第一次");
-      await module.handleMessage({
-        message: firstStart,
-        routed: routeIncomingText(firstStart.plainText),
-      });
+      await startCollectionFromWorkbench(module, firstStart, "第一次");
       await module.handleMessage({
         message: createFileMessage("旧材料.pdf"),
         routed: null,
@@ -805,7 +774,7 @@ describe("LaborRuntimeModule", () => {
         files: [expect.objectContaining({ fileName: "旧材料.pdf" })],
       }));
       const payloadCalls = sendPayload.mock.calls as unknown as Array<[string, unknown]>;
-      expect(JSON.stringify(payloadCalls.at(-1)?.[1] ?? {})).toContain("已有劳动分析正在收集");
+      expect(JSON.stringify(payloadCalls.at(-1)?.[1] ?? {})).toContain("已有材料收集正在进行");
       expect(extractMaterial).not.toHaveBeenCalled();
     } finally {
       await cleanupModule(module, tempDir);
@@ -816,10 +785,7 @@ describe("LaborRuntimeModule", () => {
     const { module, tempDir, sendPayload } = await createModule();
     try {
       const start = createTextMessage("/案件工作台 第一次");
-      await module.handleMessage({
-        message: start,
-        routed: routeIncomingText(start.plainText),
-      });
+      await startCollectionFromWorkbench(module, start, "第一次");
 
       const secondStart = createTextMessage("/案件工作台 第二次", { senderOpenId: "ou_other" });
       const result = await module.handleMessage({
@@ -829,7 +795,7 @@ describe("LaborRuntimeModule", () => {
 
       expect(result).toEqual({ claimed: true });
       const payloadCalls = sendPayload.mock.calls as unknown as Array<[string, unknown]>;
-      expect(JSON.stringify(payloadCalls.at(-1)?.[1] ?? {})).toContain("当前劳动分析任务仅限发起人继续");
+      expect(JSON.stringify(payloadCalls.at(-1)?.[1] ?? {})).toContain("当前材料收集任务仅限发起人继续");
     } finally {
       await cleanupModule(module, tempDir);
     }
@@ -840,10 +806,7 @@ describe("LaborRuntimeModule", () => {
     extractMaterial.mockRejectedValueOnce(new Error("OpenCode crashed"));
     try {
       const start = createTextMessage("/案件工作台 劳动争议演示");
-      await module.handleMessage({
-        message: start,
-        routed: routeIncomingText(start.plainText),
-      });
+      await startCollectionFromWorkbench(module, start, "劳动争议演示");
       await module.handleMessage({
         message: createFileMessage("证据1.pdf"),
         routed: null,
@@ -872,10 +835,7 @@ describe("LaborRuntimeModule", () => {
     finalizeAnalysis.mockRejectedValueOnce(new Error("analysis timeout"));
     try {
       const start = createTextMessage("/案件工作台 劳动争议演示");
-      await module.handleMessage({
-        message: start,
-        routed: routeIncomingText(start.plainText),
-      });
+      await startCollectionFromWorkbench(module, start, "劳动争议演示");
       await module.handleMessage({
         message: createFileMessage("证据1.pdf"),
         routed: null,
@@ -912,10 +872,7 @@ describe("LaborRuntimeModule", () => {
     const { module, tempDir } = await createModule();
     try {
       const start = createTextMessage("/案件工作台 劳动争议演示");
-      await module.handleMessage({
-        message: start,
-        routed: routeIncomingText(start.plainText),
-      });
+      await startCollectionFromWorkbench(module, start, "劳动争议演示");
       await module.handleMessage({
         message: createFileMessage("证据1.pdf"),
         routed: null,

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -42,6 +42,20 @@ describe("routeIncomingText", () => {
     });
   });
 
+  it("does not route multiline markdown text that contains slash-like content as a command", () => {
+    const text = [
+      "/文本不是指令",
+      "",
+      "这是用户粘贴的 Markdown 正文。",
+      "- 路径：/Users/example/demo.md",
+    ].join("\n");
+
+    expect(routeIncomingText(text)).toEqual({
+      kind: "message",
+      text,
+    });
+  });
+
   it("routes /sessions <index> without accepting bare numbers", () => {
     expect(routeIncomingText("/sessions 3")).toEqual({
       kind: "command",


### PR DESCRIPTION
## 标题

收口案件工作台上下文与输入兼容

## 描述

本次按功能拆成两组提交：

1. 案件工作台上下文与业务路由收口
- 新增案件工作台上下文持久化与 beforeTurn 注入，让后续文书生成能读取最近的案件分析结果。
- 支持普通消息中引用飞书文档链接，并把文档内容作为上下文注入 OpenCode。
- 将知识库、合同、劳动模块的自然语言自动抢占收回，保留显式命令和卡片入口，避免误劫持普通对话。
- 案件工作台入口卡保留标题并传递到材料收集流程。

2. 飞书输入与卡片回调兼容
- 富文本 post 中的 Markdown/code_block 内容保持原样进入普通消息。
- 多行 Markdown 即使以 `/` 开头也不误判为 slash command。
- 卡片回调 value 支持对象和 JSON 字符串两种形态，权限卡回调保持兼容。

## 验证

- `npm test -- --run test/case-workbench-runtime-module.test.ts test/contract-draft-onboard.test.ts test/group-chat.test.ts test/http-server.test.ts test/knowledge-flow.test.ts test/labor-runtime-module.test.ts test/router.test.ts`
- `npm run typecheck`
- `npm run lint`
