### PR TITLE
[codex] 完善发票批量识别与权限卡片回写

### DIFF
--- a/src/contract-assistant/index.ts
+++ b/src/contract-assistant/index.ts
@@ -463,6 +463,13 @@ export class ContractAssistantService {
     }
     const structured = extractStructuredInvoice(text);
     if (!structured.detection.isInvoice) {
+      const modelRecord = normalizeInvoiceRecord(readRecord(extraction.result, "record"), {
+        matchHints: readRecord(extraction.result, "matchHints"),
+        summary: readString(extraction.result, "summary"),
+      });
+      if (hasRelaxedInvoiceCoreFields(modelRecord)) {
+        return { result: extraction.result, structured: null };
+      }
       throw new Error(`这份文件不像发票，暂不写入发票台账：${structured.detection.reason}`);
     }
     const repaired = await this.repairStructuredInvoiceFields(text, structured).catch((error) => {
@@ -1582,18 +1589,28 @@ function extractInvoiceTypeFromText(text: string): string | undefined {
 }
 
 function assertUsefulInvoiceRecord(record: Record<string, unknown>, structured: StructuredInvoiceExtraction | null): void {
-  const hasCoreFields = Boolean(
-    readFieldString(record, "发票号")
-    && hasFieldValue(record, "开票日期")
+  if (hasRelaxedInvoiceCoreFields(record)) {
+    return;
+  }
+  const hasDetectorBackedFields = Boolean(
+    structured?.detection.isInvoice
     && readFieldNumber(record, "发票金额") !== undefined
+    && (hasFieldValue(record, "开票日期") || readFieldString(record, "购买方"))
   );
-  if (hasCoreFields) {
+  if (hasDetectorBackedFields) {
     return;
   }
   const reason = structured
     ? `${structured.detection.reason}；缺少字段：${structured.missingFields.join("、") || "核心字段"}`
     : "未提取到足够的发票核心字段";
   throw new Error(`发票识别结果不足，暂不写入发票台账：${reason}`);
+}
+
+function hasRelaxedInvoiceCoreFields(record: Record<string, unknown>): boolean {
+  return Boolean(
+    readFieldString(record, "发票号")
+    && (hasFieldValue(record, "开票日期") || readFieldNumber(record, "发票金额") !== undefined)
+  );
 }
 
 function hasFieldValue(record: Record<string, unknown>, key: string): boolean {

--- a/src/contract-assistant/invoice-structured.ts
+++ b/src/contract-assistant/invoice-structured.ts
@@ -210,11 +210,14 @@ function extractBuyerName(text: string): string | undefined {
 }
 
 function extractInvoiceAmount(text: string): number | undefined {
-  const value = matchFirst(text, [
-    /价税合计[^\d¥￥-]{0,12}[¥￥]?\s*([0-9,]+(?:\.\d{1,2})?)/,
-    /小写[^\d¥￥-]{0,12}[¥￥]?\s*([0-9,]+(?:\.\d{1,2})?)/,
-    /合计金额[^\d¥￥-]{0,12}[¥￥]?\s*([0-9,]+(?:\.\d{1,2})?)/,
-  ]);
+  const lines = text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  const labeledLine = lines.find((line) => /价税合计|小写|合计金额/.test(line));
+  const value = labeledLine
+    ? matchFirst(labeledLine, [
+      /(?:价税合计|小写|合计金额)[^\d¥￥-]{0,30}[¥￥]?\s*([0-9,]+(?:\.\d{1,2})?)/,
+      /[¥￥]\s*([0-9,]+(?:\.\d{1,2})?)/,
+    ])
+    : undefined;
   if (!value) {
     return undefined;
   }

--- a/src/contract-assistant/runtime-module.ts
+++ b/src/contract-assistant/runtime-module.ts
@@ -95,6 +95,7 @@ type PendingUploadInteraction = {
   requesterOpenId: string;
   anchorMessageId: string;
   expiresAt: number;
+  files?: ContractAssistantFileRef[] | undefined;
 };
 
 type PendingDraftInteraction = {
@@ -234,6 +235,11 @@ export class ContractAssistantRuntimeModule implements RuntimeModule {
       return { claimed: true };
     }
 
+    if (pending?.kind === "invoice-recognize" && routed?.kind === "command" && isUploadFinishCommand(routed.command)) {
+      const handled = await this.handlePendingUpload(message, pending, routed);
+      return { claimed: handled };
+    }
+
     if (routed?.kind === "command") {
       const claimed = await this.handleCommand(message, routed.command, workbench);
       return { claimed };
@@ -253,7 +259,7 @@ export class ContractAssistantRuntimeModule implements RuntimeModule {
       return { claimed: handled };
     }
 
-    const handled = await this.handlePendingUpload(message, pending);
+    const handled = await this.handlePendingUpload(message, pending, routed);
     return { claimed: handled };
   }
 
@@ -283,7 +289,7 @@ export class ContractAssistantRuntimeModule implements RuntimeModule {
         pendingKind,
         pendingKind === "contract-extract"
           ? `最近上传的《${pending.file.fileName}》不像合同文件，请重新上传 1 份合同文件，我会提取字段并写入合同台账。`
-          : `最近上传的《${pending.file.fileName}》不像发票文件，请重新上传 1 份发票文件，我会识别字段并写入发票记录。`,
+          : `最近上传的《${pending.file.fileName}》不像发票文件，请重新上传发票文件；可连续上传多份，完成后发送 /完成上传。`,
       );
       return true;
     }
@@ -442,7 +448,7 @@ export class ContractAssistantRuntimeModule implements RuntimeModule {
         await this.handleInvoiceRecognize(message, buildLocalContractFileInput(localPath));
         return true;
       }
-      await this.startPendingUpload(message, "invoice-recognize", "请直接上传 1 份发票文件，我会识别字段并写入发票记录。");
+      await this.startPendingUpload(message, "invoice-recognize", "可连续上传一份或多份发票文件。上传完成后发送 `/完成上传`，我会统一识别字段并写入发票记录。");
       return true;
     }
 
@@ -497,7 +503,28 @@ export class ContractAssistantRuntimeModule implements RuntimeModule {
   private async handlePendingUpload(
     message: IncomingChatMessage,
     pending: PendingUploadInteraction,
+    routed: RoutedText | null | undefined,
   ): Promise<boolean> {
+    if (pending.kind === "invoice-recognize" && routed?.kind === "command" && isUploadFinishCommand(routed.command)) {
+      const files = pending.files ?? [];
+      if (files.length === 0) {
+        await this.sendNotice(message, {
+          title: "还没有收到发票文件",
+          template: "yellow",
+          icon: "maybe_outlined",
+          message: "请先上传一份或多份发票文件，再发送 `/完成上传`。",
+        });
+        return true;
+      }
+      this.clearInteraction(message.conversationKey);
+      if (files.length === 1) {
+        await this.handleInvoiceRecognize(message, files[0]!);
+      } else {
+        await this.handleInvoiceRecognizeBatch(message, files);
+      }
+      return true;
+    }
+
     if (message.messageType !== "file") {
       if (pending.kind === "invoice-recognize") {
         const localInvoiceFiles = await this.resolveLocalInvoiceFilesFromText(message.plainText);
@@ -517,13 +544,13 @@ export class ContractAssistantRuntimeModule implements RuntimeModule {
         icon: "file-link-docx_outlined",
         message: pending.kind === "contract-extract"
           ? "请上传合同文件，我会提取字段并写入合同台账。"
-          : "请上传发票文件，我会识别字段并写入发票记录。",
+          : "请继续上传发票文件；上传完成后发送 `/完成上传`，我会统一识别字段并写入发票记录。",
       });
       return true;
     }
 
-    this.clearInteraction(message.conversationKey);
     if (pending.kind === "contract-extract") {
+      this.clearInteraction(message.conversationKey);
       await this.handleContractExtract(message, {
         messageId: message.messageId,
         fileKey: message.file.fileKey,
@@ -532,11 +559,38 @@ export class ContractAssistantRuntimeModule implements RuntimeModule {
       });
       return true;
     }
-    await this.handleInvoiceRecognize(message, {
-      messageId: message.messageId,
-      fileKey: message.file.fileKey,
-      fileName: message.file.fileName,
-      size: message.file.size,
+
+    if (!this.isFileAcceptableFor("invoice-recognize", message.file.fileName)) {
+      await this.sendNotice(message, {
+        title: "发票文件格式暂不支持",
+        template: "yellow",
+        icon: "maybe_outlined",
+        message: `已忽略《${message.file.fileName}》。请上传支持的发票文件格式：${this.featureConfig.ingest.invoiceAllowedExtensions.join(" / ")}。`,
+      });
+      return true;
+    }
+
+    const nextFiles = [
+      ...(pending.files ?? []),
+      {
+        messageId: message.messageId,
+        fileKey: message.file.fileKey,
+        fileName: message.file.fileName,
+        size: message.file.size,
+      },
+    ];
+    pending.files = nextFiles;
+    pending.expiresAt = Date.now() + this.featureConfig.ingest.pendingTtlMs;
+    this.interactions.touch(pending.conversationKey, pending.expiresAt);
+    await this.sendNotice(message, {
+      title: "已收到发票文件",
+      template: "green",
+      icon: "yes_outlined",
+      message: [
+        `已加入队列：${message.file.fileName}`,
+        `当前共 ${nextFiles.length} 份发票文件。`,
+        "可以继续上传；上传完成后发送 `/完成上传` 开始识别。",
+      ].join("\n"),
     });
     return true;
   }
@@ -1380,6 +1434,7 @@ export class ContractAssistantRuntimeModule implements RuntimeModule {
       requesterOpenId: message.senderOpenId,
       anchorMessageId: message.messageId,
       expiresAt: Date.now() + this.featureConfig.ingest.pendingTtlMs,
+      files: [],
     };
     this.interactions.set(interaction);
     await this.sendNotice(message, {
@@ -2025,7 +2080,7 @@ function formatMoney(value: number | undefined): string {
 
 function buildBitableRecordUrl(baseToken: string, tableId: string, recordId: string): string {
   const base = `https://feishu.cn/base/${encodeURIComponent(baseToken)}?table=${encodeURIComponent(tableId)}`;
-  return `${base}&recordId=${encodeURIComponent(recordId)}`;
+  return `${base}&record=${encodeURIComponent(recordId)}`;
 }
 
 function renderWorkbenchSummaryMessage(state: ContractState | null): string {
@@ -2084,6 +2139,11 @@ function detectPendingUploadKind(text: string): PendingUploadKind | null {
     }
   }
   return null;
+}
+
+function isUploadFinishCommand(command: ContractAssistantCommand): boolean {
+  return command.kind === "passthrough"
+    && command.name.trim().toLowerCase() === "完成上传";
 }
 
 function extractLocalPath(text: string): string | null {

--- a/src/feishu/contract-cards.ts
+++ b/src/feishu/contract-cards.ts
@@ -68,16 +68,10 @@ export type CaseTodoReminderCardView = {
 /** 构建案件录入进行中卡。 */
 export function buildCaseCreateProcessingPayload(view: CaseCreateProgressView | string): FeishuPostPayload {
   const progressView = typeof view === "string" ? createCaseCreateProgressState(view) : view;
-  const preview = parseCaseCreateRequestPreview(progressView.request);
   return buildDesignerCardPayload("案件信息录入中", [
-    { from: "委托人：张三", to: `委托人：${preview.clientName ?? "待识别"}` },
-    { from: "对方当事人：某科技公司", to: `对方当事人：${preview.counterpartyName ?? "待识别"}` },
-    { from: "案由：劳动争议", to: `案由：${preview.cause ?? preview.type ?? "待识别"}` },
-    { from: "程序阶段：劳动仲裁", to: `程序阶段：${preview.stage ?? preview.status ?? "待识别"}` },
-    { from: "案号：xxx", to: `案号：${preview.caseNo ?? "待识别"}` },
-    { from: "审理法院：xx法院", to: `审理法院：${preview.court ?? "待识别"}` },
     ...renderCaseCreateStepReplacements(progressView),
   ], (card) => {
+    removeCaseCreatePreviewBlock(card);
     applyCaseCreateStepStyles(card, progressView);
   });
 }
@@ -216,13 +210,14 @@ export function buildInvoiceRecognizeCompletedPayload(
     { from: "服务", to: invoiceType ?? "未识别" },
     { from: "291.94", to: amount ?? "未识别" },
     { from: "2026/03/24", to: invoiceDate ?? "未识别" },
-    { from: "xx合同.pdf", to: payer ?? "非发票文件" },
+    { from: "**xx合同.pdf**   识别失败，非发票文件", to: `购买方：${payer ?? "未识别"}` },
     { from: "耗时 32s", to: `耗时 ${formatDurationSeconds(options.elapsedMs)}` },
   ], (card) => {
     if (options.batchResults && options.batchResults.length > 1) {
       renderInvoiceBatchDetails(card, options.batchResults);
     }
     setDesignerButtonValue(card, "查看发票表", { kind: "invoice-action", action: "open-invoice-table", url: options.recordUrl });
+    setDesignerButtonUrl(card, "查看发票表", options.recordUrl);
   });
 }
 
@@ -344,6 +339,24 @@ function resolveTodoRowBackground(index: number, line: string): string {
 
 function formatDurationSeconds(elapsedMs: number): string {
   return `${Math.max(1, Math.round(elapsedMs / 1000))}s`;
+}
+
+function removeCaseCreatePreviewBlock(card: Record<string, unknown>): void {
+  const body = getDesignerRecord(card.body);
+  const elements = Array.isArray(body?.elements) ? body.elements : null;
+  if (!elements) {
+    return;
+  }
+  for (let index = elements.length - 1; index >= 0; index -= 1) {
+    const element = elements[index];
+    if (
+      designerElementContainsText(element, "委托人：")
+      || designerElementContainsText(element, "案号：")
+      || getDesignerRecord(element)?.tag === "hr"
+    ) {
+      elements.splice(index, 1);
+    }
+  }
 }
 
 function getDesignerBodyElements(card: Record<string, unknown>): Array<Record<string, unknown>> {

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -235,6 +235,9 @@ export class BridgeApp {
       sendPayload: async (chatId, payload, options, delivery) => {
         return await this.sendPayload(chatId, payload, options, delivery);
       },
+      updatePayload: async (chatId, messageId, payload, options) => {
+        return await this.updatePayload(chatId, messageId, payload, options);
+      },
       toCardContent: (payload) => this.toCardContent(payload),
     }, this.config.permissions?.defaultPolicy ?? "ask");
     const transport = createFeishuTransport({

--- a/src/runtime/permission-manager.ts
+++ b/src/runtime/permission-manager.ts
@@ -35,6 +35,12 @@ type PermissionManagerCallbacks = {
     options: SendPayloadOptions,
     delivery?: { replyToMessageId: string; replyInThread?: boolean },
   ): Promise<{ messageId: string }>;
+  updatePayload(
+    chatId: string,
+    messageId: string,
+    payload: FeishuPostPayload,
+    options: SendPayloadOptions,
+  ): Promise<{ messageId: string }>;
   toCardContent(payload: FeishuPostPayload): Record<string, unknown>;
 };
 
@@ -201,6 +207,7 @@ export class PermissionManager {
           detail,
         }, "warn");
       }
+      await this.updatePermissionRequestCard(interaction, finalResolution);
       logEvent(this.logger, "bridge/permission", "permission.decided", {
         turnId: interaction.turnId,
         sessionId: interaction.sessionId,
@@ -215,6 +222,36 @@ export class PermissionManager {
       });
     } finally {
       this.processing.delete(interaction.permissionVersion);
+    }
+  }
+
+  private async updatePermissionRequestCard(
+    interaction: PendingPermissionInteraction,
+    resolution: PermissionResolution,
+  ): Promise<void> {
+    if (!interaction.permissionMessageId) {
+      return;
+    }
+    const payload = this.buildResolutionPayload(resolution);
+    const textPreview = resolution === "deny" || resolution === "timeout" || resolution === "upstream-expired"
+      ? "权限请求已拒绝。"
+      : "权限请求已授权。";
+    try {
+      await this.callbacks.updatePayload(interaction.chatId, interaction.permissionMessageId, payload, {
+        event: "permission card updated",
+        transcriptType: "outbound-final",
+        textPreview,
+        len: textPreview.length,
+      });
+    } catch (error) {
+      this.logger.log("bridge/permission", "permission card update failed after decision", {
+        chatId: interaction.chatId,
+        messageId: interaction.permissionMessageId,
+        permissionId: interaction.permissionId,
+        nonce: interaction.permissionVersion,
+        resolution,
+        detail: error instanceof Error ? error.message : String(error),
+      }, "warn");
     }
   }
 

--- a/test/app-permission-actions.test.ts
+++ b/test/app-permission-actions.test.ts
@@ -25,6 +25,12 @@ describe("BridgeApp permission card actions", () => {
 
     expect(replyPermission).toHaveBeenCalledWith(interaction.sessionId, interaction.permissionId, "once", false);
     expect(JSON.stringify(card)).toContain("已授权");
+    expect(outbound.updateMessage).toHaveBeenCalledWith(
+      interaction.permissionMessageId,
+      expect.objectContaining({ msg_type: "interactive" }),
+    );
+    const updatedPayload = (outbound.updateMessage.mock.calls as unknown[][]).at(-1)?.[1];
+    expect(JSON.stringify(updatedPayload)).toContain("已授权");
     expect((app as unknown as { pendingInteractions: Map<string, unknown> }).pendingInteractions.has(interaction.conversationKey)).toBe(false);
   });
 
@@ -43,6 +49,10 @@ describe("BridgeApp permission card actions", () => {
 
     expect(replyPermission).toHaveBeenCalledWith(interaction.sessionId, interaction.permissionId, "always", true);
     expect(JSON.stringify(card)).toContain("已授权");
+    expect(outbound.updateMessage).toHaveBeenCalledWith(
+      interaction.permissionMessageId,
+      expect.objectContaining({ msg_type: "interactive" }),
+    );
     expect((app as unknown as { pendingInteractions: Map<string, unknown> }).pendingInteractions.has(interaction.conversationKey)).toBe(false);
   });
 
@@ -61,6 +71,12 @@ describe("BridgeApp permission card actions", () => {
 
     expect(replyPermission).toHaveBeenCalledWith(interaction.sessionId, interaction.permissionId, "reject", false);
     expect(JSON.stringify(card)).toContain("已拒绝");
+    expect(outbound.updateMessage).toHaveBeenCalledWith(
+      interaction.permissionMessageId,
+      expect.objectContaining({ msg_type: "interactive" }),
+    );
+    const updatedPayload = (outbound.updateMessage.mock.calls as unknown[][]).at(-1)?.[1];
+    expect(JSON.stringify(updatedPayload)).toContain("已拒绝");
     expect((app as unknown as { pendingInteractions: Map<string, unknown> }).pendingInteractions.has(interaction.conversationKey)).toBe(false);
   });
 

--- a/test/contract-draft-onboard.test.ts
+++ b/test/contract-draft-onboard.test.ts
@@ -417,7 +417,7 @@ describe("ContractAssistantRuntimeModule onboard draft", () => {
 
       expect(claimed).toBe(true);
       expect(recognizeInvoice).not.toHaveBeenCalled();
-      expect(JSON.stringify(sendPayload.mock.calls.at(-1)?.[1] ?? {})).toContain("重新上传 1 份发票文件");
+      expect(JSON.stringify(sendPayload.mock.calls.at(-1)?.[1] ?? {})).toContain("请重新上传发票文件");
     } finally {
       await cleanupModule(module, tempDir);
     }
@@ -659,19 +659,17 @@ describe("ContractAssistantRuntimeModule onboard draft", () => {
       expect(processingSerialized).toContain("案件信息录入中");
       expect(processingSerialized).toContain("提取案件字段：正在根据案情提取案件字段");
       expect(processingSerialized).toContain("写入案件管理表：等待中");
-      expect(processingSerialized).toContain("案由：待识别");
-      expect(processingSerialized).toContain("程序阶段：待识别");
-      expect(processingSerialized).toContain("案号：待识别");
-      expect(processingSerialized).toContain("审理法院：待识别");
-      expect(processingSerialized.match(/案由：/g)?.length).toBe(1);
-      expect(processingSerialized.match(/程序阶段：/g)?.length).toBe(1);
+      expect(processingSerialized).not.toContain("案由：待识别");
+      expect(processingSerialized).not.toContain("程序阶段：待识别");
+      expect(processingSerialized).not.toContain("案号：待识别");
+      expect(processingSerialized).not.toContain("审理法院：待识别");
       expect(progressSerialized).toContain("提取案件字段：已完成");
       expect(progressSerialized).toContain("写入案件管理表：正在写入案件管理表");
       expect(completedSerialized).toContain("案件已录入");
       expect(completedSerialized).toContain("张三 vs 北京XX科技有限公司");
       expect(completedSerialized).toContain("劳动争议");
       expect(completedSerialized).toContain("打开案件管理表");
-      expect(JSON.stringify(completedCard)).toContain("\"url\":\"https://feishu.cn/base/app_token?table=tbl_case&recordId=rec_case_1\"");
+      expect(JSON.stringify(completedCard)).toContain("\"url\":\"https://feishu.cn/base/app_token?table=tbl_case&record=rec_case_1\"");
       expect((completedCard.body?.elements ?? []).some((item: { tag?: string }) => item.tag === "column")).toBe(false);
     } finally {
       await cleanupModule(module, tempDir);
@@ -684,7 +682,7 @@ describe("ContractAssistantRuntimeModule onboard draft", () => {
       await expect(module.handleCardAction?.("ou_user", "om_card", {
         kind: "contract-case-action",
         action: "open-case-table",
-        url: "https://feishu.cn/base/app_token?table=tbl_case&recordId=rec_case_1",
+        url: "https://feishu.cn/base/app_token?table=tbl_case&record=rec_case_1",
       })).resolves.toEqual({ toast: { type: "success", content: "正在打开案件管理表。" } });
 
       await expect(module.handleCardAction?.("ou_user", "om_card", {
@@ -765,7 +763,7 @@ describe("ContractAssistantRuntimeModule onboard draft", () => {
     expect(updatePayload.mock.calls.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("merges invoice processing and completed card", async () => {
+  it("collects invoice uploads until finish command and then updates the card", async () => {
     const { module, sendPayload, updatePayload, recognizeInvoice } = createModule();
     const start = createTextMessage("/识别发票");
     await module.handleMessage({
@@ -781,6 +779,15 @@ describe("ContractAssistantRuntimeModule onboard draft", () => {
     });
 
     expect(result).toEqual({ claimed: true });
+    expect(recognizeInvoice).not.toHaveBeenCalled();
+
+    const finish = createTextMessage("/完成上传");
+    const finishResult = await module.handleMessage({
+      message: finish,
+      routed: routeIncomingText(finish.plainText),
+    });
+
+    expect(finishResult).toEqual({ claimed: true });
     expect(recognizeInvoice).toHaveBeenCalledTimes(1);
 
     const initialSerialized = JSON.stringify(sendPayload.mock.calls.at(-1)?.[1] ?? {});
@@ -797,6 +804,8 @@ describe("ContractAssistantRuntimeModule onboard draft", () => {
     expect(finalSerialized).toContain("¥20,000.00");
     expect(finalSerialized).toContain("2026-04-10");
     expect(finalSerialized).toContain("查看发票表");
+    expect(finalSerialized).toContain("购买方：张三");
+    expect(finalSerialized).not.toContain("识别失败，非发票文件");
   });
 
   it("falls back to request fields when case create response misses display fields", async () => {

--- a/test/formatter.test.ts
+++ b/test/formatter.test.ts
@@ -390,7 +390,8 @@ describe("buildPostPayload", () => {
 
     expect(content.header.title.content).toBe("案件信息录入中");
     expect(serialized).toContain("案件信息录入中");
-    expect(serialized).toContain("劳动争议");
+    expect(serialized).toContain("提取案件字段");
+    expect(serialized).not.toContain("劳动争议");
   });
 
   it("renders a notice card", () => {

--- a/test/invoice-structured.test.ts
+++ b/test/invoice-structured.test.ts
@@ -41,6 +41,20 @@ describe("invoice structured detector", () => {
     expect(result.missingFields).toEqual([]);
   });
 
+  it("does not treat the invoice number as the invoice amount", () => {
+    const text = [
+      "电子发票（普通发票）",
+      "发票号码：26952000001657386511",
+      "开票日期：2026年04月23日",
+      "购买方名称：北京市隆安（深圳）律师事务所",
+      "价税合计（小写） ¥8,000.00",
+    ].join("\n");
+    const result = extractStructuredInvoice(text);
+
+    expect(result.fields["发票号"]).toBe("26952000001657386511");
+    expect(result.fields["发票金额"]).toBe(8000);
+  });
+
   it("detects noisy photo OCR invoice text through fuzzy signals", async () => {
     const text = await readFile(fixture("invoices/noisy-photo-invoice.txt"), "utf8");
     const detection = detectInvoiceDocument(text);


### PR DESCRIPTION
## 标题

完善发票批量识别与权限卡片回写

## 描述

本次按功能拆成两组提交：

1. 发票批量识别与案件卡片表现
- `/识别发票` 进入等待上传状态后支持连续收集多份发票文件。
- 用户发送 `/完成上传` 后再统一识别，单文件走单张结果，多文件走批量结果。
- 修正发票金额抽取，避免把超长发票号码误当金额。
- 放宽模型补全后的发票核心字段判断，保留有票号且有日期或金额的有效结果。
- 修正 Base 记录链接参数为 `record`，并清理案件录入处理中卡片的待识别预览块。

2. 权限卡片状态回写
- 权限授权/拒绝后回写原权限请求卡片，避免用户看到旧卡片仍像可操作状态。
- 回写失败只记录 warning，不影响权限决策结果继续回传 OpenCode。

## 验证

- `npm test -- --run test/contract-draft-onboard.test.ts test/invoice-structured.test.ts test/formatter.test.ts test/app-permission-actions.test.ts`
- `npm run typecheck`
- `npm run lint`
