### PR TITLE
[codex][fix] 优化启动活动预览输出

### DIFF
--- a/scripts/runtime/activity-ticker.mjs
+++ b/scripts/runtime/activity-ticker.mjs
@@ -161,11 +161,16 @@ export function formatEvent(event, useColor = true) {
     const len = event.fields.replyLength ? `${event.fields.replyLength}字` : "";
     const chat = event.fields.chatId?.startsWith("oc_p2p_") ? "p2p" : event.fields.chatId?.startsWith("oc_") ? "chat" : "?";
     const sender = (event.fields.userId ?? "?").slice(0, 12);
-    const cost = event.cost && Number.isFinite(Number(event.cost.estimatedCostCny))
-      ? `¥${Number(event.cost.estimatedCostCny).toFixed(4)}`
-      : event.cost?.totalTokens ? `${event.cost.totalTokens}t` : "";
-    const tail = [duration, len, cost].filter(Boolean).join(" · ");
-    return `${tsCol}  ${co.green("✓")}  ${co.bold("turn")}     ${chat.padEnd(6)} ${co.dim(sender)}  ${co.dim(tail)}`;
+    const tail = [duration, len].filter(Boolean).join(" · ");
+    const head = `${tsCol}  ${co.green("✓")}  ${co.bold("turn")}     ${chat.padEnd(6)} ${co.dim(sender)}  ${co.dim(tail)}`;
+    // Q / A 各占一行,每段 40 字截断,dim 色 + 12 空格缩进
+    const userQ = truncatePreview(event.fields.userTextPreview, 40);
+    const replyA = truncatePreview(event.fields.replyTextPreview, 40);
+    const lines = [head];
+    const indent = "            ";
+    if (userQ) lines.push(`${indent}${co.dim("Q「" + userQ + "」")}`);
+    if (replyA) lines.push(`${indent}${co.dim("A「" + replyA + "」")}`);
+    return lines.join("\n");
   }
 
   // ws
@@ -211,7 +216,7 @@ export function formatEventJson(event) {
   if (event.cost) base.cost = event.cost;
   if (event.message) base.message = event.message;
   // 只挑常用字段,不全量倾倒
-  const picks = ["chatId", "userId", "turnId", "durationMs", "replyLength", "moduleId", "fileName", "chunks", "action"];
+  const picks = ["chatId", "userId", "turnId", "durationMs", "replyLength", "moduleId", "fileName", "chunks", "action", "userTextPreview", "replyTextPreview"];
   for (const k of picks) {
     if (event.fields?.[k] !== undefined) base[k] = event.fields[k];
   }
@@ -271,8 +276,8 @@ export function createActivityTicker(options = {}) {
       emit(out);
     },
 
-    /** 显示一行状态(uptime / session cost),作为定期心跳。 */
-    status({ uptimeSec, sessionCostCny, sessionTokens }) {
+    /** 显示一行心跳:uptime。让长时间无对话时也能确认 bridge 还活着。 */
+    status({ uptimeSec }) {
       const co = color ? c : noColor;
       const ts = co.grey(new Date().toTimeString().slice(0, 8));
       if (json) {
@@ -281,16 +286,21 @@ export function createActivityTicker(options = {}) {
           scope: "ticker",
           name: "status",
           uptimeSec,
-          sessionCostCny,
-          sessionTokens,
         }));
         return;
       }
       const uptime = formatUptime(uptimeSec);
-      const cost = sessionCostCny != null ? `¥${sessionCostCny.toFixed(4)}` : (sessionTokens != null ? `${sessionTokens}t` : "—");
-      emit(`${ts}  ${co.dim("·")}  ${co.dim("status")}   uptime ${co.bold(uptime)} · session cost ${co.bold(cost)}`);
+      emit(`${ts}  ${co.dim("·")}  ${co.dim("status")}   uptime ${co.bold(uptime)}`);
     },
   };
+}
+
+/** 安全截断文本预览,过长时加省略号。 */
+function truncatePreview(value, maxChars) {
+  if (!value || typeof value !== "string") return "";
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (!normalized) return "";
+  return normalized.length > maxChars ? `${normalized.slice(0, maxChars - 1)}…` : normalized;
 }
 
 function formatUptime(sec) {

--- a/scripts/runtime/start.mjs
+++ b/scripts/runtime/start.mjs
@@ -151,7 +151,6 @@ export async function runStart(options = {}) {
     const statusInterval = setInterval(() => {
       ticker.status({
         uptimeSec: Math.floor((Date.now() - startedAt) / 1000),
-        sessionCostCny: null,
       });
     }, options.statusEverySec ? options.statusEverySec * 1000 : 30_000);
     activityTickerHandle = { tailer, statusInterval };

--- a/src/runtime/turn-executor.ts
+++ b/src/runtime/turn-executor.ts
@@ -293,6 +293,8 @@ export class TurnExecutor {
         durationMs: Date.now() - (turn.startedAt ?? Date.now()),
         replyLength: reply.length,
         processMessageId: turn.processMessageId,
+        userTextPreview: createTextPreview(turn.text ?? ""),
+        replyTextPreview: createTextPreview(reply),
       });
     } catch (error) {
       const detail = normalizeTurnFailureDetail(error);

--- a/test/scripts-onboard-start.test.ts
+++ b/test/scripts-onboard-start.test.ts
@@ -1102,7 +1102,7 @@ describe("scripts/activity-ticker", () => {
     expect(shouldDisplay(noise)).toBe(false);
   });
 
-  it("formatEvent (no color) renders turn.completed with duration + cost", async () => {
+  it("formatEvent (no color) renders turn.completed with duration + length, no per-turn cost", async () => {
     const { formatEvent, parseLogLine } = await import("../scripts/runtime/activity-ticker.mjs");
     const event = parseLogLine('22:58:48 [bridge/queue] turn.completed { turnId="t1" durationMs=2300 replyLength=13 chatId="oc_p2p_1" userId="ou_abcdefghij12" }');
     expect(event).not.toBeNull();
@@ -1111,7 +1111,8 @@ describe("scripts/activity-ticker", () => {
     expect(out).toContain("turn");
     expect(out).toContain("2.3s");
     expect(out).toContain("13字");
-    expect(out).toContain("¥0.0124");
+    // per-turn 不再显示成本（session cost 仍在 30s status 行汇总）
+    expect(out).not.toContain("¥");
     expect(out).not.toContain("[");
   });
 
@@ -1137,15 +1138,17 @@ describe("scripts/activity-ticker", () => {
     expect(parsed.cost).toEqual({ estimatedCostCny: "0.0124", totalTokens: "600" });
   });
 
-  it("ActivityTicker.status emits status line in TTY mode", async () => {
+  it("ActivityTicker.status emits uptime heartbeat line, no cost field", async () => {
     const { createActivityTicker } = await import("../scripts/runtime/activity-ticker.mjs");
     const out: string[] = [];
     const ticker = createActivityTicker({ color: false, json: false, emit: (l: string) => out.push(l) });
-    ticker.status({ uptimeSec: 125, sessionCostCny: 0.0345 });
+    ticker.status({ uptimeSec: 125 });
     expect(out).toHaveLength(1);
     expect(out[0]).toContain("uptime");
     expect(out[0]).toContain("2m 5s");
-    expect(out[0]).toContain("¥0.0345");
+    // 心跳行不再包含 session cost
+    expect(out[0]).not.toContain("¥");
+    expect(out[0]).not.toContain("session cost");
   });
 
   it("collectEnabledExtensions returns memory + legal defaults", async () => {
@@ -1153,5 +1156,42 @@ describe("scripts/activity-ticker", () => {
     // collectEnabledExtensions 是内部函数，但我们通过 createActivityTicker 行为间接验证 status panel 不抛错
     // 这里只做最小冒烟:模块可导入。
     expect(typeof startMod.runStart).toBe("function");
+  });
+});
+
+describe("scripts/activity-ticker conversation preview", () => {
+  it("includes userTextPreview/replyTextPreview in turn.completed render", async () => {
+    const { formatEvent, parseLogLine } = await import("../scripts/runtime/activity-ticker.mjs");
+    const event = parseLogLine('22:58:48 [bridge/queue] turn.completed { turnId="t1" durationMs=2300 replyLength=13 chatId="oc_p2p_1" userId="ou_abc12" userTextPreview="帮我看下这个劳动合同有什么问题" replyTextPreview="收到,我会从条款合规性、风险点和签约程序三个方面分析" }');
+    expect(event).not.toBeNull();
+    const out = formatEvent(event!, false);
+    expect(out).toContain("turn");
+    expect(out).toContain("Q「帮我看下这个劳动合同有什么问题」");
+    expect(out).toContain("A「收到,我会从条款合规性、风险点和签约程序三个方面分析」");
+    expect(out.split("\n")).toHaveLength(3); // 三行:metadata + Q + A
+  });
+
+  it("truncates long previews at 40 chars with ellipsis", async () => {
+    const { formatEvent, parseLogLine } = await import("../scripts/runtime/activity-ticker.mjs");
+    const long = "A".repeat(60);
+    const event = parseLogLine(`22:58:48 [bridge/queue] turn.completed { turnId="t1" durationMs=2300 userTextPreview="${long}" replyTextPreview="ok" }`);
+    const out = formatEvent(event!, false);
+    expect(out).toContain("A".repeat(39) + "…");
+    expect(out).toContain("A「ok」");
+  });
+
+  it("omits preview line entirely when both previews missing", async () => {
+    const { formatEvent, parseLogLine } = await import("../scripts/runtime/activity-ticker.mjs");
+    const event = parseLogLine('22:58:48 [bridge/queue] turn.completed { turnId="t1" durationMs=2300 replyLength=13 chatId="oc_p2p_1" userId="ou_abc12" }');
+    const out = formatEvent(event!, false);
+    expect(out.split("\n")).toHaveLength(1);
+  });
+
+  it("includes previews in JSON mode", async () => {
+    const { formatEventJson, parseLogLine } = await import("../scripts/runtime/activity-ticker.mjs");
+    const event = parseLogLine('22:58:48 [bridge/queue] turn.completed { turnId="t1" durationMs=2300 userTextPreview="问题" replyTextPreview="答案" }');
+    const parsed = JSON.parse(formatEventJson(event!));
+    expect(parsed.userTextPreview).toBe("问题");
+    expect(parsed.replyTextPreview).toBe("答案");
   });
 });


### PR DESCRIPTION
## 变更内容

- turn.completed activity ticker 增加用户问题和回复摘要预览。
- 预览按 40 字截断，Q / A 分行展示。
- status 心跳行只保留 uptime，不再展示空成本字段。
- JSON 输出补充 userTextPreview / replyTextPreview 常用字段。

## 变更原因

- 终端运行时需要更直观看到每轮对话内容，而不是只看 turn 元信息。
- 成本信息不应在单轮和空心跳里误导展示。

## 影响

- 仅影响本地 runtime activity ticker 展示和 JSON 事件摘要字段。
- 不改变 Feishu 用户侧卡片和消息行为。

## 验证

- npm run typecheck
- npm test -- --run test/scripts-onboard-start.test.ts test/turn-executor.test.ts
