### PR TITLE
[codex][fix] 固定启动心跳状态行

### DIFF
--- a/scripts/runtime/activity-ticker.mjs
+++ b/scripts/runtime/activity-ticker.mjs
@@ -276,21 +276,25 @@ export function createActivityTicker(options = {}) {
       emit(out);
     },
 
-    /** 显示一行心跳:uptime。让长时间无对话时也能确认 bridge 还活着。 */
+    /**
+     * 生成心跳字符串(uptime),不自己 emit——交给调用方决定怎么显示。
+     * - sticky 模式:调用方用 \r\x1b[K 原地刷新
+     * - JSON 模式:调用方 emit JSON 行
+     * - 普通追加模式:调用方加 \n 后 emit
+     */
     status({ uptimeSec }) {
       const co = color ? c : noColor;
       const ts = co.grey(new Date().toTimeString().slice(0, 8));
       if (json) {
-        emit(JSON.stringify({
+        return JSON.stringify({
           ts: new Date().toISOString().slice(11, 19),
           scope: "ticker",
           name: "status",
           uptimeSec,
-        }));
-        return;
+        });
       }
       const uptime = formatUptime(uptimeSec);
-      emit(`${ts}  ${co.dim("·")}  ${co.dim("status")}   uptime ${co.bold(uptime)}`);
+      return `${ts}  ${co.dim("·")}  ${co.dim("status")}   uptime ${co.bold(uptime)}`;
     },
   };
 }
@@ -377,6 +381,58 @@ export function createLogTailer({ filePath, intervalMs = 500, onLine, startFromE
     stop() {
       stopped = true;
       if (timer) clearTimeout(timer);
+    },
+  };
+}
+
+/**
+ * Sticky writer:把一行"心跳状态"钉在终端底部,事件在它上面滚,它原地刷新。
+ * 用 ANSI \r\x1b[K 清当前行后重写,无需 scroll region 这种复杂招数。
+ *
+ * 调用流:
+ *   - emit(line):事件来了 → 清 sticky → 输出 line+\n → 重画 sticky
+ *   - setStatus(text):心跳更新 → 清 sticky → 存 text → 重画 sticky
+ *   - cleanup():进程退出 → 清 sticky + 输出 \n,留干净 prompt
+ *
+ * 仅适用于 TTY。非 TTY(管道 / 重定向)请用普通 emit,不要走 sticky。
+ *
+ * @param {object} options
+ * @param {NodeJS.WritableStream} options.stdout - 默认 process.stdout
+ * @returns {{emit(line: string): void, setStatus(text: string): void, cleanup(): void}}
+ */
+export function createStickyWriter(options = {}) {
+  const stdout = options.stdout ?? process.stdout;
+  let stickyText = "";
+  let stickyVisible = false;
+
+  function clearSticky() {
+    if (stickyVisible) {
+      stdout.write("\r\u001b[2K");
+      stickyVisible = false;
+    }
+  }
+
+  function drawSticky() {
+    if (stickyText) {
+      stdout.write(stickyText);
+      stickyVisible = true;
+    }
+  }
+
+  return {
+    emit(line) {
+      clearSticky();
+      stdout.write(line + "\n");
+      drawSticky();
+    },
+    setStatus(text) {
+      clearSticky();
+      stickyText = text;
+      drawSticky();
+    },
+    cleanup() {
+      clearSticky();
+      stdout.write("\n");
     },
   };
 }

--- a/scripts/runtime/start.mjs
+++ b/scripts/runtime/start.mjs
@@ -15,7 +15,7 @@ import { promisify } from "node:util";
 
 import { resolveProjectConfigPath } from "./portable.mjs";
 import { maybeCheckForUpdateOnStart } from "./update.mjs";
-import { createActivityTicker, createLogTailer } from "./activity-ticker.mjs";
+import { createActivityTicker, createLogTailer, createStickyWriter } from "./activity-ticker.mjs";
 import {
   createAugmentedEnv,
   assertPortAvailable,
@@ -134,12 +134,17 @@ export async function runStart(options = {}) {
   }
 
   // 启动 Activity Ticker:tail bridge-runtime.log,按白名单过滤渲染
+  // TTY 下用 sticky writer 把心跳钉在最后一行,事件在它上面滚,心跳原地刷新;
+  // 非 TTY(JSON / 重定向)走 append-only 走 logger.log。
   let activityTickerHandle = null;
   if (bridgeHealthy && options.activityTicker !== false) {
+    const isStickyMode = colorMode && !jsonMode && options.sticky !== false;
+    const sticky = isStickyMode ? (options.stickyWriter ?? createStickyWriter({ stdout: options.stdout ?? process.stdout })) : null;
+
     const ticker = createActivityTicker({
       color: colorMode,
       json: jsonMode,
-      emit: (line) => logger.log(line),
+      emit: sticky ? (line) => sticky.emit(line) : (line) => logger.log(line),
     });
     const tailer = createLogTailer({
       filePath: bridgeRuntimeLogPath,
@@ -148,12 +153,22 @@ export async function runStart(options = {}) {
       startFromEnd: true,
     });
     const startedAt = Date.now();
+    // sticky 模式 1s 一跳(原地刷新无成本);非 sticky 模式 30s 一行(避免刷屏)。
+    const intervalMs = sticky ? 1000 : (options.statusEverySec ? options.statusEverySec * 1000 : 30_000);
     const statusInterval = setInterval(() => {
-      ticker.status({
-        uptimeSec: Math.floor((Date.now() - startedAt) / 1000),
-      });
-    }, options.statusEverySec ? options.statusEverySec * 1000 : 30_000);
-    activityTickerHandle = { tailer, statusInterval };
+      const text = ticker.status({ uptimeSec: Math.floor((Date.now() - startedAt) / 1000) });
+      if (sticky) {
+        sticky.setStatus(text);
+      } else if (jsonMode) {
+        logger.log(text); // JSON 行
+      }
+      // 普通追加模式(无颜色无 JSON 的奇怪场景):不打心跳,避免刷屏
+    }, intervalMs);
+    // 初次立刻显示一次心跳
+    if (sticky) {
+      sticky.setStatus(ticker.status({ uptimeSec: 0 }));
+    }
+    activityTickerHandle = { tailer, statusInterval, sticky };
   }
 
   let shuttingDown = false;
@@ -165,6 +180,7 @@ export async function runStart(options = {}) {
     if (activityTickerHandle) {
       activityTickerHandle.tailer.stop();
       clearInterval(activityTickerHandle.statusInterval);
+      activityTickerHandle.sticky?.cleanup();
     }
     await stopManagedProcess(bridgeProcess, { owned: true });
     await stopManagedProcess(opencode.child, { owned: opencode.ownedProcess });

--- a/test/scripts-onboard-start.test.ts
+++ b/test/scripts-onboard-start.test.ts
@@ -1138,17 +1138,67 @@ describe("scripts/activity-ticker", () => {
     expect(parsed.cost).toEqual({ estimatedCostCny: "0.0124", totalTokens: "600" });
   });
 
-  it("ActivityTicker.status emits uptime heartbeat line, no cost field", async () => {
+  it("ActivityTicker.status returns formatted heartbeat string (does not auto-emit)", async () => {
     const { createActivityTicker } = await import("../scripts/runtime/activity-ticker.mjs");
     const out: string[] = [];
     const ticker = createActivityTicker({ color: false, json: false, emit: (l: string) => out.push(l) });
-    ticker.status({ uptimeSec: 125 });
-    expect(out).toHaveLength(1);
-    expect(out[0]).toContain("uptime");
-    expect(out[0]).toContain("2m 5s");
-    // 心跳行不再包含 session cost
-    expect(out[0]).not.toContain("¥");
-    expect(out[0]).not.toContain("session cost");
+    const returned = ticker.status({ uptimeSec: 125 });
+    // 不再自动 emit,由调用方决定怎么用
+    expect(out).toHaveLength(0);
+    expect(returned).toContain("uptime");
+    expect(returned).toContain("2m 5s");
+    expect(returned).not.toContain("¥");
+    expect(returned).not.toContain("session cost");
+  });
+
+  it("ActivityTicker.status returns JSON string in json mode", async () => {
+    const { createActivityTicker } = await import("../scripts/runtime/activity-ticker.mjs");
+    const ticker = createActivityTicker({ color: false, json: true, emit: () => {} });
+    const returned = ticker.status({ uptimeSec: 60 });
+    const parsed = JSON.parse(returned as string);
+    expect(parsed).toMatchObject({ scope: "ticker", name: "status", uptimeSec: 60 });
+  });
+});
+
+describe("scripts/activity-ticker createStickyWriter", () => {
+  function makeFakeStdout() {
+    const written: string[] = [];
+    return {
+      written,
+      write: (s: string) => { written.push(s); return true; },
+    };
+  }
+
+  it("setStatus draws sticky line; emit clears it, writes event, redraws", async () => {
+    const { createStickyWriter } = await import("../scripts/runtime/activity-ticker.mjs");
+    const stdout = makeFakeStdout();
+    const sticky = createStickyWriter({ stdout: stdout as unknown as NodeJS.WritableStream });
+    sticky.setStatus("status uptime 5s");
+    expect(stdout.written).toEqual(["status uptime 5s"]); // 无 newline,粘在底
+    sticky.emit("event A");
+    expect(stdout.written.slice(1)).toEqual([
+      "\r[2K",          // 清当前行
+      "event A\n",            // 写事件 + newline
+      "status uptime 5s",     // 重画 sticky
+    ]);
+  });
+
+  it("setStatus updates in-place (clear then re-draw)", async () => {
+    const { createStickyWriter } = await import("../scripts/runtime/activity-ticker.mjs");
+    const stdout = makeFakeStdout();
+    const sticky = createStickyWriter({ stdout: stdout as unknown as NodeJS.WritableStream });
+    sticky.setStatus("a");
+    sticky.setStatus("b");
+    expect(stdout.written).toEqual(["a", "\r[2K", "b"]);
+  });
+
+  it("cleanup clears sticky and adds final newline for prompt", async () => {
+    const { createStickyWriter } = await import("../scripts/runtime/activity-ticker.mjs");
+    const stdout = makeFakeStdout();
+    const sticky = createStickyWriter({ stdout: stdout as unknown as NodeJS.WritableStream });
+    sticky.setStatus("x");
+    sticky.cleanup();
+    expect(stdout.written).toEqual(["x", "\r[2K", "\n"]);
   });
 
   it("collectEnabledExtensions returns memory + legal defaults", async () => {


### PR DESCRIPTION
## 变更内容

- activity ticker 的 status 改为返回字符串，由调用方决定输出方式。
- 新增 sticky writer：TTY 模式下将心跳固定在底部原地刷新，事件日志在上方滚动。
- JSON 模式继续输出 status JSON 行；非 sticky 普通模式避免无意义刷屏。
- 补充 sticky writer、JSON status 和 status return 行为测试。

## 变更原因

- 运行时终端需要持续显示 bridge 仍然存活，但不希望 1 秒一行刷屏。
- 将 status 渲染和输出策略分离，方便 TTY / JSON / 重定向三种模式分别处理。

## 影响

- 仅影响本地 scripts/runtime/start.mjs 的终端 activity ticker 展示。
- 不改变 Feishu 用户侧行为、runtime turn lifecycle 或模块接口。

## 验证

- npm run typecheck
- npm test -- --run test/scripts-onboard-start.test.ts
