### PR TITLE
[codex][feat] 增强会话命令速查与操作按钮

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -13,6 +13,7 @@
 | `/cost` | 查看本地 token 与成本估算 |
 | `/sessions` | 查看当前窗口绑定的 OpenCode 会话 |
 | `/sessions all` | 查看全部 OpenCode 会话 |
+| `/sessions help` | 查看会话操作速查 |
 | `/preview <编号>` | 预览最近一次会话列表中的会话 |
 | `/preview <sessionId>` | 按 sessionId 预览 OpenCode 会话 |
 | `/switch <编号>` | 切换或绑定并切换会话 |

--- a/src/bridge/router.ts
+++ b/src/bridge/router.ts
@@ -17,7 +17,7 @@ export type RoutedText =
       | { kind: "models"; provider?: string | undefined }
       | { kind: "model-use"; model: string }
       | { kind: "model-reset" }
-      | { kind: "help" }
+      | { kind: "help"; scope?: "sessions" | undefined }
       | { kind: "knowledge-query"; question: string; explicit?: boolean | undefined }
       | { kind: "knowledge-ingest" }
       | { kind: "knowledge-ingest-end" }
@@ -107,6 +107,10 @@ export function routeIncomingText(text: string): RoutedText {
     return { kind: "command", command: { kind: "help" } };
   }
 
+  if (["help", "commands", "指令", "帮助"].includes(rawCommand) && args.length === 1 && ["sessions", "session", "会话"].includes(args[0] ?? "")) {
+    return { kind: "command", command: { kind: "help", scope: "sessions" } };
+  }
+
   if ((rawCommand === "知识入库" || rawCommand === "kb-ingest" || rawCommand === "kb-ingest-start") && args.length === 0) {
     return { kind: "command", command: { kind: "knowledge-ingest" } };
   }
@@ -121,6 +125,10 @@ export function routeIncomingText(text: string): RoutedText {
 
   if (rawCommand === "sessions" && args.length === 0) {
     return { kind: "command", command: { kind: "sessions" } };
+  }
+
+  if (rawCommand === "sessions" && args.length === 1 && ["help", "帮助"].includes(args[0] ?? "")) {
+    return { kind: "command", command: { kind: "help", scope: "sessions" } };
   }
 
   if (rawCommand === "sessions" && args.length === 1 && args[0] === "all") {

--- a/src/feishu/runtime-cards.ts
+++ b/src/feishu/runtime-cards.ts
@@ -198,6 +198,8 @@ export function buildSessionListCardPayload(view: SessionListCardView): FeishuPo
       buildDivider(),
       buildRuntimeActionBlock([
         runtimeCommandButton("新建会话", "/new", "primary", "send-message", "fill"),
+        runtimeCommandButton("全部会话", "/sessions all", "default", "send-message", "fill"),
+        runtimeCommandButton("会话帮助", "/sessions help", "default", "send-message", "fill"),
       ]),
       buildFooterTipBlock(normalizeSessionListFooter(view.footer), "efficiency_outlined", "grey", "notation"),
     ]
@@ -661,6 +663,7 @@ function buildSessionListItemBlock(item: SessionListCardView["items"][number]): 
       : [
         previewButton,
         buildCompactRuntimeButton(runtimeCommandButton("切换", `/switch ${item.index}`, "default", "send-message")),
+        buildCompactRuntimeButton(runtimeCommandButton("删除", `/delete ${item.index}`, "danger", "send-message")),
       ];
   return columnSet([
     column([
@@ -718,6 +721,8 @@ function normalizeSessionListFooter(footer: string): string {
 function buildSessionListActionBlock(view: SessionListCardView): Record<string, unknown> {
   const buttons = [
     runtimeCommandButton("新建会话", "/new", "primary", "send-message"),
+    runtimeCommandButton("全部会话", "/sessions all", "default", "send-message"),
+    runtimeCommandButton("会话帮助", "/sessions help", "default", "send-message"),
   ];
   if (view.items.some((item) => item.archived)) {
     buttons.push(runtimeCardActionButton("清理已归档", "clean-archived", "danger", "update-card", "default", {

--- a/src/feishu/ws.ts
+++ b/src/feishu/ws.ts
@@ -137,6 +137,10 @@ export class FeishuWsClient {
       // We do not need it for runtime behavior, but registering a no-op
       // handler keeps the SDK from logging an avoidable warning.
       "im.chat.access_event.bot_p2p_chat_entered_v1": async () => {},
+      // Message read receipts (someone marked the message as read).
+      // Bridge has no business logic depending on read state; no-op silences
+      // the SDK warning that otherwise floods logs on every chat read.
+      "im.message.message_read_v1": async () => {},
     });
 
     this.client = new lark.WSClient({

--- a/src/runtime/command-handler.ts
+++ b/src/runtime/command-handler.ts
@@ -390,7 +390,11 @@ export class CommandHandler {
     }
 
     if (command.kind === "help") {
-      await this.context.sendMarkdown(message.chatId, buildCommandHelpText(this.context.config), message.messageId);
+      await this.context.sendMarkdown(
+        message.chatId,
+        command.scope === "sessions" ? buildSessionHelpText() : buildCommandHelpText(this.context.config),
+        message.messageId,
+      );
       return;
     }
 
@@ -1199,6 +1203,23 @@ function buildDeleteConfirmMessage(input: { target: string; confirmCommand: stri
     input.target,
     "",
     `确认请发送 \`${input.confirmCommand}\`。`,
+  ].join("\n");
+}
+
+function buildSessionHelpText(): string {
+  return [
+    "### 会话操作速查",
+    "",
+    "不用背完整命令，优先点会话列表卡片上的按钮。",
+    "",
+    "- `/sessions`：看当前窗口绑定的 OpenCode 会话。",
+    "- `/sessions all`：看全部 OpenCode 会话，包含其他窗口和未归属会话。",
+    "- `/preview <编号>`：先看这个会话最近聊了什么，不切换。",
+    "- `/switch <编号>`：切换；如果来自 `/sessions all`，会先绑定到当前窗口。",
+    "- `/close <编号>`：只从当前窗口移除绑定，不删除真实 OpenCode 会话。",
+    "- `/delete <编号>`：彻底删除 OpenCode 会话，会先要求确认。",
+    "",
+    "建议流程：先 `/sessions all`，点“预览”，确认内容后再点“切换”或“删除”。",
   ].join("\n");
 }
 

--- a/test/app-command-surface.test.ts
+++ b/test/app-command-surface.test.ts
@@ -79,6 +79,22 @@ describe("BridgeApp command surface", () => {
     expect(helpText).not.toContain("/完成上传");
   });
 
+  it("returns focused session help", async () => {
+    const outbound = createOutbound();
+    const app = new BridgeApp(baseConfig(), outbound, logger(), createWhitelist());
+
+    await callHandleCommand(app, {
+      kind: "command",
+      command: { kind: "help", scope: "sessions" },
+    });
+
+    const helpText = extractMarkdown(getReplyPayloads(outbound)[0]);
+    expect(helpText).toContain("会话操作速查");
+    expect(helpText).toContain("/sessions all");
+    expect(helpText).toContain("/preview <编号>");
+    expect(helpText).toContain("先 `/sessions all`");
+  });
+
   it("shows enabled extension commands in help", async () => {
     const outbound = createOutbound();
     const config = baseConfig();
@@ -1962,7 +1978,7 @@ type AppCommandSurfaceTestRoute = {
     | { kind: "new"; title?: string | undefined }
     | { kind: "rename"; title: string }
     | { kind: "abort" }
-    | { kind: "help" }
+    | { kind: "help"; scope?: "sessions" | undefined }
     | { kind: "models"; provider?: string | undefined }
     | { kind: "model-use"; model: string }
     | { kind: "model-reset" }

--- a/test/formatter.test.ts
+++ b/test/formatter.test.ts
@@ -320,6 +320,8 @@ describe("buildPostPayload", () => {
     expect(content.body.elements[1].columns[0].elements[0].columns[2].elements[0].value.command).toBe("/preview 2");
     expect(content.body.elements[1].columns[0].elements[0].columns[2].elements[1].text.content).toBe("切换");
     expect(content.body.elements[1].columns[0].elements[0].columns[2].elements[1].value.command).toBe("/switch 2");
+    expect(content.body.elements[1].columns[0].elements[0].columns[2].elements[2].text.content).toBe("删除");
+    expect(content.body.elements[1].columns[0].elements[0].columns[2].elements[2].value.command).toBe("/delete 2");
     expect(content.body.elements[2].columns[0].background_style).toBe("grey-50");
     expect(content.body.elements[2].columns[0].elements[0].columns[1].elements[0].content).toBe("~~代码审查~~");
     expect(content.body.elements[2].columns[0].elements[0].columns[2].elements[0].content).toBe("已归档");
@@ -334,6 +336,10 @@ describe("buildPostPayload", () => {
     const content = JSON.parse(payload.content) as any;
     expect(content.body.elements[0].columns[0].elements[0].content).toBe("暂无会话");
     expect(content.body.elements[2].columns[0].elements[0].text.content).toBe("新建会话");
+    expect(content.body.elements[2].columns[1].elements[0].text.content).toBe("全部会话");
+    expect(content.body.elements[2].columns[1].elements[0].value.command).toBe("/sessions all");
+    expect(content.body.elements[2].columns[2].elements[0].text.content).toBe("会话帮助");
+    expect(content.body.elements[2].columns[2].elements[0].value.command).toBe("/sessions help");
     expect(content.body.elements[3].columns[0].elements[0].content).toBe("创建第一个会话");
     expect(content.body.elements[3].columns[0].elements[0].text_size).toBe("notation");
   });

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -28,6 +28,14 @@ describe("routeIncomingText", () => {
       kind: "command",
       command: { kind: "help" },
     });
+    expect(routeIncomingText("/help sessions")).toEqual({
+      kind: "command",
+      command: { kind: "help", scope: "sessions" },
+    });
+    expect(routeIncomingText("/sessions help")).toEqual({
+      kind: "command",
+      command: { kind: "help", scope: "sessions" },
+    });
     expect(routeIncomingText("/commands")).toEqual({
       kind: "command",
       command: { kind: "help" },


### PR DESCRIPTION
## 变更内容

- 新增 `/sessions help`、`/help sessions` 会话操作速查。
- 会话列表卡片新增“全部会话”“会话帮助”入口。
- 会话列表项新增“删除”按钮，和已有“预览”“切换”形成完整操作闭环。
- Feishu WS 增加 `im.message.message_read_v1` no-op 处理，减少读回执事件 warning 噪声。
- 更新命令文档、router、formatter 和 command surface 测试。

## 变更原因

- `/preview`、`/switch`、`/delete` 组合后，会话操作入口变多，需要一个用户可见的速查入口。
- 读回执事件不参与 Bridge 业务逻辑，应该静默忽略，避免污染运行日志。

## 影响

- 新增 Bridge-owned help scope，不改变既有 `/help` 总览行为。
- 会话列表卡片的操作按钮变多，但命令语义保持原有规则：`/delete` 仍会走确认。
- WS 读回执事件仅 no-op，不改变消息处理路径。

## 验证

- `npm run typecheck`
- `npm test -- --run test/router.test.ts test/formatter.test.ts test/app-command-surface.test.ts`
