### PR TITLE
[codex][feat] 补充 Docker 部署与 reasoning 面板

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,10 +2,16 @@ node_modules
 dist
 .git
 .github
+.DS_Store
 coverage
 logs
 data
 config.json
 docs
 test
+.runtime
+artifacts
+release
+turn-files
+vault
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@
 
 - README 瘦身，新增 `docs/features.md` 和 `docs/commands.md` 承接功能与命令细节。
 - `CODEX.md` 新增工程纪律、自 review 清单、文档生命周期和 release changelog 规则。
+- Docker 部署支持：Dockerfile 多阶段构建参数化、HEALTHCHECK、`docker-compose.yml`、`docs/deploy-docker.md`。
+- `package.json` 补充 description、license、repository、keywords 等元数据字段。
+- README 新增 CI 状态徽章。
 
 ### Changed
 
 - 文档入口补充功能说明、命令手册和 backlog 生命周期入口。
+- `.dockerignore` 扩充忽略范围（`.DS_Store`、`.runtime`、`artifacts`、`release`、`turn-files`、`vault`）。
 
 ### Deprecated
 
@@ -23,7 +27,7 @@
 
 ### Fixed
 
-- 无。
+- 修正 README 许可证徽章从 MIT 为 Apache-2.0，与 LICENSE 文件保持一致。
 
 ### Security
 

--- a/CODEX.md
+++ b/CODEX.md
@@ -81,6 +81,56 @@
 - [ ] 对照 slice plan 检查范围是否一致，是否有“顺手”超出或未声明的范围缩减。
 - [ ] 重新跑 `npm run typecheck` 和相关测试；不要用“上次跑过了”代替本次验证。
 
+## 外部审查交接流程
+
+当用户希望先交给其他 agent 做一审，再由 Codex 二审和修复时，使用两段式流程。
+
+一审 agent 只审查，不修改文件：
+
+- 先读 `AGENTS.md` 和 `CODEX.md`，再看 `git status`、`git diff --stat`、`git diff`。
+- 明确审查范围：仅 dirty diff、某个 issue/PR，或全项目常规审查。
+- Findings 必须按 `P1/P2/P3` 排序，并包含文件、行号、问题、影响、证据、建议修复和测试建议。
+- 不确定的问题放入 `Open Questions`；不要把风格建议伪装成 bug。
+- 不 stage、不 commit、不修复，只输出结构化审查报告。
+
+推荐报告结构：
+
+```md
+# Code Review Report
+
+## Scope
+- Branch / commit:
+- Compared against:
+- Reviewed areas:
+- Not reviewed:
+
+## Findings
+### P1 / P2 / P3: 标题
+- File:
+- Lines:
+- Problem:
+- Impact:
+- Evidence:
+- Suggested fix:
+- Test suggestion:
+
+## Open Questions
+
+## Validation
+- Commands run:
+- Results:
+- Known failures:
+
+## Residual Risks
+```
+
+Codex 接到一审报告后负责二审和落地：
+
+- 逐条复核 finding 是否成立，合并重复项，剔除误报。
+- 按优先级修复成立的问题，保持改动聚焦，不接管无关 dirty worktree。
+- 为修复补最窄有效测试，再跑相关检查；较大修复应补跑 `npm run typecheck`、`npm run lint`、`npm test`。
+- 最终回复说明采纳了哪些 finding、拒绝了哪些误报、实际验证命令和剩余风险。
+
 ## 文档生命周期
 
 文档也有生命周期。不要让已完成 slice、过期设计和当前有效规范长期混在同一个目录里。
@@ -145,9 +195,96 @@
 - runtime 和 transport 事件必须使用 `docs/observability/event-schema.md`，不要发明临时事件名。
 - 如果功能改变 architecture seam，合并前必须更新 `docs/architecture-baseline.md`。
 - 代码注释默认使用中文，除非注释内容是外部 API 原文、协议字段、错误码或必须保持英文的术语。
-- 为新增的重要文件添加文件头注释，沿用项目现有的 `职责 / 关注点` 模板。
-- 为非显而易见的代码路径添加简洁注释，尤其是兼容逻辑、fallback 行为、并发/定时器处理、外部 API 特殊行为和跨模块契约。
-- 注释应解释代码为什么存在、保护什么不变量、或规避什么历史问题；不要添加逐行复述代码的低价值注释。
+- 遵守下面的注释维护标准；新增代码文件、重要重构和测试文件都要同步维护头注释。
+
+## 注释维护标准
+
+注释是给后续维护者和 coding agent 的导航，不是给每一行代码配字幕。目标是让人快速知道文件负责什么、边界在哪里、哪些路径需要小心。
+
+文件头注释：
+
+- 所有仓库自有代码文件都应有文件头注释，包括 `src/`、`scripts/`、`test/`、根目录代码配置文件，以及声明文件。
+- 排除依赖、构建产物和缓存目录，例如 `node_modules`、`.opencode`、`dist`、`coverage`。
+- TypeScript、JavaScript、CJS、MJS 文件使用块注释模板：
+
+```ts
+/**
+ * 职责: 一句话说明这个文件负责什么。
+ * 关注点:
+ * - 说明主要输入、输出、边界或副作用。
+ * - 说明容易误用的约束、fallback 或跨模块契约。
+ */
+```
+
+- Python 文件使用模块 docstring；带 shebang 的脚本要把 docstring 放在 shebang 后、import 前：
+
+```python
+"""
+职责: 一句话说明这个脚本或模块负责什么。
+关注点:
+- 说明主要输入、输出、边界或副作用。
+- 说明容易误用的约束、fallback 或跨模块契约。
+"""
+```
+
+- 空包入口如 `__init__.py` 可以使用一行 docstring，但应放在文件最前面的有效语句位置。
+- 测试文件头注释保持轻量，说明覆盖对象和关注点即可，不要把测试用例逐条复述一遍。
+- 根目录配置脚本也要有头注释，例如 `.eslintrc.cjs`、`.dependency-cruiser.cjs`。
+
+函数和区域注释：
+
+- 复杂文件可以使用 `//#region <Name>` / `//#endregion` 分区，优先按生命周期、入口、解析、持久化、渲染、内部 helper 等职责分组。
+- 对导出的函数、类方法和关键内部 helper 添加一句短注释；简单 getter、纯类型定义和一眼可懂的小函数可以不写。
+- 以下代码路径必须优先注释：兼容逻辑、fallback 行为、重试/定时器/并发处理、外部 API 特殊行为、跨模块契约、状态迁移、数据脱敏、权限/安全边界。
+- 注释要解释“为什么存在、保护什么不变量、规避什么历史问题”，不要写“把 A 赋值给 B”这类逐行复述。
+- 注释风格要克制、稳定、可维护；避免口号化、修辞化或把实现细节写成文件职责。
+
+检查流程：
+
+1. 先扫描缺少文件头注释的自有代码文件：
+
+```bash
+node - <<'NODE'
+const { execFileSync } = require("child_process");
+const { readFileSync } = require("fs");
+
+const files = execFileSync("rg", [
+  "--files",
+  "-g", "*.ts",
+  "-g", "*.tsx",
+  "-g", "*.js",
+  "-g", "*.mjs",
+  "-g", "*.cjs",
+  "-g", "*.py",
+  "-g", "!node_modules",
+  "-g", "!.opencode",
+  "-g", "!dist",
+  "-g", "!coverage",
+], { encoding: "utf8" }).trim().split("\n").filter(Boolean).sort();
+
+for (const file of files) {
+  const text = readFileSync(file, "utf8");
+  const trimmed = text.replace(/^#!.*\n/, "").trimStart();
+  const hasHeader = trimmed.startsWith("/**")
+    || trimmed.startsWith("\"\"\"")
+    || trimmed.startsWith("'''");
+  if (!hasHeader) {
+    console.log(file);
+  }
+}
+NODE
+```
+
+2. 对扫描结果逐个判断是否属于仓库自有代码；不要给依赖缓存、生成产物或外部 vendored 文件补注释。
+3. 补注释后复跑扫描命令，确认没有遗漏。
+4. 跑格式检查，至少覆盖本次涉及的代码范围：
+
+```bash
+git diff --check -- src scripts test .dependency-cruiser.cjs .eslintrc.cjs
+```
+
+5. 如果注释整理移动了 import、shebang、docstring 或声明文件开头，再补跑相关最窄测试或 `npm run typecheck`，确认没有破坏语法和模块解析。
+6. 最后通读 `git diff`，确认本轮只改注释或注释位置；如果顺手改了逻辑，必须单独说明并补验证。
 
 ## 检查命令
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:20-bookworm-slim AS builder
+ARG NODE_IMAGE=node:20-bookworm-slim
+FROM ${NODE_IMAGE} AS builder
 WORKDIR /app
 
 COPY package.json package-lock.json ./
@@ -8,15 +9,22 @@ COPY tsconfig.json ./
 COPY src ./src
 RUN npm run build && npm prune --omit=dev
 
-FROM node:20-bookworm-slim AS runner
+# 再次声明 NODE_IMAGE，让两个阶段的基础镜像参数在各自 FROM 前都清晰可见。
+ARG NODE_IMAGE=node:20-bookworm-slim
+FROM ${NODE_IMAGE} AS runner
 WORKDIR /app
 ENV NODE_ENV=production
+ENV BRIDGE_CONFIG_PATH=/app/config.json
 
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/package-lock.json ./package-lock.json
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
+COPY config.example.json ./config.example.json
 
 EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:3000/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 
 CMD ["node", "dist/index.js"]

--- a/README.en.md
+++ b/README.en.md
@@ -1,10 +1,10 @@
 # Feishu OpenCode Bridge
 
+[![CI](https://github.com/Clukay-Fun/feishu-opencode-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/Clukay-Fun/feishu-opencode-bridge/actions/workflows/ci.yml)
 [![Node.js](https://img.shields.io/badge/Node.js-20%2B-339933)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6)](https://www.typescriptlang.org/)
 [![Feishu](https://img.shields.io/badge/Feishu-Bridge-0F6FFF)](https://open.feishu.cn/)
-[![Tests](https://img.shields.io/badge/tests-passing-success)](#developer-entry)
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 [中文](README.md) | **English**
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Feishu OpenCode Bridge
 
+[![CI](https://github.com/Clukay-Fun/feishu-opencode-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/Clukay-Fun/feishu-opencode-bridge/actions/workflows/ci.yml)
 [![Node.js](https://img.shields.io/badge/Node.js-20%2B-339933)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6)](https://www.typescriptlang.org/)
 [![Feishu](https://img.shields.io/badge/Feishu-Bridge-0F6FFF)](https://open.feishu.cn/)
-[![测试](https://img.shields.io/badge/tests-passing-success)](#开发者入口)
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 **中文** | [English](README.en.md)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  bridge:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        NODE_IMAGE: ${NODE_IMAGE:-node:20-bookworm-slim}
+    image: feishu-opencode-bridge:local
+    container_name: feishu-opencode-bridge
+    restart: unless-stopped
+    environment:
+      NODE_ENV: production
+      BRIDGE_CONFIG_PATH: /app/config.json
+      TZ: Asia/Shanghai
+    ports:
+      - "127.0.0.1:3000:3000"
+    volumes:
+      - ./config.json:/app/config.json:ro
+      - ./data:/app/data
+      - ./logs:/app/logs
+      - ./vault:/app/vault

--- a/docs/deploy-docker.md
+++ b/docs/deploy-docker.md
@@ -1,0 +1,109 @@
+# Docker 部署说明
+
+## 部署形态
+
+Docker 只运行 Feishu OpenCode Bridge 本体。
+
+Obsidian 不需要安装在服务器上。服务器只挂载一个 Markdown vault 目录，供 Bridge 写入；本地 Obsidian 通过同步工具打开这个目录。
+
+## 1. 准备服务器目录
+
+```bash
+mkdir -p /srv/feishu-opencode-bridge
+cd /srv/feishu-opencode-bridge
+```
+
+把项目代码上传到这个目录，或在服务器上拉取仓库。
+
+```bash
+git clone <your-repo-url> .
+```
+
+## 2. 准备配置和持久化目录
+
+```bash
+cp config.example.json config.json
+mkdir -p data logs vault
+```
+
+编辑 `config.json`。Docker 部署时建议至少调整：
+
+```json
+{
+  "opencode": {
+    "baseUrl": "http://host.docker.internal:4096/",
+    "directory": "/workspace"
+  },
+  "storage": {
+    "dataDir": "./data"
+  },
+  "server": {
+    "host": "0.0.0.0",
+    "port": 3000,
+    "publicBaseUrl": "https://bridge.example.com/"
+  },
+  "logging": {
+    "dir": "./logs"
+  },
+  "memory": {
+    "obsidian": {
+      "enabled": false,
+      "vaultPath": "./vault"
+    }
+  }
+}
+```
+
+如果启用知识库 Obsidian 导出，也把 `knowledgeBase.obsidian.vaultPath` 配成 `./vault`。
+
+注意：`server.host` 在容器里必须使用 `0.0.0.0`，否则宿主机反向代理无法访问容器端口。
+
+## 3. 启动
+
+```bash
+docker compose up -d --build
+```
+
+查看状态：
+
+```bash
+docker compose ps
+docker compose logs -f bridge
+curl http://127.0.0.1:3000/healthz
+```
+
+## 4. 配置 HTTPS 反向代理
+
+用 Caddy 把公网 HTTPS 转发到本机 Docker 暴露的端口：
+
+```caddyfile
+bridge.example.com {
+  encode zstd gzip
+  reverse_proxy 127.0.0.1:3000
+}
+```
+
+飞书卡片 Action 回调地址填写：
+
+```text
+https://bridge.example.com/webhook/card
+```
+
+## 5. 更新
+
+```bash
+git pull
+docker compose up -d --build
+```
+
+`config.json`、`data/`、`logs/`、`vault/` 都在宿主机目录中，不会因为重建镜像丢失。
+
+## 6. Obsidian 同步
+
+服务器侧只维护：
+
+```text
+/srv/feishu-opencode-bridge/vault
+```
+
+本地 Obsidian 可通过 Git、Syncthing、rsync、SFTP 或 WebDAV 同步这个目录。Bridge 不依赖 Obsidian 桌面应用，也不会调用 Obsidian 插件运行时。

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -7,6 +7,8 @@
 - 通过 Caddy 暴露 HTTPS
 - 飞书卡片 action 回调走公开域名
 
+如果使用 Docker 部署 Bridge 本体，优先参考 [Docker 部署说明](deploy-docker.md)。
+
 ## 1. 环境准备
 
 安装 Node.js 20+、Caddy、OpenCode。

--- a/package.json
+++ b/package.json
@@ -1,11 +1,53 @@
 {
   "name": "feishu-opencode-bridge",
   "version": "0.2.2",
+  "description": "Run OpenCode AI agents inside Feishu / Lark, with first-class support for legal-practice workflows (knowledge base, contract, labor cases).",
   "private": true,
   "type": "module",
+  "license": "Apache-2.0",
+  "author": "Clukay-Fun",
+  "homepage": "https://github.com/Clukay-Fun/feishu-opencode-bridge#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Clukay-Fun/feishu-opencode-bridge.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Clukay-Fun/feishu-opencode-bridge/issues"
+  },
+  "keywords": [
+    "feishu",
+    "lark",
+    "opencode",
+    "agentic-cli",
+    "ai-agent",
+    "ai-runtime",
+    "bridge",
+    "chatbot",
+    "legal-ai",
+    "knowledge-base",
+    "rag",
+    "feishu-bot"
+  ],
   "engines": {
     "node": ">=20.0.0"
   },
+  "main": "dist/src/index.js",
+  "bin": {
+    "feishu-opencode-bridge": "./bin/bridge"
+  },
+  "files": [
+    "dist/src/",
+    "bin/",
+    "scripts/runtime/",
+    "scripts/release/build-portable.mjs",
+    "config.example.json",
+    "config.general.example.json",
+    "config.legal.example.json",
+    "README.md",
+    "README.en.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc --noEmit -p tsconfig.json",

--- a/src/feishu/runtime-cards.ts
+++ b/src/feishu/runtime-cards.ts
@@ -26,7 +26,12 @@ export type TurnStatusCardView = {
   toolUpdates: ReadonlyArray<ToolUpdateView>;
   output: OutputView;
   costSummary?: string | undefined;
+  /** 完整 AI 推理文本(累积),折叠面板用。空字符串则不渲染该面板。 */
+  reasoningText?: string | undefined;
 };
+
+/** 思考过程面板最大字符数,超出截断加省略号——避免单卡片 payload 超限。 */
+const REASONING_MAX_CHARS = 3000;
 
 export type StatusCommandCardView = {
   currentSession: { sessionId: string; label: string } | null;
@@ -510,6 +515,12 @@ function buildTurnBodyElements(
 ): Array<Record<string, unknown>> {
   const elements: Array<Record<string, unknown>> = [];
 
+  // 思考过程折叠面板:运行中默认展开(看推理),完成后折叠(节省屏幕)
+  if (view.reasoningText && view.reasoningText.trim()) {
+    const expanded = state.kind !== "completed";
+    elements.push(buildReasoningPanel(view.reasoningText, expanded));
+  }
+
   if (state.kind !== "completed" && toolElements.length > 0) {
     elements.push(buildToolBlock(toolElements));
   }
@@ -518,6 +529,37 @@ function buildTurnBodyElements(
   elements.push(buildDivider());
   elements.push(buildFooter(view.sessionId, view.durationText));
   return elements;
+}
+
+/**
+ * 构造"思考过程"折叠面板。
+ * 飞书卡片 schema 2.0 原生支持 collapsible_panel,点击 header 自动展开/折叠,bridge 不需要写回调。
+ */
+function buildReasoningPanel(text: string, expanded: boolean): Record<string, unknown> {
+  const trimmed = text.trim();
+  const truncated = trimmed.length > REASONING_MAX_CHARS
+    ? `${trimmed.slice(0, REASONING_MAX_CHARS - 1)}…`
+    : trimmed;
+  const title = expanded ? "**正在推理**" : "**思考过程**";
+  return {
+    tag: "collapsible_panel",
+    expanded,
+    header: {
+      title: { tag: "markdown", content: title },
+      vertical_align: "center",
+      icon: { tag: "standard_icon", token: "down-small-ccm_outlined", size: "16px 16px" },
+      icon_position: "follow_text",
+      icon_expanded_angle: -180,
+    },
+    border: { color: "grey", corner_radius: "5px" },
+    vertical_spacing: "8px",
+    padding: "8px 8px 8px 8px",
+    elements: [{ tag: "markdown", content: escapeReasoningMarkdown(truncated), text_size: "notation" }],
+  };
+}
+
+function escapeReasoningMarkdown(text: string): string {
+  return normalizeAssistantMarkdown(escapeText(text)).replace(/([\\`*_[\]#])/g, "\\$1");
 }
 
 function buildToolElements(lines: ReadonlyArray<ToolUpdateView>): Array<Record<string, unknown>> {

--- a/src/runtime/turn-card-manager.ts
+++ b/src/runtime/turn-card-manager.ts
@@ -39,7 +39,12 @@ type TurnCardState = {
   toolUpdates: Array<{ key: string; view: ToolUpdateView }>;
   output: OutputView;
   costSummary?: string | undefined;
+  /** 累积的 AI 推理文本(本 turn 全部 reasoning 片段拼接),用于思考过程折叠面板。 */
+  reasoningText: string;
 };
+
+/** 单 turn 累积 reasoning 上限,超出后停止追加——避免内存膨胀。 */
+const REASONING_ACCUMULATION_LIMIT = 8000;
 
 type StreamFlushState = {
   flushedLength: number;
@@ -94,6 +99,7 @@ export class TurnCardManager {
       progressUpdates: [INITIAL_CARD_SUMMARY],
       toolUpdates: [],
       output: { text: "", paths: [], commands: [] },
+      reasoningText: "",
     };
     try {
       const payload = buildTurnStatusCardPayload(this.toTurnCardView(state));
@@ -147,6 +153,21 @@ export class TurnCardManager {
       state.timer = null;
       void this.flushStreamUpdate(turnId, text, false);
     }, delay);
+  }
+
+  /**
+   * 累积 AI reasoning 文本,供"思考过程"折叠面板使用。
+   * 只在内存里累积,不立刻刷卡片——节流由 updateTurnCard 的常规调用兜底。
+   */
+  appendReasoning(turnId: string, text: string): void {
+    const card = this.turnCards.get(turnId);
+    const normalizedText = text.trim();
+    if (!card || !normalizedText) return;
+    const separator = card.reasoningText ? "\n\n" : "";
+    const remaining = REASONING_ACCUMULATION_LIMIT - card.reasoningText.length - separator.length;
+    if (remaining <= 0) return;
+    const chunk = normalizedText.length > remaining ? normalizedText.slice(0, remaining) : normalizedText;
+    card.reasoningText = `${card.reasoningText}${separator}${chunk}`;
   }
 
   /** 立即把当前文本刷新到卡片。 */
@@ -252,6 +273,7 @@ export class TurnCardManager {
       toolUpdates: card.toolUpdates.map((item) => item.view),
       output: card.output,
       costSummary: card.costSummary,
+      reasoningText: card.reasoningText,
     };
   }
 

--- a/src/runtime/turn-executor.ts
+++ b/src/runtime/turn-executor.ts
@@ -157,6 +157,7 @@ export type TurnExecutorContext = {
     flushStreamUpdate(turnId: string, text: string, force: boolean): Promise<void>;
     updateTurnCard(turnId: string, update: { status?: string; sessionId?: string; update?: string; sanitize?: boolean; target?: "step" | "tool" | "final"; toolKey?: string; costSummary?: string }): Promise<void>;
     scheduleStreamUpdate(turnId: string, text: string): Promise<void>;
+    appendReasoning(turnId: string, text: string): void;
     cleanup(turnId: string): void;
   };
   costTracker?: CostTracker | undefined;
@@ -568,6 +569,10 @@ export class TurnExecutor {
         if (partId) {
           this.context.logger.log("opencode/events", "reasoning received", { turnId: turn.turnId, sessionId: turn.sessionId, len: text.length });
           this.context.logger.logTranscript("reasoning-raw", { turnId: turn.turnId, sessionId: turn.sessionId, partId, len: text.length }, text);
+          // 累积完整 reasoning,渲染到"思考过程"折叠面板;updateTurnCard 触发卡片刷新
+          if (text.trim()) {
+            this.context.turnCardManager.appendReasoning(turn.turnId, text);
+          }
           const step = summarizeReasoningToProgress(text);
           if (step) {
             await this.context.turnCardManager.updateTurnCard(turn.turnId, { status: "处理中", update: step, sanitize: false, target: "step" });

--- a/test/formatter.test.ts
+++ b/test/formatter.test.ts
@@ -115,6 +115,79 @@ describe("buildPostPayload", () => {
     expect(serialized).not.toContain("tokens");
   });
 
+  it("renders reasoning text in a collapsible panel while the turn is running", () => {
+    const payload = buildTurnStatusCardPayload({
+      title: "处理中",
+      status: "处理中",
+      sessionId: "ses_reasoning",
+      durationText: "",
+      progressUpdates: ["正在处理中"],
+      toolUpdates: [],
+      output: { text: "", paths: [], commands: [] },
+      reasoningText: "先分析需求\n再检查代码",
+    });
+    const panel = findByTag(JSON.parse(payload.content), "collapsible_panel");
+    const headerTitle = findByPath(panel, ["header", "title", "content"]);
+    const markdown = readPanelBodyMarkdown(panel);
+
+    expect(panel?.expanded).toBe(true);
+    expect(headerTitle).toBe("**正在推理**");
+    expect(markdown?.content).toContain("先分析需求\n再检查代码");
+  });
+
+  it("renders completed reasoning panel collapsed and escapes markdown controls", () => {
+    const payload = buildTurnStatusCardPayload({
+      title: "已完成",
+      status: "已完成",
+      sessionId: "ses_reasoning",
+      durationText: "约 3s",
+      progressUpdates: ["最终回复已生成"],
+      toolUpdates: [],
+      output: { text: "完成", paths: [], commands: [] },
+      reasoningText: "**unclosed [link <unsafe>",
+    });
+    const panel = findByTag(JSON.parse(payload.content), "collapsible_panel");
+    const headerTitle = findByPath(panel, ["header", "title", "content"]);
+    const markdown = readPanelBodyMarkdown(panel);
+
+    expect(panel?.expanded).toBe(false);
+    expect(headerTitle).toBe("**思考过程**");
+    expect(markdown?.content).toContain("\\*\\*unclosed \\[link &lt;unsafe&gt;");
+  });
+
+  it("does not render a reasoning panel for blank reasoning text", () => {
+    const payload = buildTurnStatusCardPayload({
+      title: "处理中",
+      status: "处理中",
+      sessionId: "ses_reasoning",
+      durationText: "",
+      progressUpdates: ["正在处理中"],
+      toolUpdates: [],
+      output: { text: "", paths: [], commands: [] },
+      reasoningText: "   \n  ",
+    });
+
+    expect(findByTag(JSON.parse(payload.content), "collapsible_panel")).toBeNull();
+  });
+
+  it("truncates long reasoning panel content to the card payload limit", () => {
+    const payload = buildTurnStatusCardPayload({
+      title: "处理中",
+      status: "处理中",
+      sessionId: "ses_reasoning",
+      durationText: "",
+      progressUpdates: ["正在处理中"],
+      toolUpdates: [],
+      output: { text: "", paths: [], commands: [] },
+      reasoningText: "a".repeat(3_001),
+    });
+    const panel = findByTag(JSON.parse(payload.content), "collapsible_panel");
+    const markdown = readPanelBodyMarkdown(panel);
+
+    expect(markdown?.content).toHaveLength(3_000);
+    expect(markdown?.content).toBe(`${"a".repeat(2_999)}…`);
+  });
+
   it("preserves fenced code blocks without escaping arrows", () => {
     const payload = buildTurnStatusCardPayload({
       title: "处理中",
@@ -865,3 +938,34 @@ describe("buildPostPayload", () => {
     expect(content.body.elements[0].columns[0].elements[0].icon).toBeUndefined();
   });
 });
+
+function findByTag(value: unknown, tag: string): Record<string, any> | null {
+  if (!value || typeof value !== "object") return null;
+  if ((value as Record<string, unknown>).tag === tag) return value as Record<string, any>;
+  for (const child of Object.values(value as Record<string, unknown>)) {
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        const found = findByTag(item, tag);
+        if (found) return found;
+      }
+      continue;
+    }
+    const found = findByTag(child, tag);
+    if (found) return found;
+  }
+  return null;
+}
+
+function findByPath(value: unknown, path: string[]): unknown {
+  return path.reduce<unknown>((current, key) => {
+    if (!current || typeof current !== "object") return undefined;
+    return (current as Record<string, unknown>)[key];
+  }, value);
+}
+
+function readPanelBodyMarkdown(panel: Record<string, any> | null): Record<string, any> | null {
+  const elements = panel?.elements;
+  if (!Array.isArray(elements)) return null;
+  const first = elements[0];
+  return first && typeof first === "object" ? first as Record<string, any> : null;
+}

--- a/test/turn-card-manager.test.ts
+++ b/test/turn-card-manager.test.ts
@@ -1,0 +1,108 @@
+/**
+ * 职责: 覆盖 turn 过程卡管理器的内存态聚合行为。
+ * 关注点: 验证 reasoning 累积、截断和空文本处理不会污染运行时卡片。
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { TurnCardManager } from "../src/runtime/turn-card-manager.js";
+import type { FeishuPostPayload } from "../src/feishu/shared-primitives.js";
+import type { Logger } from "../src/logging/logger.js";
+
+describe("TurnCardManager reasoning accumulation", () => {
+  it("ignores blank reasoning chunks", async () => {
+    const { manager, updates } = createManager();
+    await manager.createTurnCard("oc_1", "turn_1", "ses_1", "om_1");
+
+    manager.appendReasoning("turn_1", "");
+    manager.appendReasoning("turn_1", "   \n  ");
+    await manager.updateTurnCard("turn_1", { update: "仍在处理", target: "step" });
+
+    expect(JSON.stringify(readInteractive(updates.at(-1)))).not.toContain("collapsible_panel");
+  });
+
+  it("joins reasoning chunks with a stable paragraph separator", async () => {
+    const { manager, updates } = createManager();
+    await manager.createTurnCard("oc_1", "turn_1", "ses_1", "om_1");
+
+    manager.appendReasoning("turn_1", "第一段");
+    manager.appendReasoning("turn_1", "第二段");
+    await manager.updateTurnCard("turn_1", { update: "仍在处理", target: "step" });
+
+    const panel = findByTag(readInteractive(updates.at(-1)), "collapsible_panel");
+    const markdown = readPanelBodyMarkdown(panel);
+    expect(markdown?.content).toContain("第一段\n\n第二段");
+  });
+
+  it("keeps accumulated reasoning within the hard memory limit", async () => {
+    const { manager } = createManager();
+    await manager.createTurnCard("oc_1", "turn_1", "ses_1", "om_1");
+
+    manager.appendReasoning("turn_1", "a".repeat(7_999));
+    manager.appendReasoning("turn_1", "bbbbbbbbbb");
+
+    const card = (manager as unknown as { turnCards: Map<string, { reasoningText: string }> }).turnCards.get("turn_1");
+    expect(card?.reasoningText).toHaveLength(7_999);
+    expect(card?.reasoningText).not.toContain("b");
+  });
+
+  it("truncates the final chunk after accounting for the separator", async () => {
+    const { manager } = createManager();
+    await manager.createTurnCard("oc_1", "turn_1", "ses_1", "om_1");
+
+    manager.appendReasoning("turn_1", "a".repeat(7_990));
+    manager.appendReasoning("turn_1", "bbbbbbbbbb");
+
+    const card = (manager as unknown as { turnCards: Map<string, { reasoningText: string }> }).turnCards.get("turn_1");
+    expect(card?.reasoningText).toHaveLength(8_000);
+    expect(card?.reasoningText.endsWith("bbbbbbbb")).toBe(true);
+  });
+});
+
+function createManager() {
+  const updates: FeishuPostPayload[] = [];
+  const manager = new TurnCardManager({
+    sendMessage: vi.fn(async () => ({ messageId: "om_process" })),
+    replyMessage: vi.fn(async () => ({ messageId: "om_process" })),
+    updateMessage: vi.fn(async (_messageId, payload) => {
+      updates.push(payload);
+      return { messageId: "om_process" };
+    }),
+  }, createSilentLogger(), true);
+  return { manager, updates };
+}
+
+function createSilentLogger(): Logger {
+  return {
+    log() {},
+    logTranscript() {},
+  };
+}
+
+function readInteractive(payload: FeishuPostPayload | undefined): Record<string, unknown> {
+  if (!payload) throw new Error("missing payload");
+  return JSON.parse(payload.content) as Record<string, unknown>;
+}
+
+function findByTag(value: unknown, tag: string): Record<string, unknown> | null {
+  if (!value || typeof value !== "object") return null;
+  if ((value as Record<string, unknown>).tag === tag) return value as Record<string, unknown>;
+  for (const child of Object.values(value as Record<string, unknown>)) {
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        const found = findByTag(item, tag);
+        if (found) return found;
+      }
+      continue;
+    }
+    const found = findByTag(child, tag);
+    if (found) return found;
+  }
+  return null;
+}
+
+function readPanelBodyMarkdown(panel: Record<string, unknown> | null): Record<string, unknown> | null {
+  const elements = panel?.elements;
+  if (!Array.isArray(elements)) return null;
+  const first = elements[0];
+  return first && typeof first === "object" ? first as Record<string, unknown> : null;
+}

--- a/test/turn-executor.test.ts
+++ b/test/turn-executor.test.ts
@@ -443,6 +443,7 @@ function createContext(): TurnExecutorContext {
       async flushStreamUpdate() {},
       async updateTurnCard() {},
       async scheduleStreamUpdate() {},
+      appendReasoning() {},
       cleanup() {},
     },
     permissionManager: {


### PR DESCRIPTION
## 变更内容

- Docker 部署：扩展 Dockerfile、多阶段构建参数、HEALTHCHECK、docker-compose.yml、Docker 部署文档和 `.dockerignore`。
- 项目元数据：补充 package description/license/repository/keywords/main/bin/files 字段，README 增加 CI 徽章并修正 license badge。
- 开发规范：CODEX.md 增加外部审查交接流程和注释维护标准。
- Runtime 卡片：turn 过程卡新增 reasoning 折叠面板，运行中展开、完成后折叠，并限制卡片和内存累计长度。
- 测试：补充 formatter reasoning panel、TurnCardManager reasoning 累积、TurnExecutor context mock 覆盖。

## 变更原因

- 服务器部署需要更明确的 Docker 路径和持久化目录说明。
- 项目元数据和 README badge 需要与 Apache-2.0 和 GitHub CI 保持一致。
- reasoning 文本以前只写 transcript，不在过程卡里可见；现在通过折叠面板让用户能看到推理过程，同时避免 payload/内存过大。

## 影响

- Docker 部署新增正式入口，不改变本地 npm 启动流程。
- package 元数据变化影响发布/打包展示，不改变 runtime 行为。
- TurnStatusCardView 新增可选 reasoningText 字段；TurnCardManager 新增 appendReasoning 内存态聚合。
- 触碰 turn-executor 仅用于把已有 reasoning 事件转入卡片展示，不改变 turn lifecycle。

## 验证

- `npm run typecheck`
- `npm test -- --run test/formatter.test.ts test/turn-executor.test.ts test/turn-card-manager.test.ts`
- `docker compose config`
