### PR TITLE
[codex][fix] 修正 Docker 与全局安装入口

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
   CMD node -e "fetch('http://127.0.0.1:3000/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 
-CMD ["node", "dist/index.js"]
+CMD ["node", "dist/src/index.js"]

--- a/bin/bridge
+++ b/bin/bridge
@@ -4,9 +4,20 @@
 # - 优先使用包内 .runtime/node，不要求用户预装 Node。
 # - 缺 Node 时自动下载 portable Node。
 # - 后续命令统一交给 scripts/runtime/bootstrap.mjs。
+# - 跟随软链接,兼容 `npm i -g` 安装后被 symlink 到 /usr/local/bin/ 的情况。
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# 解析软链接到真实文件位置(跨 macOS / Linux 兼容,不依赖 GNU readlink -f)
+SOURCE="$0"
+while [ -L "$SOURCE" ]; do
+  LINK_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  case "$SOURCE" in
+    /*) ;;
+    *) SOURCE="$LINK_DIR/$SOURCE" ;;
+  esac
+done
+ROOT="$(cd -P "$(dirname "$SOURCE")/.." && pwd)"
 NODE_BIN="$ROOT/.runtime/node/bin/node"
 
 if [ ! -x "$NODE_BIN" ]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       TZ: Asia/Shanghai
     ports:
       - "127.0.0.1:3000:3000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./config.json:/app/config.json:ro
       - ./data:/app/data

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "feishu-opencode-bridge",
   "version": "0.2.2",
   "description": "Run OpenCode AI agents inside Feishu / Lark, with first-class support for legal-practice workflows (knowledge base, contract, labor cases).",
-  "private": true,
+  "private": false,
   "type": "module",
   "license": "Apache-2.0",
   "author": "Clukay-Fun",


### PR DESCRIPTION
## 变更内容

- Dockerfile CMD 修正为 `dist/src/index.js`，匹配当前 TypeScript 输出结构。
- docker-compose 增加 `host.docker.internal:host-gateway`，方便容器访问宿主机 OpenCode。
- `bin/bridge` 解析真实脚本路径，兼容 npm 全局安装后的 symlink 启动。
- `package.json` 将 `private` 改为 `false`，配合已补充的发布元数据。

## 变更原因

- PR #82 后发现 Docker 运行入口和宿主机访问路径还需要收口。
- 全局安装时 bin 可能位于 `/usr/local/bin` 等软链接位置，必须回溯真实包根目录。

## 影响

- 影响 Docker 启动和 npm 全局安装入口。
- 不改变 Bridge runtime 业务逻辑。

## 验证

- `docker compose config`
- `npm run typecheck`
- `bash -n bin/bridge`
- `git diff --check -- Dockerfile docker-compose.yml package.json bin/bridge`
