### PR TITLE
[codex][release] 准备 0.3.0 版本

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@
 
 ### Added
 
+- 无。
+
+### Changed
+
+- 无。
+
+### Deprecated
+
+- 无。
+
+### Removed
+
+- 无。
+
+### Fixed
+
+- 无。
+
+### Security
+
+- 无。
+
+## [0.3.0] - 2026-06-03
+
+### Added
+
 - README 瘦身，新增 `docs/features.md` 和 `docs/commands.md` 承接功能与命令细节。
 - `CODEX.md` 新增工程纪律、自 review 清单、文档生命周期和 release changelog 规则。
 - Docker 部署支持：Dockerfile 多阶段构建参数化、HEALTHCHECK、`docker-compose.yml`、`docs/deploy-docker.md`。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feishu-opencode-bridge",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feishu-opencode-bridge",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "dependencies": {
         "@inquirer/prompts": "^8.5.1",
         "@larksuiteoapi/node-sdk": "^1.42.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feishu-opencode-bridge",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Run OpenCode AI agents inside Feishu / Lark, with first-class support for legal-practice workflows (knowledge base, contract, labor cases).",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## 变更内容

- 将 `CHANGELOG.md` 的当前 `[Unreleased]` 内容落到 `[0.3.0] - 2026-06-03`。
- 保留新的空 `[Unreleased]` 段，供后续开发继续记录。
- 将 `package.json` 和 `package-lock.json` 版本号升级到 `0.3.0`。

## 变更原因

- 收口近期 Docker 部署、reasoning 面板、会话命令、README/文档治理等更新，形成 0.3.0 开发版本。

## 影响

- 仅版本和 changelog 收口，不改变 runtime 行为。

## 验证

- `npm run typecheck`
- `node -e "const p=require('./package.json'); const l=require('./package-lock.json'); if (p.version !== '0.3.0' || l.version !== '0.3.0' || l.packages[''].version !== '0.3.0') process.exit(1); console.log(p.version)"`
