### PR TITLE
[codex][release] 准备 0.3.0-beta.0 版本

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,4 +14,5 @@ artifacts
 release
 turn-files
 vault
+.env.tunnel
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,40 @@
 
 - 无。
 
+## [0.3.0-beta.0] - 2026-06-04
+
+### Added
+
+- 新增 npm beta 安装入口，`feishu-opencode-bridge` 与 `fob` 全局命令统一分发到跨平台启动器。
+- README 与 README.en 增加 beta 安装示例和 npm beta 徽章。
+- 新增服务器部署脚本、服务器工具更新脚本和 Cloudflare Tunnel compose 示例。
+- 运行台活动视图新增用户入站消息、机器人最终回复和 turn 摘要展示。
+- 结构化日志新增 `bridge/message inbound.received` 事件，补充 chat、conversation、thread 和 message 上下文字段。
+
+### Changed
+
+- 运行台启动脚本优先使用本地 TypeScript 源码启动，避免开发时误跑过期 `dist` 产物。
+- 活动视图改为 tail bridge 结构化日志，并输出更适合排查的 JSON 字段。
+- Docker builder 阶段补充 native 依赖安装，提升 npm 安装与构建兼容性。
+- 服务器部署规范收口到 `CODEX.md`，明确 runtime 私有文件不可被覆盖。
+
+### Deprecated
+
+- 无。
+
+### Removed
+
+- 无。
+
+### Fixed
+
+- 修复 OpenCode reasoning 文本流可能混入最终回复的问题，只有确认的 text part 会进入最终答案。
+- 服务器部署脚本不再内置具体服务器地址、用户和 SSH key 路径，改为运行时显式传入环境变量。
+
+### Security
+
+- 部署脚本移除仓库内硬编码的服务器连接信息，降低误提交部署细节的风险。
+
 ## [0.3.0] - 2026-06-03
 
 ### Added

--- a/CODEX.md
+++ b/CODEX.md
@@ -176,6 +176,18 @@ Codex 接到一审报告后负责二审和落地：
 - `0.X.Y -> 1.0.0`：正式稳定发布或需要向外承诺兼容性边界。
 - `1.0.0` 之后遵循 `MAJOR.MINOR.PATCH`，breaking change 必须升 MAJOR。
 
+## 服务器部署规则
+
+- 服务器只作为运行环境，不作为开发环境或文档归档环境。
+- 服务器目录默认是 `/srv/feishu-opencode-bridge`，运行私有文件包括 `config.json`、`.env`、`.env.tunnel`、`data/`、`logs/`、`vault/`，同步或清理时不得覆盖或删除。
+- 服务器不需要同步开发资料、计划文档、测试、CI 配置或本地运行产物；尤其不要同步 `docs/`、`test/`、`.github/`、`artifacts/`、`release/`、`.runtime/`、`turn-files/`、`node_modules/`、`dist/`。
+- 服务器更新优先使用 `ops/deploy-server.sh` 从本机白名单同步运行必需文件；该脚本负责保留运行私有文件，并清理之前误同步的非运行目录。
+- 当前服务器直连 GitHub 不稳定，不把 `git pull` 作为主更新方式，除非先解决服务器网络或配置可靠代理。
+- 当前服务器规格较小，不要在服务器上执行重型源码构建或 `docker compose up -d --build`。如需重建镜像，应优先在本机或 CI 构建并推送镜像，服务器只拉取/重启。
+- 如必须临时在服务器构建，先确认 CPU、内存、磁盘和 SSH 可恢复方案；构建后立即验证 `docker compose ps`、`systemctl --user status opencode-bridge.service` 和公开 health check URL。
+- Cloudflare Tunnel 使用 `docker-compose.tunnel.yml` 和服务器侧 `.env.tunnel`；`.env.tunnel` 属于敏感运行配置，不提交、不同步覆盖。
+- 服务器宿主工具更新使用 `ops/update-server-tools.sh`。默认只更新 `@larksuite/cli`；OpenCode 和 Cloudflare Tunnel 镜像需要显式传 `--opencode` 或 `--cloudflared`，避免自动升级影响运行中的 bridge。
+
 ## 飞书、Lark 与知识库操作
 
 - 只有用户明确要求操作飞书或 Lark 资源时，才使用 `lark-cli`。

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,14 @@ ARG NODE_IMAGE=node:20-bookworm-slim
 FROM ${NODE_IMAGE} AS builder
 WORKDIR /app
 
+RUN sed -i \
+    -e 's|http://deb.debian.org/debian-security|http://mirrors.aliyun.com/debian-security|g' \
+    -e 's|http://deb.debian.org/debian|http://mirrors.aliyun.com/debian|g' \
+    /etc/apt/sources.list /etc/apt/sources.list.d/debian.sources 2>/dev/null || true \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends python3 make g++ \
+  && rm -rf /var/lib/apt/lists/*
+
 COPY package.json package-lock.json ./
 RUN npm ci
 

--- a/README.en.md
+++ b/README.en.md
@@ -1,5 +1,6 @@
 # Feishu OpenCode Bridge
 
+[![npm](https://img.shields.io/npm/v/feishu-opencode-bridge/beta.svg?label=npm%20beta)](https://www.npmjs.com/package/feishu-opencode-bridge)
 [![CI](https://github.com/Clukay-Fun/feishu-opencode-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/Clukay-Fun/feishu-opencode-bridge/actions/workflows/ci.yml)
 [![Node.js](https://img.shields.io/badge/Node.js-20%2B-339933)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6)](https://www.typescriptlang.org/)
@@ -31,6 +32,21 @@ By default, text goes through your configured OpenCode / AI provider. Contract, 
 See [Features](docs/features.md) for details.
 
 ## Quick Start
+
+### npm Install (Beta)
+
+```bash
+npm i -g feishu-opencode-bridge@beta
+feishu-opencode-bridge setup
+feishu-opencode-bridge start
+```
+
+You can also use the short alias:
+
+```bash
+fob setup
+fob start
+```
 
 Release users should start from the portable launcher (source developers can skip to the npm section below):
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Feishu OpenCode Bridge
 
+[![npm](https://img.shields.io/npm/v/feishu-opencode-bridge/beta.svg?label=npm%20beta)](https://www.npmjs.com/package/feishu-opencode-bridge)
 [![CI](https://github.com/Clukay-Fun/feishu-opencode-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/Clukay-Fun/feishu-opencode-bridge/actions/workflows/ci.yml)
 [![Node.js](https://img.shields.io/badge/Node.js-20%2B-339933)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6)](https://www.typescriptlang.org/)
@@ -31,6 +32,21 @@ Feishu OpenCode Bridge 是飞书原生 OpenCode runtime + 法律材料工作台�
 更多功能说明见 [功能说明](docs/features.md)。
 
 ## 快速开始
+
+### npm 安装（预览版）
+
+```bash
+npm i -g feishu-opencode-bridge@beta
+feishu-opencode-bridge setup
+feishu-opencode-bridge start
+```
+
+安装后也可以使用短命令：
+
+```bash
+fob setup
+fob start
+```
 
 Release 包用户优先使用 portable 入口（源码开发者请直接跳到下方 npm 段）：
 

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/**
+ * 职责: feishu-opencode-bridge / fob 全局命令的 Node 分发入口。
+ * 关注点:
+ * - npm 全局安装时,bin 字段指向本文件(必须是 Node-runnable .mjs/.cjs/.js)。
+ * - 运行时按平台分发到对应 shell 启动器(bin/bridge / bin/bridge.cmd)。
+ * - 跟随软链接到包内真实路径,兼容 `npm i -g` 在 /usr/local/bin/ 创建的 symlink。
+ */
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { existsSync, realpathSync } from "node:fs";
+
+// 解析自身真实路径(跟随软链接 → npm 全局安装的真实 bin/cli.mjs)
+const SELF = realpathSync(fileURLToPath(import.meta.url));
+const BIN_DIR = path.dirname(SELF);
+const PACKAGE_ROOT = path.dirname(BIN_DIR);
+
+// 按平台选启动器
+const isWindows = process.platform === "win32";
+const launcher = isWindows
+  ? path.join(BIN_DIR, "bridge.cmd")
+  : path.join(BIN_DIR, "bridge");
+
+if (!existsSync(launcher)) {
+  console.error(`错误: 找不到启动器 ${launcher}`);
+  console.error(`包根目录: ${PACKAGE_ROOT}`);
+  console.error(`这可能是 npm 安装包不完整导致,请重新安装:`);
+  console.error(`  npm i -g feishu-opencode-bridge@beta`);
+  process.exit(1);
+}
+
+// 透传所有参数 + 环境变量,使用 inherit stdio 让用户直接看到输出
+const child = spawn(launcher, process.argv.slice(2), {
+  stdio: "inherit",
+  env: process.env,
+  shell: isWindows, // Windows 需要 shell:true 才能运行 .cmd
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+  } else {
+    process.exit(code ?? 0);
+  }
+});
+
+child.on("error", (err) => {
+  console.error(`启动 ${launcher} 失败:`, err.message);
+  process.exit(1);
+});

--- a/docker-compose.tunnel.yml
+++ b/docker-compose.tunnel.yml
@@ -1,0 +1,9 @@
+services:
+  cloudflared:
+    image: docker.m.daocloud.io/cloudflare/cloudflared:latest
+    container_name: feishu-opencode-bridge-tunnel
+    restart: unless-stopped
+    network_mode: host
+    env_file:
+      - .env.tunnel
+    command: tunnel --no-autoupdate run --token ${CLOUDFLARED_TOKEN}

--- a/docs/observability/event-schema.md
+++ b/docs/observability/event-schema.md
@@ -1,6 +1,6 @@
 # 可观测性事件规范
 
-> 最后更新：2026-04-19
+> 最后更新：2026-06-03
 >
 > 这份文档定义了 bridge 运行时第一版稳定事件词表。
 > 它刻意采用“文档先行”的方式：代码应逐步收敛到这些事件名，而不是在各调用点继续自由发明日志文本。
@@ -35,6 +35,30 @@
 - transcript 文件与结构化 bridge 事件应保持分离。
 
 ## 事件名
+
+### `inbound.received`
+
+在 Bridge 接受一条 Feishu 入站消息并进入核心处理链路时发出。
+
+必填字段：
+
+- `chatId`
+- `chatType`
+- `conversationKey`
+- `senderId`
+- `messageId`
+- `messageType`
+
+可选字段：
+
+- `threadKey`
+- `textPreview`
+- `len`
+
+触发点：
+
+- `BridgeApp.handleIncomingMessage()` 完成白名单和限流检查之后。
+- `textPreview` 遵循 logger 的 message logging policy，仅用于本地运行台和排障摘要。
 
 ### `turn.checkpoint`
 

--- a/ops/README.md
+++ b/ops/README.md
@@ -10,6 +10,14 @@
   - 一个最小可用的 Caddy 反向代理样例
   - 把公网域名流量转发到本地 bridge HTTP 服务
   - 适合配合 `server.publicBaseUrl` 和飞书卡片回调一起使用
+- `deploy-server.sh`
+  - 当前服务器的 rsync + Docker 部署脚本
+  - 不覆盖服务器侧 `config.json`、`.env`、`.env.tunnel`、`data/`、`logs/`、`vault/`
+  - 适合 GitHub 访问不稳定时，从本机同步已更新代码到服务器
+- `update-server-tools.sh`
+  - 更新服务器侧宿主工具，不重新部署 bridge 代码
+  - 默认更新 `@larksuite/cli`
+  - `--opencode`、`--cloudflared` 需要显式传入，避免自动升级影响正在运行的对话服务
 
 ## 这个目录适合放什么
 

--- a/ops/deploy-server.sh
+++ b/ops/deploy-server.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVER_DIR="${SERVER_DIR:-/srv/feishu-opencode-bridge}"
+
+: "${SERVER_HOST:?Set SERVER_HOST before running deploy-server.sh}"
+: "${SERVER_USER:?Set SERVER_USER before running deploy-server.sh}"
+: "${SSH_KEY:?Set SSH_KEY before running deploy-server.sh}"
+: "${PUBLIC_HEALTH_URL:?Set PUBLIC_HEALTH_URL before running deploy-server.sh}"
+
+SSH=(ssh -i "$SSH_KEY" -o BatchMode=yes)
+RSYNC_RSH="ssh -i $SSH_KEY -o BatchMode=yes"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+echo "[1/4] Sync project to $SERVER_USER@$SERVER_HOST:$SERVER_DIR"
+rsync -az --delete \
+  --include "/src/***" \
+  --include "/ops/***" \
+  --include "/Dockerfile" \
+  --include "/docker-compose.yml" \
+  --include "/docker-compose.tunnel.yml" \
+  --include "/.dockerignore" \
+  --include "/package.json" \
+  --include "/package-lock.json" \
+  --include "/tsconfig.json" \
+  --include "/config.example.json" \
+  --include "/config.general.example.json" \
+  --include "/config.legal.example.json" \
+  --include "/AGENTS.md" \
+  --include "/CODEX.md" \
+  --include "/README.md" \
+  --include "/README.en.md" \
+  --include "/LICENSE" \
+  --exclude "*" \
+  -e "$RSYNC_RSH" \
+  "$ROOT_DIR/" \
+  "$SERVER_USER@$SERVER_HOST:$SERVER_DIR/"
+
+echo "      Remove stale non-runtime files from previous full sync"
+"${SSH[@]}" "$SERVER_USER@$SERVER_HOST" \
+  "cd '$SERVER_DIR' && rm -rf .claude .github .opencode .runtime artifacts bin coverage docs release test turn-files node_modules dist .DS_Store"
+
+echo "[2/4] Rebuild and restart Bridge"
+"${SSH[@]}" "$SERVER_USER@$SERVER_HOST" \
+  "cd '$SERVER_DIR' && docker compose up -d"
+
+echo "[3/4] Ensure tunnel and OpenCode are running"
+"${SSH[@]}" "$SERVER_USER@$SERVER_HOST" \
+  "cd '$SERVER_DIR' && docker compose -f docker-compose.tunnel.yml --env-file .env.tunnel up -d && systemctl --user restart opencode-bridge.service"
+
+echo "[4/4] Verify health"
+"${SSH[@]}" "$SERVER_USER@$SERVER_HOST" \
+  "cd '$SERVER_DIR' && docker compose ps && curl -fsS '$PUBLIC_HEALTH_URL' >/dev/null"
+
+echo "Deploy complete: $PUBLIC_HEALTH_URL"

--- a/ops/update-server-tools.sh
+++ b/ops/update-server-tools.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVER_DIR="${SERVER_DIR:-/srv/feishu-opencode-bridge}"
+
+: "${SERVER_HOST:?Set SERVER_HOST before running update-server-tools.sh}"
+: "${SERVER_USER:?Set SERVER_USER before running update-server-tools.sh}"
+: "${SSH_KEY:?Set SSH_KEY before running update-server-tools.sh}"
+
+UPDATE_LARK=1
+UPDATE_OPENCODE=0
+UPDATE_CLOUDFLARED=0
+
+usage() {
+  cat <<'USAGE'
+Usage: ops/update-server-tools.sh [options]
+
+Update server-side CLI/tooling dependencies without redeploying bridge code.
+
+Options:
+  --lark-cli       Update @larksuite/cli. This is enabled by default.
+  --opencode      Update opencode-ai and restart opencode-bridge.service.
+  --cloudflared   Pull the cloudflared image and restart the tunnel compose service.
+  --all           Update lark-cli, opencode, and cloudflared.
+  --no-lark-cli   Skip @larksuite/cli.
+  -h, --help      Show this help.
+
+Environment:
+  SERVER_HOST     Required target host.
+  SERVER_USER     Required SSH user.
+  SERVER_DIR      Default: /srv/feishu-opencode-bridge
+  SSH_KEY         Required SSH private key path.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --lark-cli)
+      UPDATE_LARK=1
+      ;;
+    --no-lark-cli)
+      UPDATE_LARK=0
+      ;;
+    --opencode)
+      UPDATE_OPENCODE=1
+      ;;
+    --cloudflared)
+      UPDATE_CLOUDFLARED=1
+      ;;
+    --all)
+      UPDATE_LARK=1
+      UPDATE_OPENCODE=1
+      UPDATE_CLOUDFLARED=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+SSH=(ssh -i "$SSH_KEY" -o BatchMode=yes)
+
+remote_run() {
+  "${SSH[@]}" "$SERVER_USER@$SERVER_HOST" "$1"
+}
+
+if [[ "$UPDATE_LARK" -eq 1 ]]; then
+  echo "[lark-cli] Update @larksuite/cli"
+  remote_run "set -euo pipefail
+sudo -n npm install -g --prefix /usr/local @larksuite/cli@latest
+lark-cli --version 2>/dev/null || lark-cli version"
+fi
+
+if [[ "$UPDATE_OPENCODE" -eq 1 ]]; then
+  echo "[opencode] Update opencode-ai and restart OpenCode service"
+  remote_run "set -euo pipefail
+sudo -n npm install -g opencode-ai@latest
+systemctl --user restart opencode-bridge.service
+sleep 3
+systemctl --user is-active opencode-bridge.service
+opencode --version"
+fi
+
+if [[ "$UPDATE_CLOUDFLARED" -eq 1 ]]; then
+  echo "[cloudflared] Pull image and restart tunnel service"
+  remote_run "set -euo pipefail
+cd '$SERVER_DIR'
+docker compose -f docker-compose.tunnel.yml --env-file .env.tunnel pull cloudflared
+docker compose -f docker-compose.tunnel.yml --env-file .env.tunnel up -d cloudflared
+docker compose -f docker-compose.tunnel.yml --env-file .env.tunnel ps cloudflared"
+fi
+
+echo "Server tool update complete."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feishu-opencode-bridge",
-  "version": "0.3.0",
+  "version": "0.3.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feishu-opencode-bridge",
-      "version": "0.3.0",
+      "version": "0.3.0-beta.0",
       "dependencies": {
         "@inquirer/prompts": "^8.5.1",
         "@larksuiteoapi/node-sdk": "^1.42.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feishu-opencode-bridge",
-  "version": "0.3.0",
+  "version": "0.3.0-beta.0",
   "description": "Run OpenCode AI agents inside Feishu / Lark, with first-class support for legal-practice workflows (knowledge base, contract, labor cases).",
   "private": false,
   "type": "module",
@@ -33,11 +33,19 @@
   },
   "main": "dist/src/index.js",
   "bin": {
-    "feishu-opencode-bridge": "./bin/bridge"
+    "feishu-opencode-bridge": "bin/cli.mjs",
+    "fob": "bin/cli.mjs"
   },
   "files": [
     "dist/src/",
-    "bin/",
+    "bin/cli.mjs",
+    "bin/bridge",
+    "bin/bridge.cmd",
+    "bin/bridge.ps1",
+    "bin/setup.command",
+    "bin/setup.bat",
+    "bin/start.command",
+    "bin/start.bat",
     "scripts/runtime/",
     "scripts/release/build-portable.mjs",
     "config.example.json",

--- a/scripts/runtime/activity-ticker.mjs
+++ b/scripts/runtime/activity-ticker.mjs
@@ -2,7 +2,7 @@
  * 职责: 把 Bridge runtime 日志过滤、格式化成终端 Activity 面板。
  * 关注点:
  * - 解析 `HH:MM:SS [scope] event_name { k="v" ... }` 格式日志行。
- * - 白名单过滤(turn / ws / error / kb / card / module / boot)。
+ * - 白名单过滤(message / reply / turn / ws / error / kb / card / module / boot)。
  * - TTY 输出彩色单行,非 TTY 输出 JSON 行。
  * - 关联 turn.completed 和 cost/usage,把 cost 信息合并到 turn 完成行。
  * - 不引入第三方依赖,只用 Node 内置 + 裸 ANSI 转义。
@@ -50,6 +50,8 @@ const noColor = {
 
 const LINE_REGEX = /^(\d\d:\d\d:\d\d)\s+\[([^\]]+)\]\s+(\S+(?:\s\S+)*?)\s*\{(.*)\}\s*$/;
 const BRACKET_LEVEL_REGEX = /^\[(warn|error|info)\]:\s*(.*)$/;
+const TURN_PREVIEW_CHARS = 140;
+const MESSAGE_PREVIEW_CHARS = 220;
 
 /** 解析一行日志,返回 { ts, scope, name, fields, level } 或 null。 */
 export function parseLogLine(rawLine) {
@@ -103,7 +105,7 @@ function stripAnsi(s) {
 
 /**
  * 决定一个 parsed event 是否进入 ticker。
- * 白名单:turn 完成 / WS 连接事件 / 错误警告 / 卡片回调 / 知识库入库 / 模块状态 / 启动期。
+ * 白名单:对话摘要 / turn 完成 / WS 连接事件 / 错误警告 / 卡片回调 / 知识库入库 / 模块状态 / 启动期。
  */
 export function shouldDisplay(event) {
   if (!event) return false;
@@ -114,6 +116,12 @@ export function shouldDisplay(event) {
 
   // turn 完成
   if (event.scope === "bridge/queue" && event.name === "turn.completed") return true;
+
+  // 普通对话摘要
+  if (event.scope === "bridge/message" && event.name === "inbound.received") return true;
+  if (event.scope === "feishu/reply" && event.name === "transport.sent") {
+    return event.fields.legacyEvent === "final message sent" || event.fields.legacyEvent === "fallback final message sent";
+  }
 
   // 飞书 WS 连接事件
   if (event.scope === "feishu/ws" || event.scope === "feishu/connection") {
@@ -159,17 +167,43 @@ export function formatEvent(event, useColor = true) {
   if (event.scope === "bridge/queue" && event.name === "turn.completed") {
     const duration = event.fields.durationMs ? `${(Number(event.fields.durationMs) / 1000).toFixed(1)}s` : "?";
     const len = event.fields.replyLength ? `${event.fields.replyLength}字` : "";
-    const chat = event.fields.chatId?.startsWith("oc_p2p_") ? "p2p" : event.fields.chatId?.startsWith("oc_") ? "chat" : "?";
+    const chat = formatChatLabel(event.fields.chatId, event.fields.chatType, event.fields.conversationKey);
     const sender = (event.fields.userId ?? "?").slice(0, 12);
-    const tail = [duration, len].filter(Boolean).join(" · ");
-    const head = `${tsCol}  ${co.green("✓")}  ${co.bold("turn")}     ${chat.padEnd(6)} ${co.dim(sender)}  ${co.dim(tail)}`;
-    // Q / A 各占一行,每段 40 字截断,dim 色 + 12 空格缩进
-    const userQ = truncatePreview(event.fields.userTextPreview, 40);
-    const replyA = truncatePreview(event.fields.replyTextPreview, 40);
+    const summary = [duration, len].filter(Boolean).join(" · ");
+    const head = `${tsCol}  ${co.green("✓")}  ${co.bold("turn")}     ${chat} ${co.dim(sender)}  ${co.dim(summary)}`;
+    const userQ = truncatePreview(event.fields.userTextPreview, TURN_PREVIEW_CHARS);
+    const replyA = truncatePreview(event.fields.replyTextPreview, TURN_PREVIEW_CHARS);
     const lines = [head];
-    const indent = "            ";
-    if (userQ) lines.push(`${indent}${co.dim("Q「" + userQ + "」")}`);
-    if (replyA) lines.push(`${indent}${co.dim("A「" + replyA + "」")}`);
+    pushDetail(lines, co, "session", event.fields.sessionId);
+    pushDetail(lines, co, "turn", event.fields.turnId);
+    pushDetail(lines, co, "window", event.fields.conversationKey);
+    if (userQ) pushDetail(lines, co, "Q", `「${userQ}」`);
+    if (replyA) pushDetail(lines, co, "A", `「${replyA}」`);
+    return lines.join("\n");
+  }
+
+  // 入站用户消息
+  if (event.scope === "bridge/message" && event.name === "inbound.received") {
+    const chat = formatChatLabel(event.fields.chatId, event.fields.chatType, event.fields.conversationKey);
+    const sender = (event.fields.senderId ?? "?").slice(0, 12);
+    const text = truncatePreview(event.fields.textPreview, MESSAGE_PREVIEW_CHARS);
+    const len = event.fields.len ? `${event.fields.len}字` : "";
+    const lines = [`${tsCol}  ${co.cyan("←")}  ${co.bold("user")}     ${chat} ${co.dim(sender)}  ${co.dim(len)}`];
+    pushDetail(lines, co, "msg", event.fields.messageId);
+    pushDetail(lines, co, "window", event.fields.conversationKey);
+    if (text) pushDetail(lines, co, "text", `「${text}」`);
+    return lines.join("\n");
+  }
+
+  // 出站最终回复或命令结果
+  if (event.scope === "feishu/reply" && event.name === "transport.sent") {
+    const chat = formatChatLabel(event.fields.chatId, event.fields.chatType, event.fields.conversationKey);
+    const kind = event.fields.payloadKind ?? "?";
+    const text = truncatePreview(event.fields.textPreview, MESSAGE_PREVIEW_CHARS);
+    const len = event.fields.len ? `${event.fields.len}字` : "";
+    const lines = [`${tsCol}  ${co.green("→")}  ${co.bold("bot")}      ${chat} ${co.dim(`${kind} · ${len}`)}`];
+    pushDetail(lines, co, "msg", event.fields.messageId);
+    if (text) pushDetail(lines, co, "text", `「${text}」`);
     return lines.join("\n");
   }
 
@@ -216,7 +250,7 @@ export function formatEventJson(event) {
   if (event.cost) base.cost = event.cost;
   if (event.message) base.message = event.message;
   // 只挑常用字段,不全量倾倒
-  const picks = ["chatId", "userId", "turnId", "durationMs", "replyLength", "moduleId", "fileName", "chunks", "action", "userTextPreview", "replyTextPreview"];
+  const picks = ["chatId", "chatType", "conversationKey", "threadKey", "senderId", "messageId", "userId", "turnId", "sessionId", "durationMs", "replyLength", "moduleId", "fileName", "chunks", "action", "userTextPreview", "replyTextPreview", "textPreview", "payloadKind", "legacyEvent"];
   for (const k of picks) {
     if (event.fields?.[k] !== undefined) base[k] = event.fields[k];
   }
@@ -309,6 +343,17 @@ function truncatePreview(value, maxChars) {
   const normalized = value.replace(/\s+/g, " ").trim();
   if (!normalized) return "";
   return normalized.length > maxChars ? `${normalized.slice(0, maxChars - 1)}…` : normalized;
+}
+
+function pushDetail(lines, co, label, value) {
+  if (!value) return;
+  lines.push(`            ${co.dim(label.padEnd(7))} ${value}`);
+}
+
+function formatChatLabel(chatId, chatType, conversationKey) {
+  if (chatType === "p2p" || (typeof chatId === "string" && chatId.startsWith("oc_p2p_")) || (typeof conversationKey === "string" && conversationKey.endsWith(":main"))) return "p2p";
+  if (chatType === "group" || chatType === "chat" || (typeof chatId === "string" && chatId.startsWith("oc_"))) return "chat";
+  return "?";
 }
 
 function formatUptime(sec) {
@@ -485,7 +530,7 @@ export function createDashboardRenderer(options = {}) {
     out.push(`  Quit       Ctrl+C`);
     out.push("");
     out.push("───────────────────────────────────────────────────────");
-    out.push(`  ${co.dim("Live activity (turns · ws · errors · kb · cards, last " + capacity + ")")}`);
+    out.push(`  ${co.dim("Live activity (messages · replies · turns · ws · errors, last " + capacity + ")")}`);
     out.push("───────────────────────────────────────────────────────");
     out.push("");
     for (const line of state.activity) {

--- a/scripts/runtime/start.mjs
+++ b/scripts/runtime/start.mjs
@@ -95,6 +95,7 @@ export async function runStart(options = {}) {
     findExecutableFn: options.findExecutableFn ?? findExecutable,
   });
   const bridgeRuntimeLogPath = path.join(loggingDir, "bridge-runtime.log");
+  const bridgeActivityLogPath = resolveBridgeStructuredLogPath(loggingDir, rawConfig?.logging?.rotateDaily);
   const bridgeRuntimeLogStream = createWriteStream(bridgeRuntimeLogPath, { flags: "a" });
   const bridgeEnv = {
     ...bridgeLaunch.env,
@@ -102,6 +103,7 @@ export async function runStart(options = {}) {
   };
   logger.log(`[3/3] 启动 Bridge Runtime ... ${bridgeLaunch.command}`);
   logger.log(`      运行日志: ${bridgeRuntimeLogPath}`);
+  logger.log(`      活动日志: ${bridgeActivityLogPath}`);
   const bridgeProcess = (options.spawnFn ?? spawn)(bridgeLaunch.command, bridgeLaunch.args, {
     cwd,
     env: bridgeEnv,
@@ -121,7 +123,7 @@ export async function runStart(options = {}) {
         endpoint: `http://${serverHost}:${serverPort}`,
         profile: typeof rawConfig?.profile === "string" ? rawConfig.profile : "legal",
         extensions: collectEnabledExtensions(rawConfig),
-        logPath: bridgeRuntimeLogPath,
+        logPath: bridgeActivityLogPath,
         startedAt: new Date(),
       });
     }
@@ -137,7 +139,7 @@ export async function runStart(options = {}) {
     }
   }
 
-  // 启动 Activity Ticker:tail bridge-runtime.log,按白名单过滤渲染
+  // 启动 Activity Ticker:tail Bridge 结构化日志,按白名单过滤渲染
   // 三种模式:
   //   - dashboard:alt-screen 全屏 dashboard(顶部 panel + 活动区,每秒重绘),TTY+彩色 默认走这条
   //   - sticky:心跳钉在最后一行,事件在它上面滚(BRIDGE_DASHBOARD=0 时退回)
@@ -153,7 +155,7 @@ export async function runStart(options = {}) {
         endpoint: `http://${serverHost}:${serverPort}`,
         profile: typeof rawConfig?.profile === "string" ? rawConfig.profile : "legal",
         extensions: collectEnabledExtensions(rawConfig),
-        logPath: bridgeRuntimeLogPath,
+        logPath: bridgeActivityLogPath,
         startedAt: new Date(),
       },
       stdout: options.stdout ?? process.stdout,
@@ -175,7 +177,7 @@ export async function runStart(options = {}) {
     }
 
     const tailer = createLogTailer({
-      filePath: bridgeRuntimeLogPath,
+      filePath: bridgeActivityLogPath,
       intervalMs: options.tickerPollMs ?? 500,
       onLine: (line) => {
         const parsed = ticker.handle(line);
@@ -537,10 +539,20 @@ export async function ensureOpencodeServer(options) {
   };
 }
 
-// Resolve whether to launch the built output or fall back to `tsx src/index.ts`.
+// Resolve whether to launch local source or built output.
 export function resolveBridgeLaunch(options) {
   const cwd = options.cwd ?? process.cwd();
   const env = createAugmentedEnv(cwd, options.env ?? process.env);
+  const srcEntry = path.join(cwd, "src", "index.ts");
+  const tsxPath = (options.findExecutableFn ?? findExecutable)("tsx", { cwd, env });
+  if (pathExists(srcEntry) && tsxPath) {
+    return {
+      command: tsxPath,
+      args: ["src/index.ts"],
+      env,
+    };
+  }
+
   const distEntry = findBuildEntry(cwd);
   if (distEntry && pathExists(distEntry)) {
     return {
@@ -550,7 +562,6 @@ export function resolveBridgeLaunch(options) {
     };
   }
 
-  const tsxPath = (options.findExecutableFn ?? findExecutable)("tsx", { cwd, env });
   if (tsxPath) {
     return {
       command: tsxPath,
@@ -615,6 +626,21 @@ async function readRecentLogLines(logPath, maxLines = 12) {
   } catch {
     return "";
   }
+}
+
+// Match src/logging/logger.ts bridge log file naming.
+export function resolveBridgeStructuredLogPath(loggingDir, rotateDaily = true, now = new Date()) {
+  if (rotateDaily === false) {
+    return path.join(loggingDir, "bridge.log");
+  }
+  return path.join(loggingDir, `bridge-${formatLocalDay(now)}.log`);
+}
+
+function formatLocalDay(value) {
+  const year = value.getFullYear();
+  const month = String(value.getMonth() + 1).padStart(2, "0");
+  const day = String(value.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
 // Restrict auto-start behavior to loopback OpenCode addresses.

--- a/src/feishu/ws.ts
+++ b/src/feishu/ws.ts
@@ -168,6 +168,7 @@ export class FeishuWsClient {
     await runWithLogContext({
       correlationId: randomUUID(),
       chatId: payload.message?.chat_id,
+      chatType: payload.message?.chat_type,
       messageId: payload.message?.message_id,
       userId: payload.sender?.sender_id?.open_id,
     }, async () => {

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -16,6 +16,7 @@ export type LogLevel = "debug" | "info" | "warn" | "error";
 export type LogFormat = "pretty" | "json";
 export type LogMessagePolicy = "full" | "preview" | "hash" | "none";
 export type BridgeEventName =
+  | "inbound.received"
   | "turn.started"
   | "turn.completed"
   | "turn.failed"
@@ -32,6 +33,9 @@ export type LogContext = {
   turnId?: string | undefined;
   userId?: string | undefined;
   chatId?: string | undefined;
+  chatType?: string | undefined;
+  conversationKey?: string | undefined;
+  threadKey?: string | undefined;
   messageId?: string | undefined;
   sessionId?: string | undefined;
 };

--- a/src/runtime/app-helpers.ts
+++ b/src/runtime/app-helpers.ts
@@ -355,15 +355,6 @@ export function mapToolStatus(status: string | undefined): string {
   }
 }
 
-export function summarizeReasoningToProgress(text: string): string {
-  const normalized = text.replace(/<system-reminder>[\s\S]*?<\/system-reminder>/gi, "").trim();
-  if (!normalized) return "";
-  if (/considering user response/i.test(normalized)) return "";
-  if (/news|headline|search/i.test(normalized)) return "正在检索相关信息";
-  if (/project|package\.json|file/i.test(normalized)) return "正在整理上下文信息";
-  return "正在处理中";
-}
-
 export function formatToolRecord(toolName: string, status: string | undefined, title: string | undefined): string {
   const statusLabel = mapToolStatus(status);
   const detail = formatToolTarget(title) || "-";

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -394,6 +394,17 @@ export class BridgeApp {
       messageId: message.messageId,
       messageType: message.messageType,
     }, message.plainText);
+    logEvent(this.logger, "bridge/message", "inbound.received", {
+      chatId: message.chatId,
+      chatType: message.chatType,
+      conversationKey: message.conversationKey,
+      threadKey: message.threadKey,
+      senderId: message.senderOpenId,
+      messageId: message.messageId,
+      messageType: message.messageType,
+      textPreview: message.plainText,
+      len: message.plainText.length,
+    });
     this.messageContextStore.rememberInbound(message);
     const messageContext = this.messageContextStore.buildRuntimeContext(message);
 
@@ -1730,7 +1741,7 @@ export class BridgeApp {
    * 为当前 turn 组装统一的日志上下文字段。
    */
   private buildTurnLogContext(
-    message: Pick<IncomingChatMessage, "chatId" | "senderOpenId" | "messageId">,
+    message: Pick<IncomingChatMessage, "chatId" | "chatType" | "conversationKey" | "threadKey" | "senderOpenId" | "messageId">,
     turnId: string,
     sessionId?: string,
   ): LogContext {
@@ -1738,6 +1749,9 @@ export class BridgeApp {
       ...getLogContext(),
       turnId,
       chatId: message.chatId,
+      chatType: message.chatType,
+      conversationKey: message.conversationKey,
+      threadKey: message.threadKey,
       userId: message.senderOpenId,
       messageId: message.messageId,
       sessionId,

--- a/src/runtime/turn-executor.ts
+++ b/src/runtime/turn-executor.ts
@@ -34,7 +34,6 @@ import {
   readOptionalBoolean,
   readOptionalRecord,
   readOptionalString,
-  summarizeReasoningToProgress,
   toQuestionRequest,
 } from "./app-helpers.js";
 import { cleanAssistantReply } from "./sanitize.js";
@@ -42,6 +41,15 @@ import { cleanAssistantReply } from "./sanitize.js";
 const FIRST_SSE_FALLBACK_MS = 5_000;
 const PERMISSION_TTL_MS = 120_000;
 const QUESTION_TTL_MS = 10 * 60_000;
+
+type PendingTextEvent = {
+  messageId: string;
+  kind: "delta" | "set";
+  value: string;
+  partId?: string | undefined;
+};
+
+type TextPartKind = "text" | "reasoning" | "ignored";
 
 /**
  * 负责管理一次 turn 执行的收敛过程，避免重复完成或重复报错。
@@ -204,8 +212,10 @@ export class TurnExecutor {
   /** 在 assistant 消息 id 确定后回放之前积压的文本事件。 */
   private async flushPendingTextEvents(
     assistantMessageId: string,
-    pendingTextEvents: Array<{ messageId: string; kind: "delta" | "set"; value: string }>,
+    pendingTextEvents: PendingTextEvent[],
     runtime: {
+      textPartTypes: Map<string, TextPartKind>;
+      pendingTextPartDeltas: Map<string, string>;
       appendFinalText: (delta: string) => Promise<void>;
       setFinalText: (value: string) => Promise<void>;
     },
@@ -214,6 +224,15 @@ export class TurnExecutor {
     pendingTextEvents.length = 0;
 
     for (const event of matchingEvents) {
+      if (event.partId) {
+        const partKind = runtime.textPartTypes.get(event.partId);
+        if (partKind === "reasoning" || partKind === "ignored") continue;
+        if (!partKind && event.kind === "delta") {
+          runtime.pendingTextPartDeltas.set(event.partId, `${runtime.pendingTextPartDeltas.get(event.partId) ?? ""}${event.value}`);
+          continue;
+        }
+      }
+
       if (event.kind === "set") {
         await runtime.setFinalText(event.value);
         continue;
@@ -289,6 +308,8 @@ export class TurnExecutor {
       await this.context.turnCardManager.updateTurnCard(turn.turnId, { status: "已完成", update: `最终回复已生成（${reply.length} 字）`, target: "step", ...(costSummary ? { costSummary } : {}) });
       queue.replaceActive(transitionTurn({ ...turn, sessionId }, "done"));
       logEvent(this.context.logger, "bridge/queue", "turn.completed", {
+        chatType: turn.chatType,
+        conversationKey: turn.conversationKey,
         turnId: turn.turnId,
         sessionId,
         durationMs: Date.now() - (turn.startedAt ?? Date.now()),
@@ -392,7 +413,9 @@ export class TurnExecutor {
       let assistantMessageId: string | null = null;
       let finalText = "";
       const ignoredTextPartIds = new Set<string>();
-      const pendingTextEvents: Array<{ messageId: string; kind: "delta" | "set"; value: string }> = [];
+      const textPartTypes = new Map<string, TextPartKind>();
+      const pendingTextPartDeltas = new Map<string, string>();
+      const pendingTextEvents: PendingTextEvent[] = [];
 
       let unsubscribe = (): void => {};
       const settleWithError = (error: Error): void => { settlement.settleWithError(error); };
@@ -432,6 +455,8 @@ export class TurnExecutor {
               assistantMessageId = value;
               if (assistantMessageId) {
                 await this.flushPendingTextEvents(assistantMessageId, pendingTextEvents, {
+                  textPartTypes,
+                  pendingTextPartDeltas,
                   appendFinalText: async (delta) => {
                     finalText += delta;
                     await this.context.turnCardManager.scheduleStreamUpdate(turn.turnId, finalText);
@@ -444,8 +469,10 @@ export class TurnExecutor {
               }
             },
             ignoredTextPartIds,
-            queuePendingTextEvent: (messageId, eventType, value) => {
-              pendingTextEvents.push({ messageId, kind: eventType, value });
+            textPartTypes,
+            pendingTextPartDeltas,
+            queuePendingTextEvent: (messageId, eventType, value, partId) => {
+              pendingTextEvents.push({ messageId, kind: eventType, value, partId });
             },
             appendFinalText: async (delta) => {
               finalText += delta;
@@ -503,7 +530,9 @@ export class TurnExecutor {
       getAssistantMessageId: () => string | null;
       setAssistantMessageId: (value: string | null) => Promise<void>;
       ignoredTextPartIds: Set<string>;
-      queuePendingTextEvent: (messageId: string, eventType: "delta" | "set", value: string) => void;
+      textPartTypes: Map<string, TextPartKind>;
+      pendingTextPartDeltas: Map<string, string>;
+      queuePendingTextEvent: (messageId: string, eventType: "delta" | "set", value: string, partId?: string | undefined) => void;
       appendFinalText: (delta: string) => Promise<void>;
       setFinalText: (value: string) => Promise<void>;
       finish: () => Promise<void>;
@@ -529,9 +558,17 @@ export class TurnExecutor {
         const delta = readOptionalString(event.properties, "delta") ?? "";
         if (!runtime.getAssistantMessageId()) {
           if (messageId) {
-            runtime.queuePendingTextEvent(messageId, "delta", delta);
+            runtime.queuePendingTextEvent(messageId, "delta", delta, partId);
           }
           return;
+        }
+        if (partId) {
+          const partKind = runtime.textPartTypes.get(partId);
+          if (partKind === "reasoning" || partKind === "ignored") return;
+          if (!partKind) {
+            runtime.pendingTextPartDeltas.set(partId, `${runtime.pendingTextPartDeltas.get(partId) ?? ""}${delta}`);
+            return;
+          }
         }
         await runtime.appendFinalText(delta);
       }
@@ -548,18 +585,32 @@ export class TurnExecutor {
 
       if (partType === "text") {
         if (readOptionalBoolean(part, "synthetic") || readOptionalBoolean(part, "ignored")) {
-          if (partId) runtime.ignoredTextPartIds.add(partId);
+          if (partId) {
+            runtime.ignoredTextPartIds.add(partId);
+            runtime.textPartTypes.set(partId, "ignored");
+            runtime.pendingTextPartDeltas.delete(partId);
+          }
           return;
         }
+        if (partId) runtime.textPartTypes.set(partId, "text");
         const text = readOptionalString(part, "text");
         if (text !== undefined) {
           if (!runtime.getAssistantMessageId()) {
             if (messageId) {
-              runtime.queuePendingTextEvent(messageId, "set", text);
+              runtime.queuePendingTextEvent(messageId, "set", text, partId);
             }
             return;
           }
           await runtime.setFinalText(text);
+          if (partId) runtime.pendingTextPartDeltas.delete(partId);
+          return;
+        }
+        if (partId) {
+          const pendingDelta = runtime.pendingTextPartDeltas.get(partId);
+          if (pendingDelta) {
+            runtime.pendingTextPartDeltas.delete(partId);
+            await runtime.appendFinalText(pendingDelta);
+          }
         }
         return;
       }
@@ -567,15 +618,19 @@ export class TurnExecutor {
       if (partType === "reasoning") {
         const text = readOptionalString(part, "text") ?? "";
         if (partId) {
+          runtime.ignoredTextPartIds.add(partId);
+          runtime.textPartTypes.set(partId, "reasoning");
+          runtime.pendingTextPartDeltas.delete(partId);
           this.context.logger.log("opencode/events", "reasoning received", { turnId: turn.turnId, sessionId: turn.sessionId, len: text.length });
           this.context.logger.logTranscript("reasoning-raw", { turnId: turn.turnId, sessionId: turn.sessionId, partId, len: text.length }, text);
-          // 累积完整 reasoning,渲染到"思考过程"折叠面板;updateTurnCard 触发卡片刷新
           if (text.trim()) {
+            const currentFinalText = runtime.getFinalText();
+            const nextFinalText = removeLeakedReasoningText(currentFinalText, text);
+            if (nextFinalText !== currentFinalText) {
+              await runtime.setFinalText(nextFinalText);
+            }
             this.context.turnCardManager.appendReasoning(turn.turnId, text);
-          }
-          const step = summarizeReasoningToProgress(text);
-          if (step) {
-            await this.context.turnCardManager.updateTurnCard(turn.turnId, { status: "处理中", update: step, sanitize: false, target: "step" });
+            await this.context.turnCardManager.updateTurnCard(turn.turnId, { status: "处理中" });
           }
         }
         return;
@@ -887,4 +942,13 @@ function serializeErrorValue(value: unknown): string {
 
 function normalizeMissingModelName(value: string | undefined): string | undefined {
   return value?.trim().replace(/\.$/, "");
+}
+
+function removeLeakedReasoningText(finalText: string, reasoningText: string): string {
+  const leaked = reasoningText.trim();
+  if (!finalText || !leaked) return finalText;
+  if (finalText === leaked) return "";
+  if (finalText.startsWith(leaked)) return finalText.slice(leaked.length).trimStart();
+  if (finalText.endsWith(leaked)) return finalText.slice(0, -leaked.length).trimEnd();
+  return finalText;
 }

--- a/test/scripts-onboard-start.test.ts
+++ b/test/scripts-onboard-start.test.ts
@@ -957,7 +957,24 @@ describe("scripts/start", () => {
     expect(launch.args).toEqual(["src/index.ts"]);
   });
 
-  it("prefers dist/src/index.js when build output exists", async () => {
+  it("prefers local TypeScript source over stale build output when tsx is available", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-start-source-"));
+    await mkdir(path.join(dir, "src"), { recursive: true });
+    await mkdir(path.join(dir, "dist", "src"), { recursive: true });
+    await writeFile(path.join(dir, "src", "index.ts"), "console.log('source');");
+    await writeFile(path.join(dir, "dist", "src", "index.js"), "console.log('old build');");
+
+    const launch = resolveBridgeLaunch({
+      cwd: dir,
+      env: {},
+      findExecutableFn: (command: string) => command === "tsx" ? "/tmp/node_modules/.bin/tsx" : null,
+    });
+
+    expect(launch.command).toBe("/tmp/node_modules/.bin/tsx");
+    expect(launch.args).toEqual(["src/index.ts"]);
+  });
+
+  it("uses dist/src/index.js when source or tsx is missing", async () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), "bridge-start-build-"));
     await mkdir(path.join(dir, "dist", "src"), { recursive: true });
     await writeFile(path.join(dir, "dist", "src", "index.js"), "console.log('ok');");
@@ -1090,15 +1107,21 @@ describe("scripts/activity-ticker", () => {
     expect(parseLogLine("not a log line at all")).toBeNull();
   });
 
-  it("shouldDisplay whitelist includes turn.completed / ws / errors / kb", async () => {
+  it("shouldDisplay whitelist includes messages / replies / turn.completed / ws / errors / kb", async () => {
     const { shouldDisplay, parseLogLine } = await import("../scripts/runtime/activity-ticker.mjs");
+    const inbound = parseLogLine('22:58:46 [bridge/message] inbound.received { chatId="oc_p2p_1" chatType="p2p" senderId="ou_1" textPreview="你好" }');
+    const outbound = parseLogLine('22:58:47 [feishu/reply] transport.sent { chatId="oc_p2p_1" payloadKind="post" legacyEvent="final message sent" textPreview="收到" }');
     const turn = parseLogLine('22:58:48 [bridge/queue] turn.completed { turnId="t1" durationMs=1000 }');
     const ws = parseLogLine('22:58:51 [feishu/ws] connection reconnected { }');
     const kb = parseLogLine('22:59:00 [knowledge/ingest] file added { fileName="a.pdf" chunks=12 }');
+    const processCard = parseLogLine('22:58:47 [feishu/reply] transport.sent { chatId="oc_p2p_1" payloadKind="card" legacyEvent="process message updated" textPreview="处理中" }');
     const noise = parseLogLine('22:58:33 [runtime/modules] module.invoked { moduleId="persona" hook="beforeTurn" result="completed" durationMs=0 }');
+    expect(shouldDisplay(inbound)).toBe(true);
+    expect(shouldDisplay(outbound)).toBe(true);
     expect(shouldDisplay(turn)).toBe(true);
     expect(shouldDisplay(ws)).toBe(true);
     expect(shouldDisplay(kb)).toBe(true);
+    expect(shouldDisplay(processCard)).toBe(false);
     expect(shouldDisplay(noise)).toBe(false);
   });
 
@@ -1207,42 +1230,83 @@ describe("scripts/activity-ticker createStickyWriter", () => {
     // 这里只做最小冒烟:模块可导入。
     expect(typeof startMod.runStart).toBe("function");
   });
+
+  it("resolves the structured bridge log used by the local activity dashboard", async () => {
+    const { resolveBridgeStructuredLogPath } = await import("../scripts/runtime/start.mjs");
+    const now = new Date("2026-06-04T10:20:30+08:00");
+
+    expect(resolveBridgeStructuredLogPath("/tmp/logs", true, now)).toBe(path.join("/tmp/logs", "bridge-2026-06-04.log"));
+    expect(resolveBridgeStructuredLogPath("/tmp/logs", false, now)).toBe(path.join("/tmp/logs", "bridge.log"));
+  });
 });
 
 describe("scripts/activity-ticker conversation preview", () => {
+  it("renders inbound user message summaries", async () => {
+    const { formatEvent, parseLogLine } = await import("../scripts/runtime/activity-ticker.mjs");
+    const event = parseLogLine('22:58:46 [bridge/message] inbound.received { chatId="oc_p2p_1" chatType="p2p" conversationKey="oc_p2p_1:main" messageId="om_1" senderId="ou_abcdef123456" len=5 textPreview="你好呀" }');
+    const out = formatEvent(event!, false);
+    expect(out).toContain("user");
+    expect(out).toContain("p2p");
+    expect(out).toContain("ou_abcdef12");
+    expect(out).toContain("msg     om_1");
+    expect(out).toContain("window  oc_p2p_1:main");
+    expect(out).toContain("text    「你好呀」");
+    expect(out.split("\n")).toHaveLength(4);
+  });
+
+  it("renders outbound final reply summaries", async () => {
+    const { formatEvent, parseLogLine } = await import("../scripts/runtime/activity-ticker.mjs");
+    const event = parseLogLine('22:58:47 [feishu/reply] transport.sent { chatId="oc_p2p_1" messageId="om_reply" payloadKind="post" legacyEvent="final message sent" len=6 textPreview="收到,我看看" }');
+    const out = formatEvent(event!, false);
+    expect(out).toContain("bot");
+    expect(out).toContain("p2p");
+    expect(out).toContain("post");
+    expect(out).toContain("msg     om_reply");
+    expect(out).toContain("text    「收到,我看看」");
+    expect(out.split("\n")).toHaveLength(3);
+  });
+
   it("includes userTextPreview/replyTextPreview in turn.completed render", async () => {
     const { formatEvent, parseLogLine } = await import("../scripts/runtime/activity-ticker.mjs");
-    const event = parseLogLine('22:58:48 [bridge/queue] turn.completed { turnId="t1" durationMs=2300 replyLength=13 chatId="oc_p2p_1" userId="ou_abc12" userTextPreview="帮我看下这个劳动合同有什么问题" replyTextPreview="收到,我会从条款合规性、风险点和签约程序三个方面分析" }');
+    const event = parseLogLine('22:58:48 [bridge/queue] turn.completed { turnId="t1" sessionId="ses_1" durationMs=2300 replyLength=13 chatId="oc_p2p_1" userId="ou_abc12" userTextPreview="帮我看下这个劳动合同有什么问题" replyTextPreview="收到,我会从条款合规性、风险点和签约程序三个方面分析" }');
     expect(event).not.toBeNull();
     const out = formatEvent(event!, false);
     expect(out).toContain("turn");
-    expect(out).toContain("Q「帮我看下这个劳动合同有什么问题」");
-    expect(out).toContain("A「收到,我会从条款合规性、风险点和签约程序三个方面分析」");
-    expect(out.split("\n")).toHaveLength(3); // 三行:metadata + Q + A
+    expect(out).toContain("session ses_1");
+    expect(out).toContain("turn    t1");
+    expect(out).toContain("Q       「帮我看下这个劳动合同有什么问题」");
+    expect(out).toContain("A       「收到,我会从条款合规性、风险点和签约程序三个方面分析」");
+    expect(out.split("\n")).toHaveLength(5);
   });
 
-  it("truncates long previews at 40 chars with ellipsis", async () => {
+  it("keeps longer previews in local dashboard before truncating", async () => {
     const { formatEvent, parseLogLine } = await import("../scripts/runtime/activity-ticker.mjs");
-    const long = "A".repeat(60);
+    const long = "A".repeat(160);
     const event = parseLogLine(`22:58:48 [bridge/queue] turn.completed { turnId="t1" durationMs=2300 userTextPreview="${long}" replyTextPreview="ok" }`);
     const out = formatEvent(event!, false);
-    expect(out).toContain("A".repeat(39) + "…");
-    expect(out).toContain("A「ok」");
+    expect(out).toContain("A".repeat(139) + "…");
+    expect(out).toContain("A       「ok」");
   });
 
-  it("omits preview line entirely when both previews missing", async () => {
+  it("omits preview lines when both previews are missing", async () => {
     const { formatEvent, parseLogLine } = await import("../scripts/runtime/activity-ticker.mjs");
     const event = parseLogLine('22:58:48 [bridge/queue] turn.completed { turnId="t1" durationMs=2300 replyLength=13 chatId="oc_p2p_1" userId="ou_abc12" }');
     const out = formatEvent(event!, false);
-    expect(out.split("\n")).toHaveLength(1);
+    expect(out).not.toContain("Q       ");
+    expect(out).not.toContain("A       ");
+    expect(out.split("\n")).toHaveLength(2);
   });
 
   it("includes previews in JSON mode", async () => {
     const { formatEventJson, parseLogLine } = await import("../scripts/runtime/activity-ticker.mjs");
-    const event = parseLogLine('22:58:48 [bridge/queue] turn.completed { turnId="t1" durationMs=2300 userTextPreview="问题" replyTextPreview="答案" }');
+    const event = parseLogLine('22:58:48 [bridge/queue] turn.completed { turnId="t1" sessionId="ses_1" chatId="oc_p2p_1" conversationKey="oc_p2p_1:main" durationMs=2300 userTextPreview="问题" replyTextPreview="答案" textPreview="摘要" }');
     const parsed = JSON.parse(formatEventJson(event!));
+    expect(parsed.chatId).toBe("oc_p2p_1");
+    expect(parsed.sessionId).toBe("ses_1");
+    expect(parsed.conversationKey).toBe("oc_p2p_1:main");
     expect(parsed.userTextPreview).toBe("问题");
     expect(parsed.replyTextPreview).toBe("答案");
+    expect(parsed.textPreview).toBe("摘要");
   });
 });
 

--- a/test/turn-executor.test.ts
+++ b/test/turn-executor.test.ts
@@ -7,6 +7,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { TurnExecutor, type TurnExecutorContext } from "../src/runtime/turn-executor.js";
 import type { BridgeMessageContextStore } from "../src/runtime/message-context.js";
 
+type PendingTextEvent = { messageId: string; kind: "delta" | "set"; value: string; partId?: string | undefined };
+type TextPartKind = "text" | "reasoning" | "ignored";
+type FlushRuntime = {
+  textPartTypes: Map<string, TextPartKind>;
+  pendingTextPartDeltas: Map<string, string>;
+  appendFinalText: (delta: string) => Promise<void>;
+  setFinalText: (value: string) => Promise<void>;
+};
+
 describe("TurnExecutor text buffering", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -17,11 +26,11 @@ describe("TurnExecutor text buffering", () => {
       handleEvent: (turn: Record<string, unknown>, event: Record<string, unknown>, runtime: ReturnType<typeof createRuntime>) => Promise<void>;
       flushPendingTextEvents: (
         assistantMessageId: string,
-        pendingTextEvents: Array<{ messageId: string; kind: "delta" | "set"; value: string }>,
-        runtime: { appendFinalText: (delta: string) => Promise<void>; setFinalText: (value: string) => Promise<void> },
+        pendingTextEvents: PendingTextEvent[],
+        runtime: FlushRuntime,
       ) => Promise<void>;
     };
-    const pendingTextEvents: Array<{ messageId: string; kind: "delta" | "set"; value: string }> = [];
+    const pendingTextEvents: PendingTextEvent[] = [];
     const runtime = createRuntime(executor, pendingTextEvents);
 
     await executor.handleEvent(createTurn(), {
@@ -52,11 +61,11 @@ describe("TurnExecutor text buffering", () => {
       handleEvent: (turn: Record<string, unknown>, event: Record<string, unknown>, runtime: ReturnType<typeof createRuntime>) => Promise<void>;
       flushPendingTextEvents: (
         assistantMessageId: string,
-        pendingTextEvents: Array<{ messageId: string; kind: "delta" | "set"; value: string }>,
-        runtime: { appendFinalText: (delta: string) => Promise<void>; setFinalText: (value: string) => Promise<void> },
+        pendingTextEvents: PendingTextEvent[],
+        runtime: FlushRuntime,
       ) => Promise<void>;
     };
-    const pendingTextEvents: Array<{ messageId: string; kind: "delta" | "set"; value: string }> = [];
+    const pendingTextEvents: PendingTextEvent[] = [];
     const runtime = createRuntime(executor, pendingTextEvents);
 
     await executor.handleEvent(createTurn(), {
@@ -81,6 +90,132 @@ describe("TurnExecutor text buffering", () => {
     expect(runtime.getFinalText()).toBe("完整回答");
   });
 
+  it("keeps reasoning deltas out of the final answer until the part type is known", async () => {
+    const context = createContext();
+    const appendReasoning = vi.fn();
+    const updateTurnCard = vi.fn(async () => {});
+    context.turnCardManager.appendReasoning = appendReasoning;
+    context.turnCardManager.updateTurnCard = updateTurnCard;
+    const executor = new TurnExecutor(context) as unknown as {
+      handleEvent: (turn: Record<string, unknown>, event: Record<string, unknown>, runtime: ReturnType<typeof createRuntime>) => Promise<void>;
+      flushPendingTextEvents: (
+        assistantMessageId: string,
+        pendingTextEvents: PendingTextEvent[],
+        runtime: FlushRuntime,
+      ) => Promise<void>;
+    };
+    const runtime = createRuntime(executor, []);
+
+    await executor.handleEvent(createTurn(), {
+      type: "message.updated",
+      properties: { info: { id: "msg_assistant", role: "assistant", sessionID: "ses_1" } },
+    }, runtime);
+    await executor.handleEvent(createTurn(), {
+      type: "message.part.delta",
+      properties: { sessionID: "ses_1", messageID: "msg_assistant", partID: "part_reasoning", field: "text", delta: "先分析需求" },
+    }, runtime);
+
+    expect(runtime.getFinalText()).toBe("");
+
+    await executor.handleEvent(createTurn(), {
+      type: "message.part.updated",
+      properties: {
+        part: {
+          id: "part_reasoning",
+          type: "reasoning",
+          messageID: "msg_assistant",
+          text: "先分析需求",
+        },
+      },
+    }, runtime);
+
+    expect(runtime.getFinalText()).toBe("");
+    expect(runtime.ignoredTextPartIds.has("part_reasoning")).toBe(true);
+    expect(appendReasoning).toHaveBeenCalledWith("turn_1", "先分析需求");
+    expect(updateTurnCard).toHaveBeenCalledWith("turn_1", { status: "处理中" });
+    expect(updateTurnCard).not.toHaveBeenCalledWith("turn_1", expect.objectContaining({
+      target: "step",
+      update: expect.stringContaining("先分析需求"),
+    }));
+  });
+
+  it("removes reasoning text that was already leaked into the final answer", async () => {
+    const context = createContext();
+    const appendReasoning = vi.fn();
+    context.turnCardManager.appendReasoning = appendReasoning;
+    const executor = new TurnExecutor(context) as unknown as {
+      handleEvent: (turn: Record<string, unknown>, event: Record<string, unknown>, runtime: ReturnType<typeof createRuntime>) => Promise<void>;
+      flushPendingTextEvents: (
+        assistantMessageId: string,
+        pendingTextEvents: PendingTextEvent[],
+        runtime: FlushRuntime,
+      ) => Promise<void>;
+    };
+    const runtime = createRuntime(executor, []);
+
+    await executor.handleEvent(createTurn(), {
+      type: "message.updated",
+      properties: { info: { id: "msg_assistant", role: "assistant", sessionID: "ses_1" } },
+    }, runtime);
+    await executor.handleEvent(createTurn(), {
+      type: "message.part.delta",
+      properties: { sessionID: "ses_1", messageID: "msg_assistant", field: "text", delta: "先分析需求" },
+    }, runtime);
+
+    expect(runtime.getFinalText()).toBe("先分析需求");
+
+    await executor.handleEvent(createTurn(), {
+      type: "message.part.updated",
+      properties: {
+        part: {
+          id: "part_reasoning",
+          type: "reasoning",
+          messageID: "msg_assistant",
+          text: "先分析需求",
+        },
+      },
+    }, runtime);
+
+    expect(runtime.getFinalText()).toBe("");
+    expect(appendReasoning).toHaveBeenCalledWith("turn_1", "先分析需求");
+  });
+
+  it("flushes buffered text deltas once a part is confirmed as final text", async () => {
+    const executor = new TurnExecutor(createContext()) as unknown as {
+      handleEvent: (turn: Record<string, unknown>, event: Record<string, unknown>, runtime: ReturnType<typeof createRuntime>) => Promise<void>;
+      flushPendingTextEvents: (
+        assistantMessageId: string,
+        pendingTextEvents: PendingTextEvent[],
+        runtime: FlushRuntime,
+      ) => Promise<void>;
+    };
+    const runtime = createRuntime(executor, []);
+
+    await executor.handleEvent(createTurn(), {
+      type: "message.updated",
+      properties: { info: { id: "msg_assistant", role: "assistant", sessionID: "ses_1" } },
+    }, runtime);
+    await executor.handleEvent(createTurn(), {
+      type: "message.part.delta",
+      properties: { sessionID: "ses_1", messageID: "msg_assistant", partID: "part_text", field: "text", delta: "助手开头" },
+    }, runtime);
+
+    expect(runtime.getFinalText()).toBe("");
+
+    await executor.handleEvent(createTurn(), {
+      type: "message.part.updated",
+      properties: {
+        part: {
+          id: "part_text",
+          type: "text",
+          messageID: "msg_assistant",
+        },
+      },
+    }, runtime);
+
+    expect(runtime.getFinalText()).toBe("助手开头");
+  });
+
   it("renders a clear text fallback for permission requests", async () => {
     const context = createContext();
     let capturedPayload: { content: string } | null = null;
@@ -93,8 +228,8 @@ describe("TurnExecutor text buffering", () => {
       handleEvent: (turn: Record<string, unknown>, event: Record<string, unknown>, runtime: ReturnType<typeof createRuntime>) => Promise<void>;
       flushPendingTextEvents: (
         assistantMessageId: string,
-        pendingTextEvents: Array<{ messageId: string; kind: "delta" | "set"; value: string }>,
-        runtime: { appendFinalText: (delta: string) => Promise<void>; setFinalText: (value: string) => Promise<void> },
+        pendingTextEvents: PendingTextEvent[],
+        runtime: FlushRuntime,
       ) => Promise<void>;
     };
     const runtime = createRuntime(executor, []);
@@ -119,8 +254,8 @@ describe("TurnExecutor text buffering", () => {
       handleEvent: (turn: Record<string, unknown>, event: Record<string, unknown>, runtime: ReturnType<typeof createRuntime>) => Promise<void>;
       flushPendingTextEvents: (
         assistantMessageId: string,
-        pendingTextEvents: Array<{ messageId: string; kind: "delta" | "set"; value: string }>,
-        runtime: { appendFinalText: (delta: string) => Promise<void>; setFinalText: (value: string) => Promise<void> },
+        pendingTextEvents: PendingTextEvent[],
+        runtime: FlushRuntime,
       ) => Promise<void>;
     };
     const runtime = createRuntime(executor, []);
@@ -494,14 +629,16 @@ function createRuntime(
   executor: {
     flushPendingTextEvents: (
       assistantMessageId: string,
-      pendingTextEvents: Array<{ messageId: string; kind: "delta" | "set"; value: string }>,
-      runtime: { appendFinalText: (delta: string) => Promise<void>; setFinalText: (value: string) => Promise<void> },
+      pendingTextEvents: PendingTextEvent[],
+      runtime: FlushRuntime,
     ) => Promise<void>;
   },
-  pendingTextEvents: Array<{ messageId: string; kind: "delta" | "set"; value: string }>,
+  pendingTextEvents: PendingTextEvent[],
 ) {
   let assistantMessageId: string | null = null;
   let finalText = "";
+  const textPartTypes = new Map<string, TextPartKind>();
+  const pendingTextPartDeltas = new Map<string, string>();
 
   return {
     getAssistantMessageId: () => assistantMessageId,
@@ -509,6 +646,8 @@ function createRuntime(
       assistantMessageId = value;
       if (assistantMessageId) {
         await executor.flushPendingTextEvents(assistantMessageId, pendingTextEvents, {
+          textPartTypes,
+          pendingTextPartDeltas,
           appendFinalText: async (delta: string) => {
             finalText += delta;
           },
@@ -519,8 +658,10 @@ function createRuntime(
       }
     },
     ignoredTextPartIds: new Set<string>(),
-    queuePendingTextEvent: (messageId: string, eventType: "delta" | "set", value: string) => {
-      pendingTextEvents.push({ messageId, kind: eventType, value });
+    textPartTypes,
+    pendingTextPartDeltas,
+    queuePendingTextEvent: (messageId: string, eventType: "delta" | "set", value: string, partId?: string | undefined) => {
+      pendingTextEvents.push({ messageId, kind: eventType, value, partId });
     },
     appendFinalText: async (delta: string) => {
       finalText += delta;


### PR DESCRIPTION
## Summary

- unify project version at 0.3.0-beta.0 across package metadata and changelog
- add npm beta global CLI entry for feishu-opencode-bridge / fob
- add server deployment helpers and Cloudflare Tunnel compose example
- extend runtime activity dashboard with inbound/outbound message observability
- prevent reasoning text parts from leaking into final replies

## Validation

- npm run typecheck
- npm test -- --run test/scripts-onboard-start.test.ts test/turn-executor.test.ts
- npm run build
- npm run lint
- npm run lint:deps
- npm run check:formatter-exports
- npm run check:docs-diff
- node --check bin/cli.mjs
- bash -n ops/deploy-server.sh ops/update-server-tools.sh
- docker compose -f docker-compose.tunnel.yml --env-file .env.tunnel config (with dummy local env)
- npm pack --dry-run