### PR TITLE
[codex][fix] 完善运行卡片结果交付

### DIFF
--- a/src/feishu/runtime-cards.ts
+++ b/src/feishu/runtime-cards.ts
@@ -920,7 +920,7 @@ function buildOutputElements(output: OutputView, state: CardState): Array<Record
   const elements: Array<Record<string, unknown>> = [];
 
   if (output.text) {
-    elements.push(markdown(formatOutputText(output.text), { size: "normal_v2" }));
+    elements.push(...buildOutputTextElements(output.text));
   }
 
   if (output.paths.length > 0 || output.commands.length > 0) {
@@ -973,6 +973,21 @@ function formatOutputText(text: string): string {
     .join("");
 }
 
+function buildOutputTextElements(text: string): Array<Record<string, unknown>> {
+  if (!containsMarkdownTable(text)) {
+    return [markdown(formatOutputText(text), { size: "normal_v2" })];
+  }
+  return splitMarkdownByCodeFence(normalizeAssistantMarkdown(text))
+    .flatMap((segment) => segment.kind === "code"
+      ? [markdown(segment.content, { size: "normal_v2" })]
+      : buildEscapedMarkdownSegmentElements(segment.content));
+}
+
+function containsMarkdownTable(text: string): boolean {
+  const lines = normalizeAssistantMarkdown(text).split("\n");
+  return lines.some((line, index) => isMarkdownTableRow(line) && isMarkdownTableSeparator(lines[index + 1] ?? ""));
+}
+
 function formatOutputLine(line: string): string {
   const trimmed = line.trim();
   if (!trimmed) return line;
@@ -989,34 +1004,66 @@ function formatOutputLine(line: string): string {
 }
 
 function formatEscapedMarkdownSegment(text: string): string {
-  return neutralizeMarkdownTables(escapeText(text))
+  return escapeText(text)
     .split("\n")
     .map((line) => formatOutputLine(line))
     .join("\n");
 }
 
-function neutralizeMarkdownTables(text: string): string {
+function buildEscapedMarkdownSegmentElements(text: string): Array<Record<string, unknown>> {
+  return splitMarkdownTables(text).flatMap((segment) => {
+    if (segment.kind === "table") {
+      return buildMarkdownTableElements(segment.rows);
+    }
+    const content = formatEscapedMarkdownSegment(segment.content).trim();
+    return content ? [markdown(content, { size: "normal_v2" })] : [];
+  });
+}
+
+function splitMarkdownTables(text: string): Array<{ kind: "text"; content: string } | { kind: "table"; rows: string[][] }> {
   const lines = text.split("\n");
-  const output: string[] = [];
+  const segments: Array<{ kind: "text"; content: string } | { kind: "table"; rows: string[][] }> = [];
+  const pendingText: string[] = [];
+  const flushText = () => {
+    if (pendingText.length === 0) return;
+    segments.push({ kind: "text", content: pendingText.join("\n") });
+    pendingText.length = 0;
+  };
+
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index] ?? "";
     const nextLine = lines[index + 1] ?? "";
     if (!isMarkdownTableRow(line) || !isMarkdownTableSeparator(nextLine)) {
-      output.push(line);
+      pendingText.push(line);
       continue;
     }
 
-    const tableLines = [line, nextLine];
+    flushText();
+    const rows = [splitMarkdownTableCells(line)];
     index += 2;
     while (index < lines.length && isMarkdownTableRow(lines[index] ?? "")) {
-      tableLines.push(lines[index] ?? "");
+      rows.push(splitMarkdownTableCells(lines[index] ?? ""));
       index += 1;
     }
-    output.push(formatMarkdownTableAsCodeBlock(tableLines));
+    segments.push({ kind: "table", rows });
     index -= 1;
   }
 
-  return output.join("\n");
+  flushText();
+  return segments;
+}
+
+function buildMarkdownTableElements(rows: readonly string[][]): Array<Record<string, unknown>> {
+  if (rows.length === 0) {
+    return [];
+  }
+  const columnCount = Math.max(...rows.map((row) => row.length));
+  return rows.map((row, rowIndex) => columnSet(Array.from({ length: columnCount }, (_unused, columnIndex) => column([
+    markdown(formatTableCell(row[columnIndex] ?? "", rowIndex === 0), { size: "notation" }),
+  ], {
+    bg: rowIndex === 0 ? "grey-100" : "bg-white",
+    weight: 1,
+  }))));
 }
 
 function isMarkdownTableRow(line: string): boolean {
@@ -1041,8 +1088,9 @@ function splitMarkdownTableCells(line: string): string[] {
     .filter((cell) => cell.length > 0);
 }
 
-function formatMarkdownTableAsCodeBlock(lines: readonly string[]): string {
-  return ["```", ...lines, "```"].join("\n");
+function formatTableCell(value: string, header: boolean): string {
+  const text = escapeText(value || "-");
+  return header ? `**${text}**` : text;
 }
 
 function splitMarkdownByCodeFence(text: string): Array<{ kind: "text" | "code"; content: string }> {

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -20,6 +20,7 @@ import {
   toInteractiveCardContent,
   type FeishuPostPayload,
 } from "../feishu/shared-primitives.js";
+import { buildScheduleNoticeCardPayload } from "../feishu/scheduler-cards.js";
 import { createTextPreview, getLogContext, logEvent, type LogContext, type Logger, type TranscriptType } from "../logging/logger.js";
 import {
   type KnowledgeBasePort,
@@ -40,7 +41,7 @@ import type { WhitelistStore } from "../store/whitelist.js";
 import type { AppConfig } from "../config/schema.js";
 import { SchedulerRuntime } from "../scheduler/runtime.js";
 import { ScheduledRunner } from "../scheduler/runner.js";
-import { ScheduleCommands, type SchedulerCommandRuntimePort } from "../scheduler/commands.js";
+import { ScheduleCommands, type ScheduleCommandResult, type SchedulerCommandRuntimePort } from "../scheduler/commands.js";
 import type { ScheduledJob } from "../scheduler/types.js";
 import { SUPPORTED_MATERIAL_EXTENSIONS } from "../document-pipeline/material-support.js";
 import {
@@ -488,6 +489,10 @@ export class BridgeApp {
   ): Promise<Record<string, unknown>> {
     if (value.kind === "schedule-delete-confirm" && typeof value.shortId === "string") {
       const result = await this.schedulerCommands?.handleDeleteConfirm(actorOpenId, value.shortId);
+      const payload = buildSchedulerCardActionPayload(result);
+      if (payload) {
+        return payload as unknown as Record<string, unknown>;
+      }
       return {
         toast: {
           type: result?.ok ? "success" : "warning",
@@ -513,6 +518,10 @@ export class BridgeApp {
         };
       }
       const result = await this.schedulerCommands?.handleNlConfirm(actorOpenId, value.pendingKey);
+      const payload = buildSchedulerCardActionPayload(result);
+      if (payload) {
+        return payload as unknown as Record<string, unknown>;
+      }
       return {
         toast: {
           type: result?.ok ? "success" : "warning",
@@ -2224,6 +2233,16 @@ function formatUploadedFileSize(sizeBytes: number | undefined): string {
   }
   const sizeMb = sizeKb / 1024;
   return `${sizeMb.toFixed(sizeMb >= 10 ? 0 : 1)} MB`;
+}
+
+function buildSchedulerCardActionPayload(result: ScheduleCommandResult | undefined): FeishuPostPayload | null {
+  if (!result?.ok || result.card !== "notice" || !result.data) {
+    return null;
+  }
+  return buildScheduleNoticeCardPayload(result.data as {
+    job: ScheduledJob;
+    action: "created" | "deleted" | "triggered";
+  });
 }
 
 type PermissionTextResolution = "once" | "always" | "deny";

--- a/src/runtime/turn-card-manager.ts
+++ b/src/runtime/turn-card-manager.ts
@@ -171,14 +171,14 @@ export class TurnCardManager {
   }
 
   /** 立即把当前文本刷新到卡片。 */
-  async flushStreamUpdate(turnId: string, text: string, force: boolean): Promise<void> {
+  async flushStreamUpdate(turnId: string, text: string, force: boolean): Promise<boolean> {
     const state = this.streamFlushStates.get(turnId);
     if (state?.timer) {
       clearTimeout(state.timer);
       state.timer = null;
     }
 
-    await this.updateTurnCard(turnId, { update: text, sanitize: false, target: "final" });
+    const updated = await this.updateTurnCard(turnId, { update: text, sanitize: false, target: "final" });
     const nextState = state ?? { flushedLength: 0, lastFlushedAt: 0, timer: null };
     nextState.flushedLength = text.length;
     nextState.lastFlushedAt = Date.now();
@@ -187,12 +187,13 @@ export class TurnCardManager {
     if (force) {
       this.clearStreamFlushState(turnId);
     }
+    return updated;
   }
 
   /** 更新 turn 卡片中的状态、步骤、工具或最终输出。 */
-  async updateTurnCard(turnId: string, update: { status?: string; sessionId?: string; update?: string; sanitize?: boolean; target?: "step" | "tool" | "final"; toolKey?: string; costSummary?: string }): Promise<void> {
+  async updateTurnCard(turnId: string, update: { status?: string; sessionId?: string; update?: string; sanitize?: boolean; target?: "step" | "tool" | "final"; toolKey?: string; costSummary?: string }): Promise<boolean> {
     const card = this.turnCards.get(turnId);
-    if (!card) return;
+    if (!card) return false;
 
     if (update.status) card.status = update.status;
     if (update.sessionId) card.sessionId = update.sessionId;
@@ -237,6 +238,7 @@ export class TurnCardManager {
           },
         });
       }
+      return true;
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       logEvent(this.logger, "feishu/reply", "transport.failed", {
@@ -248,6 +250,7 @@ export class TurnCardManager {
         errorKind: error instanceof Error ? error.name : "unknown",
         detail,
       }, "warn");
+      return false;
     }
   }
 

--- a/src/runtime/turn-executor.ts
+++ b/src/runtime/turn-executor.ts
@@ -162,8 +162,8 @@ export type TurnExecutorContext = {
   sessionStatuses: Map<string, OpenCodeSessionStatus>;
   turnCardManager: {
     createTurnCard(chatId: string, turnId: string, sessionId: string, replyToMessageId: string): Promise<{ messageId: string } | null>;
-    flushStreamUpdate(turnId: string, text: string, force: boolean): Promise<void>;
-    updateTurnCard(turnId: string, update: { status?: string; sessionId?: string; update?: string; sanitize?: boolean; target?: "step" | "tool" | "final"; toolKey?: string; costSummary?: string }): Promise<void>;
+    flushStreamUpdate(turnId: string, text: string, force: boolean): Promise<boolean>;
+    updateTurnCard(turnId: string, update: { status?: string; sessionId?: string; update?: string; sanitize?: boolean; target?: "step" | "tool" | "final"; toolKey?: string; costSummary?: string }): Promise<boolean>;
     scheduleStreamUpdate(turnId: string, text: string): Promise<void>;
     appendReasoning(turnId: string, text: string): void;
     cleanup(turnId: string): void;
@@ -301,11 +301,23 @@ export class TurnExecutor {
           window: this.context.getSessionWindow(turn.conversationKey, turn.chatType),
         });
       }
+      let fallbackSent = false;
       if (!initialCard && reply) {
         await this.sendTurnFallbackMarkdown(turn.chatId, reply, turn.inboundMessageId);
+        fallbackSent = true;
       }
-      await this.context.turnCardManager.flushStreamUpdate(turn.turnId, reply, true);
-      await this.context.turnCardManager.updateTurnCard(turn.turnId, { status: "已完成", update: `最终回复已生成（${reply.length} 字）`, target: "step", ...(costSummary ? { costSummary } : {}) });
+      const finalOutputUpdated = await this.context.turnCardManager.flushStreamUpdate(turn.turnId, reply, true);
+      const finalStatusUpdated = await this.context.turnCardManager.updateTurnCard(turn.turnId, { status: "已完成", update: `最终回复已生成（${reply.length} 字）`, target: "step", ...(costSummary ? { costSummary } : {}) });
+      if (initialCard && reply && !fallbackSent && (!finalOutputUpdated || !finalStatusUpdated)) {
+        logEvent(this.context.logger, "bridge/queue", "turn.fallback_triggered", {
+          turnId: turn.turnId,
+          sessionId,
+          chatId: turn.chatId,
+          fallbackKind: "final-markdown",
+          reason: "process-card-update-failed",
+        }, "warn");
+        await this.sendTurnFallbackMarkdown(turn.chatId, reply, turn.inboundMessageId);
+      }
       queue.replaceActive(transitionTurn({ ...turn, sessionId }, "done"));
       logEvent(this.context.logger, "bridge/queue", "turn.completed", {
         chatType: turn.chatType,

--- a/test/app-command-surface.test.ts
+++ b/test/app-command-surface.test.ts
@@ -1985,6 +1985,8 @@ describe("BridgeApp command surface", () => {
         shortId: "sched-001",
       });
       expect(JSON.stringify(result)).toContain("已删除");
+      expect((result as { msg_type?: string }).msg_type).toBe("interactive");
+      expect(extractInteractiveHeader(result as any)).toBe("定时任务");
 
       await callHandleCommand(app, {
         kind: "command",
@@ -2029,6 +2031,9 @@ describe("BridgeApp command surface", () => {
         pendingKey,
       });
       expect(JSON.stringify(confirmed)).toContain("sched-001");
+      expect((confirmed as { msg_type?: string }).msg_type).toBe("interactive");
+      expect(extractInteractiveHeader(confirmed as any)).toBe("定时任务");
+      expect(extractInteractiveAnyText(confirmed as any)).toContain("已创建");
 
       await callHandleCommand(app, {
         kind: "command",

--- a/test/formatter.test.ts
+++ b/test/formatter.test.ts
@@ -241,7 +241,7 @@ describe("buildPostPayload", () => {
     expect(output).not.toContain("```bash");
   });
 
-  it("renders markdown tables as code blocks in turn output so Feishu keeps rows aligned", () => {
+  it("renders markdown tables as card rows in turn output", () => {
     const payload = buildTurnStatusCardPayload({
       title: "已完成",
       status: "已完成",
@@ -263,9 +263,12 @@ describe("buildPostPayload", () => {
     const content = JSON.parse(payload.content) as any;
     const serialized = JSON.stringify(content);
 
-    expect(serialized).toContain("```\\n| 项目 | 结论 |");
-    expect(serialized).toContain("| --- | --- |");
-    expect(serialized).toContain("| 劳动关系 | 证据较强 |");
+    expect(serialized).toContain("\"tag\":\"column_set\"");
+    expect(serialized).toContain("**项目**");
+    expect(serialized).toContain("**结论**");
+    expect(serialized).toContain("劳动关系");
+    expect(serialized).toContain("证据较强");
+    expect(serialized).not.toContain("| --- | --- |");
     expect(serialized).not.toContain("- 项目 ｜ 结论");
   });
 

--- a/test/turn-executor.test.ts
+++ b/test/turn-executor.test.ts
@@ -93,7 +93,7 @@ describe("TurnExecutor text buffering", () => {
   it("keeps reasoning deltas out of the final answer until the part type is known", async () => {
     const context = createContext();
     const appendReasoning = vi.fn();
-    const updateTurnCard = vi.fn(async () => {});
+    const updateTurnCard = vi.fn(async () => true);
     context.turnCardManager.appendReasoning = appendReasoning;
     context.turnCardManager.updateTurnCard = updateTurnCard;
     const executor = new TurnExecutor(context) as unknown as {
@@ -317,6 +317,7 @@ describe("TurnExecutor text buffering", () => {
     });
     context.turnCardManager.updateTurnCard = vi.fn(async (_turnId, update) => {
       if (update.sessionId) order.push(`card-session:${update.sessionId}`);
+      return true;
     });
     context.ensureSession = vi.fn(async () => {
       order.push("ensure-session");
@@ -332,6 +333,35 @@ describe("TurnExecutor text buffering", () => {
 
     expect(order.slice(0, 3)).toEqual(["card:准备中", "ensure-session", "card-session:ses_created"]);
     expect(replaceActive).toHaveBeenCalledWith(expect.objectContaining({ processMessageId: "om_card" }));
+  });
+
+  it("sends a fallback final reply when final card update exceeds Feishu limits", async () => {
+    const context = createContext();
+    const sendPayload = vi.fn(async () => ({ messageId: "om_fallback" }));
+    context.sendPayload = sendPayload;
+    context.queues.get = () => ({
+      peek: () => createTurn(),
+      replaceActive() {},
+      current: () => createTurn(),
+      finishActive() {},
+    });
+    context.turnCardManager.createTurnCard = vi.fn(async () => ({ messageId: "om_card" }));
+    context.turnCardManager.flushStreamUpdate = vi.fn(async () => false);
+    context.turnCardManager.updateTurnCard = vi.fn(async () => false);
+    const executor = new TurnExecutor(context) as unknown as {
+      runTurn: (queueKey: string) => Promise<void>;
+      executeTurn: () => Promise<string>;
+    };
+    executor.executeTurn = vi.fn(async () => "很长的最终回复");
+
+    await executor.runTurn("queue-1");
+
+    expect(sendPayload).toHaveBeenCalledWith(
+      "oc_p2p_1",
+      expect.any(Object),
+      expect.objectContaining({ event: "fallback final message sent" }),
+      { replyToMessageId: "om_1" },
+    );
   });
 
   it("cleans turn-owned resources after a failed run", async () => {
@@ -436,7 +466,7 @@ describe("TurnExecutor text buffering", () => {
 
   it("surfaces OpenCode session errors with actionable model guidance", async () => {
     const context = createContext();
-    const updateTurnCard = vi.fn(async () => {});
+    const updateTurnCard = vi.fn(async () => true);
     context.turnCardManager.createTurnCard = vi.fn(async () => ({ messageId: "om_card" }));
     context.turnCardManager.updateTurnCard = updateTurnCard;
     context.queues.get = () => ({
@@ -487,7 +517,7 @@ describe("TurnExecutor text buffering", () => {
 
   it("normalizes generic model-not-found errors from OpenCode", async () => {
     const context = createContext();
-    const updateTurnCard = vi.fn(async () => {});
+    const updateTurnCard = vi.fn(async () => true);
     context.turnCardManager.createTurnCard = vi.fn(async () => ({ messageId: "om_card" }));
     context.turnCardManager.updateTurnCard = updateTurnCard;
     context.queues.get = () => ({
@@ -575,8 +605,8 @@ function createContext(): TurnExecutorContext {
     sessionStatuses: new Map(),
     turnCardManager: {
       async createTurnCard() { return null; },
-      async flushStreamUpdate() {},
-      async updateTurnCard() {},
+      async flushStreamUpdate() { return true; },
+      async updateTurnCard() { return true; },
       async scheduleStreamUpdate() {},
       appendReasoning() {},
       cleanup() {},


### PR DESCRIPTION
## Summary

- render Markdown tables as native card column rows instead of code blocks
- return scheduler create/delete results as interactive result cards
- make turn card updates report delivery success
- send fallback Markdown when the final process-card update fails

## Validation

- npm run typecheck
- npm run lint
- npm test -- --run test/app-command-surface.test.ts test/formatter.test.ts test/turn-executor.test.ts test/http-server.test.ts
- git diff --check
