### PR TITLE
[codex][ops] 增加 Caddy 公网入口配置

### DIFF
--- a/docker-compose.caddy.yml
+++ b/docker-compose.caddy.yml
@@ -1,0 +1,15 @@
+services:
+  caddy:
+    image: docker.m.daocloud.io/library/caddy:2-alpine
+    container_name: feishu-opencode-bridge-caddy
+    restart: unless-stopped
+    network_mode: host
+    volumes:
+      - ./ops/Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./ops/site:/srv:ro
+      - caddy_data:/data
+      - caddy_config:/config
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/ops/Caddyfile
+++ b/ops/Caddyfile
@@ -1,4 +1,10 @@
-bridge.example.com {
+ominiagent.online, www.ominiagent.online {
+  encode zstd gzip
+  root * /srv
+  file_server
+}
+
+bridge.ominiagent.online {
   encode zstd gzip
   reverse_proxy 127.0.0.1:3000
 }

--- a/ops/README.md
+++ b/ops/README.md
@@ -7,9 +7,13 @@
 ## 当前内容
 
 - `Caddyfile`
-  - 一个最小可用的 Caddy 反向代理样例
-  - 把公网域名流量转发到本地 bridge HTTP 服务
-  - 适合配合 `server.publicBaseUrl` 和飞书卡片回调一起使用
+  - 阿里云服务器直连入口配置
+  - 根域名提供备案展示页，`bridge.ominiagent.online` 反向代理本地 bridge
+- `site/index.html`
+  - `ominiagent.online` 的最小备案展示页
+- `../docker-compose.caddy.yml`
+  - 使用 host 网络监听服务器 `80/443`
+  - Caddy 自动申请和续期 HTTPS 证书
 - `deploy-server.sh`
   - 当前服务器的 rsync + Docker 部署脚本
   - 不覆盖服务器侧 `config.json`、`.env`、`.env.tunnel`、`data/`、`logs/`、`vault/`

--- a/ops/deploy-server.sh
+++ b/ops/deploy-server.sh
@@ -20,6 +20,7 @@ rsync -az --delete \
   --include "/Dockerfile" \
   --include "/docker-compose.yml" \
   --include "/docker-compose.tunnel.yml" \
+  --include "/docker-compose.caddy.yml" \
   --include "/.dockerignore" \
   --include "/package.json" \
   --include "/package-lock.json" \

--- a/ops/site/index.html
+++ b/ops/site/index.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>OminiAgent</title>
+    <style>
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: #f5f7fa;
+        color: #172033;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      main {
+        width: min(560px, calc(100% - 48px));
+        text-align: center;
+      }
+
+      h1 {
+        margin: 0 0 12px;
+        font-size: 36px;
+        letter-spacing: 0;
+      }
+
+      p {
+        margin: 0 0 40px;
+        color: #5b6475;
+        line-height: 1.7;
+      }
+
+      footer {
+        font-size: 14px;
+      }
+
+      a {
+        color: #3157c8;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>OminiAgent</h1>
+      <p>智能工作助理服务运行中</p>
+      <footer>
+        <a href="https://beian.miit.gov.cn/" target="_blank" rel="noreferrer">粤ICP备2026020854号-1</a>
+      </footer>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- add Caddy compose file for host-network public ingress
- configure root domain static ICP landing page and bridge subdomain reverse proxy
- add minimal `ops/site/index.html` landing page
- include `docker-compose.caddy.yml` in server deploy sync allowlist
- update ops README with Caddy entrypoint notes

## Validation

- bash -n ops/deploy-server.sh ops/update-server-tools.sh
- docker compose -f docker-compose.caddy.yml config
- git diff --check
